### PR TITLE
feat: resend email integration with React Email (#21)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "fuzzycat",
       "dependencies": {
+        "@react-email/components": "^1.0.8",
         "@sentry/nextjs": "^10.39.0",
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.95.3",
@@ -25,6 +26,7 @@
         "radix-ui": "^1.4.3",
         "react": "^19",
         "react-dom": "^19",
+        "resend": "^6.9.2",
         "stripe": "^20.3.1",
         "superjson": "^2.2.6",
         "tailwind-merge": "^3.4.1",
@@ -636,6 +638,48 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
+    "@react-email/body": ["@react-email/body@0.2.1", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-ljDiQiJDu/Fq//vSIIP0z5Nuvt4+DX1RqGasstChDGJB/14ogd4VdNS9aacoede/ZjGy3o3Qb+cxyS+XgM6SwQ=="],
+
+    "@react-email/button": ["@react-email/button@0.2.1", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A=="],
+
+    "@react-email/code-block": ["@react-email/code-block@0.2.1", "", { "dependencies": { "prismjs": "^1.30.0" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-M3B7JpVH4ytgn83/ujRR1k1DQHvTeABiDM61OvAbjLRPhC/5KLHU5KkzIbbuGIrjWwxAbL1kSQzU8MhLEtSxyw=="],
+
+    "@react-email/code-inline": ["@react-email/code-inline@0.0.6", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-jfhebvv3dVsp3OdPgKXnk8+e2pBiDVZejDOBFzBa/IblrAJ9cQDkN6rBD5IyEg8hTOxwbw3iaI/yZFmDmIguIA=="],
+
+    "@react-email/column": ["@react-email/column@0.0.14", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-f+W+Bk2AjNO77zynE33rHuQhyqVICx4RYtGX9NKsGUg0wWjdGP0qAuIkhx9Rnmk4/hFMo1fUrtYNqca9fwJdHg=="],
+
+    "@react-email/components": ["@react-email/components@1.0.8", "", { "dependencies": { "@react-email/body": "0.2.1", "@react-email/button": "0.2.1", "@react-email/code-block": "0.2.1", "@react-email/code-inline": "0.0.6", "@react-email/column": "0.0.14", "@react-email/container": "0.0.16", "@react-email/font": "0.0.10", "@react-email/head": "0.0.13", "@react-email/heading": "0.0.16", "@react-email/hr": "0.0.12", "@react-email/html": "0.0.12", "@react-email/img": "0.0.12", "@react-email/link": "0.0.13", "@react-email/markdown": "0.0.18", "@react-email/preview": "0.0.14", "@react-email/render": "2.0.4", "@react-email/row": "0.0.13", "@react-email/section": "0.0.17", "@react-email/tailwind": "2.0.5", "@react-email/text": "0.1.6" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-zY81ED6o5MWMzBkr9uZFuT24lWarT+xIbOZxI6C9dsFmCWBczM8IE1BgOI8rhpUK4JcYVDy1uKxYAFqsx2Bc4w=="],
+
+    "@react-email/container": ["@react-email/container@0.0.16", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-QWBB56RkkU0AJ9h+qy33gfT5iuZknPC7Un/IjZv9B0QmMIK+WWacc0cH6y2SV5Cv/b99hU94fjEMOOO4enpkbQ=="],
+
+    "@react-email/font": ["@react-email/font@0.0.10", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-0urVSgCmQIfx5r7Xc586miBnQUVnGp3OTYUm8m5pwtQRdTRO5XrTtEfNJ3JhYhSOruV0nD8fd+dXtKXobum6tA=="],
+
+    "@react-email/head": ["@react-email/head@0.0.13", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-AJg6le/08Gz4tm+6MtKXqtNNyKHzmooOCdmtqmWxD7FxoAdU1eVcizhtQ0gcnVaY6ethEyE/hnEzQxt1zu5Kog=="],
+
+    "@react-email/heading": ["@react-email/heading@0.0.16", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-jmsKnQm1ykpBzw4hCYHwBkt5pW2jScXffPeEH5ZRF5tZeF5b1pvlFTO9han7C0pCkZYo1kEvWiRtx69yfCIwuw=="],
+
+    "@react-email/hr": ["@react-email/hr@0.0.12", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-TwmOmBDibavUQpXBxpmZYi2Iks/yeZOzFYh+di9EltMSnEabH8dMZXrl+pxNXzCgZ2XE8HY7VmUL65Lenfu5PA=="],
+
+    "@react-email/html": ["@react-email/html@0.0.12", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-KTShZesan+UsreU7PDUV90afrZwU5TLwYlALuCSU0OT+/U8lULNNbAUekg+tGwCnOfIKYtpDPKkAMRdYlqUznw=="],
+
+    "@react-email/img": ["@react-email/img@0.0.12", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-sRCpEARNVTf3FQhZOC+JTvu5r6ubiYWkT0ucYXg8ctkyi4G8QG+jgYPiNUqVeTLA2STOfmPM/nrk1nb84y6CPQ=="],
+
+    "@react-email/link": ["@react-email/link@0.0.13", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-lkWc/NjOcefRZMkQoSDDbuKBEBDES9aXnFEOuPH845wD3TxPwh+QTf0fStuzjoRLUZWpHnio4z7qGGRYusn/sw=="],
+
+    "@react-email/markdown": ["@react-email/markdown@0.0.18", "", { "dependencies": { "marked": "^15.0.12" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-gSuYK5fsMbGk87jDebqQ6fa2fKcWlkf2Dkva8kMONqLgGCq8/0d+ZQYMEJsdidIeBo3kmsnHZPrwdFB4HgjUXg=="],
+
+    "@react-email/preview": ["@react-email/preview@0.0.14", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-aYK8q0IPkBXyMsbpMXgxazwHxYJxTrXrV95GFuu2HbEiIToMwSyUgb8HDFYwPqqfV03/jbwqlsXmFxsOd+VNaw=="],
+
+    "@react-email/render": ["@react-email/render@2.0.4", "", { "dependencies": { "html-to-text": "^9.0.5", "prettier": "^3.5.3" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-kht2oTFQ1SwrLpd882ahTvUtNa9s53CERHstiTbzhm6aR2Hbykp/mQ4tpPvsBGkKAEvKRlDEoooh60Uk6nHK1g=="],
+
+    "@react-email/row": ["@react-email/row@0.0.13", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-bYnOac40vIKCId7IkwuLAAsa3fKfSfqCvv6epJKmPE0JBuu5qI4FHFCl9o9dVpIIS08s/ub+Y/txoMt0dYziGw=="],
+
+    "@react-email/section": ["@react-email/section@0.0.17", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-qNl65ye3W0Rd5udhdORzTV9ezjb+GFqQQSae03NDzXtmJq6sqVXNWNiVolAjvJNypim+zGXmv6J9TcV5aNtE/w=="],
+
+    "@react-email/tailwind": ["@react-email/tailwind@2.0.5", "", { "dependencies": { "tailwindcss": "^4.1.18" }, "peerDependencies": { "@react-email/body": "0.2.1", "@react-email/button": "0.2.1", "@react-email/code-block": "0.2.1", "@react-email/code-inline": "0.0.6", "@react-email/container": "0.0.16", "@react-email/heading": "0.0.16", "@react-email/hr": "0.0.12", "@react-email/img": "0.0.12", "@react-email/link": "0.0.13", "@react-email/preview": "0.0.14", "@react-email/text": "0.1.6", "react": "^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@react-email/body", "@react-email/button", "@react-email/code-block", "@react-email/code-inline", "@react-email/container", "@react-email/heading", "@react-email/hr", "@react-email/img", "@react-email/link", "@react-email/preview"] }, "sha512-7Ey+kiWliJdxPMCLYsdDts8ffp4idlP//w4Ui3q/A5kokVaLSNKG8DOg/8qAuzWmRiGwNQVOKBk7PXNlK5W+sg=="],
+
+    "@react-email/text": ["@react-email/text@0.1.6", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw=="],
+
     "@rollup/plugin-commonjs": ["@rollup/plugin-commonjs@28.0.1", "", { "dependencies": { "@rollup/pluginutils": "^5.0.1", "commondir": "^1.0.1", "estree-walker": "^2.0.2", "fdir": "^6.2.0", "is-reference": "1.2.1", "magic-string": "^0.30.3", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^2.68.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA=="],
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
@@ -692,6 +736,8 @@
 
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
 
+    "@selderee/plugin-htmlparser2": ["@selderee/plugin-htmlparser2@0.11.0", "", { "dependencies": { "domhandler": "^5.0.3", "selderee": "^0.11.0" } }, "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ=="],
+
     "@sentry-internal/browser-utils": ["@sentry-internal/browser-utils@10.39.0", "", { "dependencies": { "@sentry/core": "10.39.0" } }, "sha512-W6WODonMGiI13Az5P7jd/m2lj/JpIyuVKg7wE4X+YdlMehLspAv6I7gRE4OBSumS14ZjdaYDpD/lwtnBwKAzcA=="],
 
     "@sentry-internal/feedback": ["@sentry-internal/feedback@10.39.0", "", { "dependencies": { "@sentry/core": "10.39.0" } }, "sha512-cRXmmDeOr5FzVsBNRLU4WDEuC3fhuD0XV362EWl4DI3XBGao8ukaueKcLIKic5WZx6uXimjWw/UJmDLgxeCqkg=="],
@@ -741,6 +787,8 @@
     "@sentry/webpack-plugin": ["@sentry/webpack-plugin@4.9.1", "", { "dependencies": { "@sentry/bundler-plugin-core": "4.9.1", "unplugin": "1.0.1", "uuid": "^9.0.0" }, "peerDependencies": { "webpack": ">=4.40.0" } }, "sha512-Ssx2lHiq8VWywUGd/hmW3U3VYBC0Up7D6UzUiDAWvy18PbTCVszaa54fKMFEQ1yIBg/ePRET53pIzfkcZgifmQ=="],
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
+
+    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
     "@supabase/auth-js": ["@supabase/auth-js@2.95.3", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-vD2YoS8E2iKIX0F7EwXTmqhUpaNsmbU6X2R0/NdFcs02oEfnHyNP/3M716f3wVJ2E5XHGiTFXki6lRckhJ0Thg=="],
 
@@ -1112,7 +1160,15 @@
 
     "diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
 
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
     "dompurify": ["dompurify@3.3.1", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
     "dot-prop": ["dot-prop@5.3.0", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q=="],
 
@@ -1140,7 +1196,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.19.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg=="],
 
-    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -1197,6 +1253,8 @@
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
@@ -1299,6 +1357,10 @@
     "hono": ["hono@4.11.9", "", {}, "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ=="],
 
     "hosted-git-info": ["hosted-git-info@6.1.3", "", { "dependencies": { "lru-cache": "^7.5.1" } }, "sha512-HVJyzUrLIL1c0QmviVh5E8VGyUS7xCFPS6yydaVd1UegW+ibV/CohqTH9MkOLDp5o+rb82DMo77PTuc9F/8GKw=="],
+
+    "html-to-text": ["html-to-text@9.0.5", "", { "dependencies": { "@selderee/plugin-htmlparser2": "^0.11.0", "deepmerge": "^4.3.1", "dom-serializer": "^2.0.0", "htmlparser2": "^8.0.2", "selderee": "^0.11.0" } }, "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg=="],
+
+    "htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
@@ -1410,6 +1472,8 @@
 
     "knip": ["knip@5.83.1", "", { "dependencies": { "@nodelib/fs.walk": "^1.2.3", "fast-glob": "^3.3.3", "formatly": "^0.3.0", "jiti": "^2.6.0", "js-yaml": "^4.1.1", "minimist": "^1.2.8", "oxc-resolver": "^11.15.0", "picocolors": "^1.1.1", "picomatch": "^4.0.1", "smol-toml": "^1.5.2", "strip-json-comments": "5.0.3", "zod": "^4.1.11" }, "peerDependencies": { "@types/node": ">=18", "typescript": ">=5.0.4 <7" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-av3ZG/Nui6S/BNL8Tmj12yGxYfTnwWnslouW97m40him7o8MwiMjZBY9TPvlEWUci45aVId0/HbgTwSKIDGpMw=="],
 
+    "leac": ["leac@0.6.0", "", {}, "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg=="],
+
     "license-checker-rseidelsohn": ["license-checker-rseidelsohn@4.4.2", "", { "dependencies": { "chalk": "4.1.2", "debug": "^4.3.4", "lodash.clonedeep": "^4.5.0", "mkdirp": "^1.0.4", "nopt": "^7.2.0", "read-installed-packages": "^2.0.1", "semver": "^7.3.5", "spdx-correct": "^3.1.1", "spdx-expression-parse": "^3.0.1", "spdx-satisfies": "^5.0.1", "treeify": "^1.1.0" }, "bin": { "license-checker-rseidelsohn": "bin/license-checker-rseidelsohn.js" } }, "sha512-Sf8WaJhd2vELvCne+frS9AXqnY/vv591s2/nZcJDwTnoNgltG4mAmoenffVb8L2YPRYbxARLyrHJBC38AVfpuA=="],
 
     "lightningcss": ["lightningcss@1.30.2", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.30.2", "lightningcss-darwin-arm64": "1.30.2", "lightningcss-darwin-x64": "1.30.2", "lightningcss-freebsd-x64": "1.30.2", "lightningcss-linux-arm-gnueabihf": "1.30.2", "lightningcss-linux-arm64-gnu": "1.30.2", "lightningcss-linux-arm64-musl": "1.30.2", "lightningcss-linux-x64-gnu": "1.30.2", "lightningcss-linux-x64-musl": "1.30.2", "lightningcss-win32-arm64-msvc": "1.30.2", "lightningcss-win32-x64-msvc": "1.30.2" } }, "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ=="],
@@ -1481,6 +1545,8 @@
     "madge": ["madge@8.0.0", "", { "dependencies": { "chalk": "^4.1.2", "commander": "^7.2.0", "commondir": "^1.0.1", "debug": "^4.3.4", "dependency-tree": "^11.0.0", "ora": "^5.4.1", "pluralize": "^8.0.0", "pretty-ms": "^7.0.1", "rc": "^1.2.8", "stream-to-array": "^2.3.0", "ts-graphviz": "^2.1.2", "walkdir": "^0.4.1" }, "peerDependencies": { "typescript": "^5.4.4" }, "optionalPeers": ["typescript"], "bin": { "madge": "bin/cli.js" } }, "sha512-9sSsi3TBPhmkTCIpVQF0SPiChj1L7Rq9kU2KDG1o6v2XH9cCw086MopjVCD+vuoL5v8S77DTbVopTO8OUiQpIw=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -1584,6 +1650,8 @@
 
     "parse-ms": ["parse-ms@2.1.0", "", {}, "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA=="],
 
+    "parseley": ["parseley@0.12.1", "", { "dependencies": { "leac": "^0.6.0", "peberminta": "^0.9.0" } }, "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw=="],
+
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
@@ -1597,6 +1665,8 @@
     "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
+    "peberminta": ["peberminta@0.9.0", "", {}, "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ=="],
 
     "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
 
@@ -1615,6 +1685,8 @@
     "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
 
     "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
+
+    "postal-mime": ["postal-mime@2.7.3", "", {}, "sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
@@ -1642,7 +1714,11 @@
 
     "precinct": ["precinct@12.2.0", "", { "dependencies": { "@dependents/detective-less": "^5.0.1", "commander": "^12.1.0", "detective-amd": "^6.0.1", "detective-cjs": "^6.0.1", "detective-es6": "^5.0.1", "detective-postcss": "^7.0.1", "detective-sass": "^6.0.1", "detective-scss": "^5.0.1", "detective-stylus": "^5.0.1", "detective-typescript": "^14.0.0", "detective-vue2": "^2.2.0", "module-definition": "^6.0.1", "node-source-walk": "^7.0.1", "postcss": "^8.5.1", "typescript": "^5.7.3" }, "bin": { "precinct": "bin/cli.js" } }, "sha512-NFBMuwIfaJ4SocE9YXPU/n4AcNSoFMVFjP72nvl3cx69j/ke61/hPOWFREVxLkFhhEGnA8ZuVfTqJBa+PK3b5w=="],
 
+    "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
+
     "pretty-ms": ["pretty-ms@7.0.1", "", { "dependencies": { "parse-ms": "^2.1.0" } }, "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q=="],
+
+    "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
 
     "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
 
@@ -1702,6 +1778,8 @@
 
     "requirejs-config-file": ["requirejs-config-file@4.0.0", "", { "dependencies": { "esprima": "^4.0.0", "stringify-object": "^3.2.1" } }, "sha512-jnIre8cbWOyvr8a5F2KuqBnY+SDA4NXr/hzEZJG79Mxm2WiFQz2dzhC8ibtPJS7zkmBEl1mxSwp5HhC1W4qpxw=="],
 
+    "resend": ["resend@6.9.2", "", { "dependencies": { "postal-mime": "2.7.3", "svix": "1.84.1" }, "peerDependencies": { "@react-email/render": "*" }, "optionalPeers": ["@react-email/render"] }, "sha512-uIM6CQ08tS+hTCRuKBFbOBvHIGaEhqZe8s4FOgqsVXSbQLAhmNWpmUhG3UAtRnmcwTWFUqnHa/+Vux8YGPyDBA=="],
+
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
     "resolve-dependency-path": ["resolve-dependency-path@4.0.1", "", {}, "sha512-YQftIIC4vzO9UMhO/sCgXukNyiwVRCVaxiWskCBy7Zpqkplm8kTAISZ8O1MoKW1ca6xzgLUBjZTcDgypXvXxiQ=="],
@@ -1735,6 +1813,8 @@
     "schema-utils": ["schema-utils@4.3.3", "", { "dependencies": { "@types/json-schema": "^7.0.9", "ajv": "^8.9.0", "ajv-formats": "^2.1.1", "ajv-keywords": "^5.1.0" } }, "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA=="],
 
     "scmp": ["scmp@2.1.0", "", {}, "sha512-o/mRQGk9Rcer/jEEw/yw4mwo3EU/NvYvp577/Btqrym9Qy5/MdWGBqipbALgd2lrdWTJ5/gqDusxfnQBxOxT2Q=="],
+
+    "selderee": ["selderee@0.11.0", "", { "dependencies": { "parseley": "^0.12.0" } }, "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -1794,6 +1874,8 @@
 
     "stacktrace-parser": ["stacktrace-parser@0.1.11", "", { "dependencies": { "type-fest": "^0.7.1" } }, "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg=="],
 
+    "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
@@ -1831,6 +1913,8 @@
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "svix": ["svix@1.84.1", "", { "dependencies": { "standardwebhooks": "1.0.0", "uuid": "^10.0.0" } }, "sha512-K8DPPSZaW/XqXiz1kEyzSHYgmGLnhB43nQCMeKjWGCUpLIpAMMM8kx3rVVOSm6Bo6EHyK1RQLPT4R06skM/MlQ=="],
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
@@ -2050,6 +2134,8 @@
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
+    "@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -2127,6 +2213,8 @@
     "stacktrace-parser/type-fest": ["type-fest@0.7.1", "", {}, "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="],
 
     "stylus-lookup/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "svix/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 

--- a/lib/__tests__/env.test.ts
+++ b/lib/__tests__/env.test.ts
@@ -12,6 +12,7 @@ describe('env validation', () => {
     process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key';
     process.env.DATABASE_URL = 'postgresql://localhost:5432/test';
     process.env.STRIPE_SECRET_KEY = 'sk_test_abc123';
+    process.env.RESEND_API_KEY = 're_test_abc123';
     process.env.TWILIO_ACCOUNT_SID = 'ACtest1234567890abcdef1234567890ab';
     process.env.TWILIO_AUTH_TOKEN = 'test-twilio-auth-token';
     process.env.TWILIO_PHONE_NUMBER = '+15551234567';

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -10,6 +10,7 @@ const serverSchema = z.object({
   DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
   STRIPE_SECRET_KEY: z.string().startsWith('sk_', 'STRIPE_SECRET_KEY must start with sk_'),
   STRIPE_WEBHOOK_SECRET: z.string().optional(),
+  RESEND_API_KEY: z.string().startsWith('re_', 'RESEND_API_KEY must start with re_'),
   TWILIO_ACCOUNT_SID: z.string().startsWith('AC', 'TWILIO_ACCOUNT_SID must start with AC'),
   TWILIO_AUTH_TOKEN: z.string().min(1, 'TWILIO_AUTH_TOKEN is required'),
   TWILIO_PHONE_NUMBER: z

--- a/lib/resend.ts
+++ b/lib/resend.ts
@@ -1,4 +1,15 @@
-// TODO: Resend email client configuration (#21)
-// import { Resend } from 'resend';
-//
-// export const resend = new Resend(process.env.RESEND_API_KEY!);
+import { Resend } from 'resend';
+import { serverEnv } from '@/lib/env';
+
+let _resend: Resend | undefined;
+
+/**
+ * Lazily initialized Resend client. Uses the validated RESEND_API_KEY
+ * from server environment variables. Must only be called server-side.
+ */
+export function resend(): Resend {
+  if (!_resend) {
+    _resend = new Resend(serverEnv().RESEND_API_KEY);
+  }
+  return _resend;
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "db:create-admin": "bun run scripts/create-admin.ts"
   },
   "dependencies": {
+    "@react-email/components": "^1.0.8",
     "@sentry/nextjs": "^10.39.0",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.95.3",
@@ -49,6 +50,7 @@
     "radix-ui": "^1.4.3",
     "react": "^19",
     "react-dom": "^19",
+    "resend": "^6.9.2",
     "stripe": "^20.3.1",
     "superjson": "^2.2.6",
     "tailwind-merge": "^3.4.1",

--- a/server/__tests__/email.test.ts
+++ b/server/__tests__/email.test.ts
@@ -1,0 +1,394 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+// ── Mocks ────────────────────────────────────────────────────────────
+
+const mockEmailsSend = mock(() =>
+  Promise.resolve({
+    data: { id: 'email_test_123' } as { id: string } | null,
+    error: null as { message: string; name: string } | null,
+  }),
+);
+
+mock.module('@/lib/resend', () => ({
+  resend: () => ({
+    emails: { send: mockEmailsSend },
+  }),
+}));
+
+// Import after mocking to ensure mocks are in place
+const {
+  sendEnrollmentConfirmation,
+  sendPaymentReminder,
+  sendPaymentSuccess,
+  sendPaymentFailed,
+  sendPlanCompleted,
+  sendClinicWelcome,
+  sendClinicPayoutNotification,
+} = await import('@/server/services/email');
+
+// ── Helper ───────────────────────────────────────────────────────────
+
+/** Extract the call arguments from the mock as a plain object. */
+function lastCallArgs(): Record<string, unknown> {
+  const calls = mockEmailsSend.mock.calls as unknown as Record<string, unknown>[][];
+  return calls[calls.length - 1][0];
+}
+
+// ── Test data ────────────────────────────────────────────────────────
+
+const testDate = new Date('2026-03-01T12:00:00Z');
+const futureDate = new Date('2026-03-15T12:00:00Z');
+
+const enrollmentProps = {
+  ownerName: 'Jane Doe',
+  petName: 'Whiskers',
+  clinicName: 'Happy Paws Vet',
+  totalBillCents: 120_000,
+  feeCents: 7_200,
+  totalWithFeeCents: 127_200,
+  depositCents: 31_800,
+  installmentCents: 15_900,
+  numInstallments: 6,
+  schedule: [
+    { type: 'deposit' as const, sequenceNum: 0, amountCents: 31_800, scheduledAt: testDate },
+    { type: 'installment' as const, sequenceNum: 1, amountCents: 15_900, scheduledAt: futureDate },
+  ],
+  enrollmentDate: testDate,
+  dashboardUrl: 'https://fuzzycatapp.com/owner/payments',
+};
+
+const reminderProps = {
+  ownerName: 'Jane Doe',
+  petName: 'Whiskers',
+  clinicName: 'Happy Paws Vet',
+  amountCents: 15_900,
+  scheduledDate: futureDate,
+  installmentNumber: 2,
+  totalInstallments: 6,
+  remainingBalanceCents: 63_600,
+  dashboardUrl: 'https://fuzzycatapp.com/owner/payments',
+};
+
+const successProps = {
+  ownerName: 'Jane Doe',
+  petName: 'Whiskers',
+  clinicName: 'Happy Paws Vet',
+  amountCents: 15_900,
+  paymentDate: testDate,
+  paymentType: 'installment' as const,
+  installmentNumber: 2,
+  totalInstallments: 6,
+  remainingBalanceCents: 47_700,
+  nextPaymentDate: futureDate,
+  nextPaymentAmountCents: 15_900,
+  dashboardUrl: 'https://fuzzycatapp.com/owner/payments',
+};
+
+const failedProps = {
+  ownerName: 'Jane Doe',
+  petName: 'Whiskers',
+  clinicName: 'Happy Paws Vet',
+  amountCents: 15_900,
+  failedDate: testDate,
+  installmentNumber: 2,
+  totalInstallments: 6,
+  failureReason: 'Insufficient funds',
+  retryDate: futureDate,
+  retriesRemaining: 2,
+  dashboardUrl: 'https://fuzzycatapp.com/owner/payments',
+};
+
+const completedProps = {
+  ownerName: 'Jane Doe',
+  petName: 'Whiskers',
+  clinicName: 'Happy Paws Vet',
+  totalPaidCents: 127_200,
+  completedDate: futureDate,
+  enrollmentDate: testDate,
+  dashboardUrl: 'https://fuzzycatapp.com/owner/payments',
+};
+
+const clinicWelcomeProps = {
+  clinicName: 'Happy Paws Vet',
+  contactName: 'Dr. Smith',
+  dashboardUrl: 'https://fuzzycatapp.com/clinic/dashboard',
+  connectUrl: 'https://fuzzycatapp.com/clinic/connect',
+};
+
+const clinicPayoutProps = {
+  clinicName: 'Happy Paws Vet',
+  contactName: 'Dr. Smith',
+  transferAmountCents: 15_327,
+  clinicShareCents: 477,
+  paymentAmountCents: 15_900,
+  planId: 'plan-123',
+  ownerName: 'Jane Doe',
+  petName: 'Whiskers',
+  payoutDate: testDate,
+  stripeTransferId: 'tr_abc123',
+  dashboardUrl: 'https://fuzzycatapp.com/clinic/payouts',
+};
+
+// ── Helper to create error mock ──────────────────────────────────────
+
+function mockResendError(message: string, name: string) {
+  mockEmailsSend.mockImplementation(() =>
+    Promise.resolve({
+      data: null,
+      error: { message, name },
+    }),
+  );
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe('email service', () => {
+  beforeEach(() => {
+    mockEmailsSend.mockClear();
+    mockEmailsSend.mockImplementation(() =>
+      Promise.resolve({
+        data: { id: 'email_test_123' },
+        error: null,
+      }),
+    );
+  });
+
+  // ── sendEnrollmentConfirmation ───────────────────────────────────
+
+  describe('sendEnrollmentConfirmation', () => {
+    it('sends enrollment confirmation email via Resend', async () => {
+      const result = await sendEnrollmentConfirmation('jane@example.com', enrollmentProps);
+
+      expect(result.id).toBe('email_test_123');
+      expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes correct from address and recipient', async () => {
+      await sendEnrollmentConfirmation('jane@example.com', enrollmentProps);
+
+      const args = lastCallArgs();
+      expect(args.from).toBe('FuzzyCat <noreply@fuzzycatapp.com>');
+      expect(args.to).toBe('jane@example.com');
+    });
+
+    it('includes pet name in subject line', async () => {
+      await sendEnrollmentConfirmation('jane@example.com', enrollmentProps);
+
+      const args = lastCallArgs();
+      expect(args.subject).toContain('Whiskers');
+    });
+
+    it('passes a React component for rendering', async () => {
+      await sendEnrollmentConfirmation('jane@example.com', enrollmentProps);
+
+      const args = lastCallArgs();
+      expect(args.react).toBeDefined();
+    });
+
+    it('throws when Resend returns an error', async () => {
+      mockResendError('Invalid API key', 'validation_error');
+
+      await expect(sendEnrollmentConfirmation('jane@example.com', enrollmentProps)).rejects.toThrow(
+        'Failed to send enrollment confirmation email: Invalid API key',
+      );
+    });
+  });
+
+  // ── sendPaymentReminder ──────────────────────────────────────────
+
+  describe('sendPaymentReminder', () => {
+    it('sends payment reminder email via Resend', async () => {
+      const result = await sendPaymentReminder('jane@example.com', reminderProps);
+
+      expect(result.id).toBe('email_test_123');
+      expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+    });
+
+    it('includes pet name in subject line', async () => {
+      await sendPaymentReminder('jane@example.com', reminderProps);
+
+      const args = lastCallArgs();
+      expect(args.subject).toContain('Whiskers');
+    });
+
+    it('throws when Resend returns an error', async () => {
+      mockResendError('Rate limited', 'rate_limit_error');
+
+      await expect(sendPaymentReminder('jane@example.com', reminderProps)).rejects.toThrow(
+        'Failed to send payment reminder email: Rate limited',
+      );
+    });
+  });
+
+  // ── sendPaymentSuccess ───────────────────────────────────────────
+
+  describe('sendPaymentSuccess', () => {
+    it('sends payment success email via Resend', async () => {
+      const result = await sendPaymentSuccess('jane@example.com', successProps);
+
+      expect(result.id).toBe('email_test_123');
+      expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+    });
+
+    it('includes pet name in subject line', async () => {
+      await sendPaymentSuccess('jane@example.com', successProps);
+
+      const args = lastCallArgs();
+      expect(args.subject).toContain('Whiskers');
+    });
+
+    it('throws when Resend returns an error', async () => {
+      mockResendError('Server error', 'internal_server_error');
+
+      await expect(sendPaymentSuccess('jane@example.com', successProps)).rejects.toThrow(
+        'Failed to send payment success email: Server error',
+      );
+    });
+  });
+
+  // ── sendPaymentFailed ────────────────────────────────────────────
+
+  describe('sendPaymentFailed', () => {
+    it('sends payment failed email via Resend', async () => {
+      const result = await sendPaymentFailed('jane@example.com', failedProps);
+
+      expect(result.id).toBe('email_test_123');
+      expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+    });
+
+    it('includes pet name in subject line', async () => {
+      await sendPaymentFailed('jane@example.com', failedProps);
+
+      const args = lastCallArgs();
+      expect(args.subject).toContain('Whiskers');
+    });
+
+    it('throws when Resend returns an error', async () => {
+      mockResendError('Forbidden', 'forbidden');
+
+      await expect(sendPaymentFailed('jane@example.com', failedProps)).rejects.toThrow(
+        'Failed to send payment failed email: Forbidden',
+      );
+    });
+  });
+
+  // ── sendPlanCompleted ────────────────────────────────────────────
+
+  describe('sendPlanCompleted', () => {
+    it('sends plan completed email via Resend', async () => {
+      const result = await sendPlanCompleted('jane@example.com', completedProps);
+
+      expect(result.id).toBe('email_test_123');
+      expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+    });
+
+    it('includes pet name in subject line', async () => {
+      await sendPlanCompleted('jane@example.com', completedProps);
+
+      const args = lastCallArgs();
+      expect(args.subject).toContain('Whiskers');
+    });
+
+    it('throws when Resend returns an error', async () => {
+      mockResendError('Not found', 'not_found');
+
+      await expect(sendPlanCompleted('jane@example.com', completedProps)).rejects.toThrow(
+        'Failed to send plan completed email: Not found',
+      );
+    });
+  });
+
+  // ── sendClinicWelcome ────────────────────────────────────────────
+
+  describe('sendClinicWelcome', () => {
+    it('sends clinic welcome email via Resend', async () => {
+      const result = await sendClinicWelcome('clinic@example.com', clinicWelcomeProps);
+
+      expect(result.id).toBe('email_test_123');
+      expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+    });
+
+    it('includes clinic name in subject line', async () => {
+      await sendClinicWelcome('clinic@example.com', clinicWelcomeProps);
+
+      const args = lastCallArgs();
+      expect(args.subject).toContain('Happy Paws Vet');
+    });
+
+    it('throws when Resend returns an error', async () => {
+      mockResendError('Invalid recipient', 'validation_error');
+
+      await expect(sendClinicWelcome('clinic@example.com', clinicWelcomeProps)).rejects.toThrow(
+        'Failed to send clinic welcome email: Invalid recipient',
+      );
+    });
+  });
+
+  // ── sendClinicPayoutNotification ─────────────────────────────────
+
+  describe('sendClinicPayoutNotification', () => {
+    it('sends clinic payout notification email via Resend', async () => {
+      const result = await sendClinicPayoutNotification('clinic@example.com', clinicPayoutProps);
+
+      expect(result.id).toBe('email_test_123');
+      expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+    });
+
+    it('includes owner and pet name in subject line', async () => {
+      await sendClinicPayoutNotification('clinic@example.com', clinicPayoutProps);
+
+      const args = lastCallArgs();
+      expect(args.subject).toContain('Jane Doe');
+      expect(args.subject).toContain('Whiskers');
+    });
+
+    it('throws when Resend returns an error', async () => {
+      mockResendError('Service unavailable', 'internal_server_error');
+
+      await expect(
+        sendClinicPayoutNotification('clinic@example.com', clinicPayoutProps),
+      ).rejects.toThrow('Failed to send clinic payout notification email: Service unavailable');
+    });
+  });
+
+  // ── Cross-cutting tests ──────────────────────────────────────────
+
+  describe('common behavior', () => {
+    it('all send functions use the FuzzyCat from address', async () => {
+      const sends = [
+        sendEnrollmentConfirmation('test@example.com', enrollmentProps),
+        sendPaymentReminder('test@example.com', reminderProps),
+        sendPaymentSuccess('test@example.com', successProps),
+        sendPaymentFailed('test@example.com', failedProps),
+        sendPlanCompleted('test@example.com', completedProps),
+        sendClinicWelcome('test@example.com', clinicWelcomeProps),
+        sendClinicPayoutNotification('test@example.com', clinicPayoutProps),
+      ];
+
+      await Promise.all(sends);
+
+      expect(mockEmailsSend).toHaveBeenCalledTimes(7);
+
+      const allCalls = mockEmailsSend.mock.calls as unknown as Record<string, unknown>[][];
+      for (const call of allCalls) {
+        expect(call[0].from).toBe('FuzzyCat <noreply@fuzzycatapp.com>');
+      }
+    });
+
+    it('all send functions return the email id', async () => {
+      const results = await Promise.all([
+        sendEnrollmentConfirmation('test@example.com', enrollmentProps),
+        sendPaymentReminder('test@example.com', reminderProps),
+        sendPaymentSuccess('test@example.com', successProps),
+        sendPaymentFailed('test@example.com', failedProps),
+        sendPlanCompleted('test@example.com', completedProps),
+        sendClinicWelcome('test@example.com', clinicWelcomeProps),
+        sendClinicPayoutNotification('test@example.com', clinicPayoutProps),
+      ]);
+
+      for (const result of results) {
+        expect(result.id).toBe('email_test_123');
+      }
+    });
+  });
+});

--- a/server/emails/clinic-payout.tsx
+++ b/server/emails/clinic-payout.tsx
@@ -1,0 +1,85 @@
+import { Button, Section, Text } from '@react-email/components';
+import { EmailLayout } from '@/server/emails/components/layout';
+import {
+  heading,
+  muted,
+  paragraph,
+  primaryButton,
+  successBox,
+  tableContainer,
+  tableRow,
+  tableRowBold,
+} from '@/server/emails/components/styles';
+import { formatCents, formatDate } from '@/server/emails/helpers';
+
+export interface ClinicPayoutProps {
+  clinicName: string;
+  contactName: string;
+  transferAmountCents: number;
+  clinicShareCents: number;
+  paymentAmountCents: number;
+  planId: string;
+  ownerName: string;
+  petName: string;
+  payoutDate: Date;
+  stripeTransferId: string;
+  dashboardUrl: string;
+}
+
+export function ClinicPayout({
+  clinicName,
+  contactName,
+  transferAmountCents,
+  clinicShareCents,
+  paymentAmountCents,
+  planId,
+  ownerName,
+  petName,
+  payoutDate,
+  stripeTransferId,
+  dashboardUrl,
+}: ClinicPayoutProps) {
+  return (
+    <EmailLayout
+      preview={`Payout of ${formatCents(transferAmountCents)} has been sent to ${clinicName}`}
+    >
+      <Text style={heading}>Payout Sent!</Text>
+
+      <Text style={paragraph}>Hi {contactName},</Text>
+
+      <Section style={successBox}>
+        <Text style={{ ...paragraph, color: '#065f46', margin: '0' }}>
+          A payout of {formatCents(transferAmountCents)} has been transferred to {clinicName}'s bank
+          account.
+        </Text>
+      </Section>
+
+      <Section style={tableContainer}>
+        <Text style={tableRowBold}>Payout Details</Text>
+        <Text style={tableRow}>Transfer amount: {formatCents(transferAmountCents)}</Text>
+        <Text style={tableRow}>Includes clinic revenue share: {formatCents(clinicShareCents)}</Text>
+        <Text style={tableRow}>From pet owner payment: {formatCents(paymentAmountCents)}</Text>
+        <Text style={tableRow}>Date: {formatDate(payoutDate)}</Text>
+        <Text style={tableRow}>Stripe transfer ID: {stripeTransferId}</Text>
+      </Section>
+
+      <Section style={tableContainer}>
+        <Text style={tableRowBold}>Plan Reference</Text>
+        <Text style={tableRow}>Plan ID: {planId}</Text>
+        <Text style={tableRow}>Pet owner: {ownerName}</Text>
+        <Text style={tableRow}>Pet: {petName}</Text>
+      </Section>
+
+      <Section style={{ textAlign: 'center' as const, margin: '24px 0' }}>
+        <Button style={primaryButton} href={dashboardUrl}>
+          View Payout History
+        </Button>
+      </Section>
+
+      <Text style={muted}>
+        Funds typically arrive in your bank account within 2 business days. You can also view this
+        payout in your Stripe Connect dashboard.
+      </Text>
+    </EmailLayout>
+  );
+}

--- a/server/emails/clinic-welcome.tsx
+++ b/server/emails/clinic-welcome.tsx
@@ -1,0 +1,90 @@
+import { Button, Hr, Section, Text } from '@react-email/components';
+import { EmailLayout } from '@/server/emails/components/layout';
+import {
+  heading,
+  infoBox,
+  muted,
+  paragraph,
+  primaryButton,
+  tableContainer,
+  tableRow,
+} from '@/server/emails/components/styles';
+
+export interface ClinicWelcomeProps {
+  clinicName: string;
+  contactName: string;
+  dashboardUrl: string;
+  connectUrl: string;
+}
+
+export function ClinicWelcome({
+  clinicName,
+  contactName,
+  dashboardUrl,
+  connectUrl,
+}: ClinicWelcomeProps) {
+  return (
+    <EmailLayout preview={`Welcome to FuzzyCat, ${clinicName}! Let's get you set up.`}>
+      <Text style={heading}>Welcome to FuzzyCat!</Text>
+
+      <Text style={paragraph}>Hi {contactName},</Text>
+
+      <Text style={paragraph}>
+        We are thrilled to have {clinicName} join the FuzzyCat family! Your clinic is now registered
+        on our platform and ready to offer Guaranteed Payment Plans to your clients.
+      </Text>
+
+      <Section style={tableContainer}>
+        <Text style={{ ...paragraph, fontWeight: 'bold', margin: '0 0 8px' }}>
+          How FuzzyCat Works for Your Clinic
+        </Text>
+        <Text style={tableRow}>
+          1. Offer FuzzyCat payment plans to clients with bills of $500 or more
+        </Text>
+        <Text style={tableRow}>
+          2. Clients pay 25% upfront and the rest in 6 biweekly installments
+        </Text>
+        <Text style={tableRow}>3. Your clinic receives payments as they come in -- guaranteed</Text>
+        <Text style={tableRow}>4. Earn a 3% revenue share on every enrollment</Text>
+      </Section>
+
+      <Section style={infoBox}>
+        <Text style={{ ...paragraph, color: '#1e40af', margin: '0' }}>
+          Your clinic earns 3% on every FuzzyCat enrollment. This is paid as platform administration
+          compensation alongside each payment transfer.
+        </Text>
+      </Section>
+
+      <Text style={{ ...paragraph, fontWeight: 'bold' }}>Getting Started</Text>
+
+      <Text style={paragraph}>
+        To start receiving payments, you will need to connect your bank account through Stripe
+        Connect. This is a one-time setup that takes about 5 minutes.
+      </Text>
+
+      <Section style={{ textAlign: 'center' as const, margin: '24px 0' }}>
+        <Button style={primaryButton} href={connectUrl}>
+          Connect Your Bank Account
+        </Button>
+      </Section>
+
+      <Hr style={{ borderColor: '#e5e7eb', margin: '16px 0' }} />
+
+      <Text style={paragraph}>
+        Once connected, you can manage everything from your clinic dashboard -- view active plans,
+        track payouts, and monitor your revenue share earnings.
+      </Text>
+
+      <Section style={{ textAlign: 'center' as const, margin: '24px 0' }}>
+        <Button style={{ ...primaryButton, backgroundColor: '#4b5563' }} href={dashboardUrl}>
+          Go to Your Dashboard
+        </Button>
+      </Section>
+
+      <Text style={muted}>
+        If you have any questions about getting started, our team is here to help. We look forward
+        to a great partnership!
+      </Text>
+    </EmailLayout>
+  );
+}

--- a/server/emails/components/layout.tsx
+++ b/server/emails/components/layout.tsx
@@ -1,0 +1,76 @@
+import { Body, Container, Head, Hr, Html, Preview, Section, Text } from '@react-email/components';
+import type { ReactNode } from 'react';
+
+const main: React.CSSProperties = {
+  backgroundColor: '#f6f9fc',
+  fontFamily:
+    '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Ubuntu, sans-serif',
+};
+
+const container: React.CSSProperties = {
+  backgroundColor: '#ffffff',
+  margin: '0 auto',
+  padding: '20px 0 48px',
+  marginBottom: '64px',
+  maxWidth: '580px',
+};
+
+const header: React.CSSProperties = {
+  padding: '20px 48px',
+};
+
+const logoText: React.CSSProperties = {
+  fontSize: '24px',
+  fontWeight: 'bold',
+  color: '#7c3aed',
+  margin: '0',
+};
+
+const content: React.CSSProperties = {
+  padding: '0 48px',
+};
+
+const footer: React.CSSProperties = {
+  padding: '0 48px',
+};
+
+const footerText: React.CSSProperties = {
+  color: '#8898aa',
+  fontSize: '12px',
+  lineHeight: '16px',
+  margin: '0',
+};
+
+interface EmailLayoutProps {
+  preview: string;
+  children: ReactNode;
+}
+
+/**
+ * Shared email layout for all FuzzyCat transactional emails.
+ * Provides consistent branding, header, and footer.
+ */
+export function EmailLayout({ preview, children }: EmailLayoutProps) {
+  return (
+    <Html>
+      <Head />
+      <Preview>{preview}</Preview>
+      <Body style={main}>
+        <Container style={container}>
+          <Section style={header}>
+            <Text style={logoText}>FuzzyCat</Text>
+          </Section>
+          <Section style={content}>{children}</Section>
+          <Hr style={{ borderColor: '#e6ebf1', margin: '20px 48px' }} />
+          <Section style={footer}>
+            <Text style={footerText}>FuzzyCat - Guaranteed Payment Plans for Veterinary Care</Text>
+            <Text style={footerText}>
+              This is an automated message from FuzzyCat. Please do not reply directly to this
+              email.
+            </Text>
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  );
+}

--- a/server/emails/components/styles.ts
+++ b/server/emails/components/styles.ts
@@ -1,0 +1,79 @@
+// ── Shared email styles ──────────────────────────────────────────────
+// Reusable inline style objects for React Email templates.
+
+export const heading: React.CSSProperties = {
+  fontSize: '24px',
+  fontWeight: 'bold',
+  color: '#1f2937',
+  margin: '0 0 16px',
+};
+
+export const paragraph: React.CSSProperties = {
+  fontSize: '16px',
+  lineHeight: '26px',
+  color: '#374151',
+  margin: '0 0 16px',
+};
+
+export const tableContainer: React.CSSProperties = {
+  backgroundColor: '#f9fafb',
+  borderRadius: '8px',
+  padding: '16px 20px',
+  margin: '16px 0',
+};
+
+export const tableRow: React.CSSProperties = {
+  fontSize: '14px',
+  lineHeight: '24px',
+  color: '#374151',
+  margin: '0',
+};
+
+export const tableRowBold: React.CSSProperties = {
+  ...tableRow,
+  fontWeight: 'bold',
+  fontSize: '16px',
+};
+
+export const primaryButton: React.CSSProperties = {
+  backgroundColor: '#7c3aed',
+  borderRadius: '6px',
+  color: '#ffffff',
+  fontSize: '16px',
+  fontWeight: 'bold',
+  textDecoration: 'none',
+  textAlign: 'center' as const,
+  display: 'block',
+  padding: '12px 24px',
+};
+
+export const warningBox: React.CSSProperties = {
+  backgroundColor: '#fef3c7',
+  borderRadius: '8px',
+  padding: '16px 20px',
+  margin: '16px 0',
+  borderLeft: '4px solid #f59e0b',
+};
+
+export const successBox: React.CSSProperties = {
+  backgroundColor: '#ecfdf5',
+  borderRadius: '8px',
+  padding: '16px 20px',
+  margin: '16px 0',
+  borderLeft: '4px solid #10b981',
+};
+
+export const infoBox: React.CSSProperties = {
+  backgroundColor: '#eff6ff',
+  borderRadius: '8px',
+  padding: '16px 20px',
+  margin: '16px 0',
+  borderLeft: '4px solid #3b82f6',
+};
+
+export const muted: React.CSSProperties = {
+  fontSize: '14px',
+  lineHeight: '22px',
+  color: '#6b7280',
+  margin: '0 0 8px',
+};

--- a/server/emails/enrollment-confirmation.tsx
+++ b/server/emails/enrollment-confirmation.tsx
@@ -1,0 +1,106 @@
+import { Button, Hr, Section, Text } from '@react-email/components';
+import { EmailLayout } from '@/server/emails/components/layout';
+import {
+  heading,
+  muted,
+  paragraph,
+  primaryButton,
+  tableContainer,
+  tableRow,
+  tableRowBold,
+} from '@/server/emails/components/styles';
+import { formatCents, formatDate, formatShortDate } from '@/server/emails/helpers';
+
+interface ScheduleEntry {
+  type: 'deposit' | 'installment';
+  sequenceNum: number;
+  amountCents: number;
+  scheduledAt: Date;
+}
+
+export interface EnrollmentConfirmationProps {
+  ownerName: string;
+  petName: string;
+  clinicName: string;
+  totalBillCents: number;
+  feeCents: number;
+  totalWithFeeCents: number;
+  depositCents: number;
+  installmentCents: number;
+  numInstallments: number;
+  schedule: ScheduleEntry[];
+  enrollmentDate: Date;
+  dashboardUrl: string;
+}
+
+export function EnrollmentConfirmation({
+  ownerName,
+  petName,
+  clinicName,
+  totalBillCents,
+  feeCents,
+  totalWithFeeCents,
+  depositCents,
+  installmentCents,
+  numInstallments,
+  schedule,
+  enrollmentDate,
+  dashboardUrl,
+}: EnrollmentConfirmationProps) {
+  return (
+    <EmailLayout preview={`Your payment plan for ${petName} at ${clinicName} is confirmed`}>
+      <Text style={heading}>Purrfect -- Your Payment Plan Is Set!</Text>
+
+      <Text style={paragraph}>Hi {ownerName},</Text>
+
+      <Text style={paragraph}>
+        Great news! Your FuzzyCat payment plan for {petName}'s care at {clinicName} has been
+        confirmed. Here is a summary of your plan:
+      </Text>
+
+      <Section style={tableContainer}>
+        <Text style={tableRow}>Clinic: {clinicName}</Text>
+        <Text style={tableRow}>Pet: {petName}</Text>
+        <Text style={tableRow}>Enrollment date: {formatDate(enrollmentDate)}</Text>
+        <Hr style={{ borderColor: '#e5e7eb', margin: '8px 0' }} />
+        <Text style={tableRow}>Veterinary bill: {formatCents(totalBillCents)}</Text>
+        <Text style={tableRow}>Platform fee (6%): {formatCents(feeCents)}</Text>
+        <Text style={tableRowBold}>Total: {formatCents(totalWithFeeCents)}</Text>
+        <Hr style={{ borderColor: '#e5e7eb', margin: '8px 0' }} />
+        <Text style={tableRow}>Deposit (25%): {formatCents(depositCents)}</Text>
+        <Text style={tableRow}>
+          {numInstallments} biweekly installments of {formatCents(installmentCents)}
+        </Text>
+      </Section>
+
+      <Text style={{ ...paragraph, fontWeight: 'bold' }}>Payment Schedule</Text>
+
+      <Section style={tableContainer}>
+        {schedule.map((entry) => (
+          <Text key={entry.sequenceNum} style={tableRow}>
+            {entry.type === 'deposit' ? 'Deposit' : `Installment #${entry.sequenceNum}`}:{' '}
+            {formatCents(entry.amountCents)} -- {formatShortDate(entry.scheduledAt)}
+          </Text>
+        ))}
+      </Section>
+
+      <Section style={{ textAlign: 'center' as const, margin: '24px 0' }}>
+        <Button style={primaryButton} href={dashboardUrl}>
+          View Your Payment Plan
+        </Button>
+      </Section>
+
+      <Text style={muted}>
+        Payments will be automatically collected on the scheduled dates. You will receive a reminder
+        3 days before each payment. If you have questions, visit your FuzzyCat dashboard or contact
+        our support team.
+      </Text>
+
+      <Text style={muted}>
+        Disclosure: FuzzyCat charges a flat 6% platform fee on the original veterinary bill amount.
+        This fee is included in your total above. No additional interest or hidden charges will be
+        applied. FuzzyCat is a payment facilitation platform, not a lender.
+      </Text>
+    </EmailLayout>
+  );
+}

--- a/server/emails/helpers.ts
+++ b/server/emails/helpers.ts
@@ -1,0 +1,34 @@
+// ── Email template helpers ───────────────────────────────────────────
+// Formatting utilities for email content.
+
+import { formatCents } from '@/lib/utils/money';
+
+/**
+ * Format integer cents as a USD currency string for display in emails.
+ * Re-exports formatCents from the shared money utilities.
+ */
+export { formatCents };
+
+/**
+ * Format a Date as a human-readable string for emails.
+ * Example: "February 20, 2026"
+ */
+export function formatDate(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+/**
+ * Format a Date as a shorter string for schedule tables.
+ * Example: "Feb 20, 2026"
+ */
+export function formatShortDate(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}

--- a/server/emails/payment-failed.tsx
+++ b/server/emails/payment-failed.tsx
@@ -1,0 +1,96 @@
+import { Button, Section, Text } from '@react-email/components';
+import { EmailLayout } from '@/server/emails/components/layout';
+import {
+  heading,
+  muted,
+  paragraph,
+  primaryButton,
+  tableContainer,
+  tableRow,
+  tableRowBold,
+  warningBox,
+} from '@/server/emails/components/styles';
+import { formatCents, formatDate } from '@/server/emails/helpers';
+
+export interface PaymentFailedProps {
+  ownerName: string;
+  petName: string;
+  clinicName: string;
+  amountCents: number;
+  failedDate: Date;
+  installmentNumber: number;
+  totalInstallments: number;
+  failureReason: string | null;
+  retryDate: Date | null;
+  retriesRemaining: number;
+  dashboardUrl: string;
+}
+
+export function PaymentFailed({
+  ownerName,
+  petName,
+  clinicName,
+  amountCents,
+  failedDate,
+  installmentNumber,
+  totalInstallments,
+  failureReason,
+  retryDate,
+  retriesRemaining,
+  dashboardUrl,
+}: PaymentFailedProps) {
+  return (
+    <EmailLayout
+      preview={`Action needed -- your ${formatCents(amountCents)} payment for ${petName} was not successful`}
+    >
+      <Text style={heading}>Payment Was Not Successful</Text>
+
+      <Text style={paragraph}>Hi {ownerName},</Text>
+
+      <Section style={warningBox}>
+        <Text style={{ ...paragraph, color: '#92400e', margin: '0' }}>
+          We were unable to process your payment of {formatCents(amountCents)} for {petName}'s care
+          at {clinicName}. Please ensure your payment method has sufficient funds.
+        </Text>
+      </Section>
+
+      <Section style={tableContainer}>
+        <Text style={tableRowBold}>Payment Details</Text>
+        <Text style={tableRow}>Amount: {formatCents(amountCents)}</Text>
+        <Text style={tableRow}>
+          Installment: {installmentNumber} of {totalInstallments}
+        </Text>
+        <Text style={tableRow}>Failed on: {formatDate(failedDate)}</Text>
+        {failureReason ? <Text style={tableRow}>Reason: {failureReason}</Text> : null}
+      </Section>
+
+      <Section style={tableContainer}>
+        <Text style={tableRowBold}>What Happens Next</Text>
+        {retryDate && retriesRemaining > 0 ? (
+          <>
+            <Text style={tableRow}>
+              We will automatically retry this payment on {formatDate(retryDate)}.
+            </Text>
+            <Text style={tableRow}>Retries remaining: {retriesRemaining} of 3</Text>
+          </>
+        ) : (
+          <Text style={tableRow}>
+            All automatic retries have been exhausted. Please update your payment method or contact
+            support to avoid disruption to your payment plan.
+          </Text>
+        )}
+      </Section>
+
+      <Section style={{ textAlign: 'center' as const, margin: '24px 0' }}>
+        <Button style={primaryButton} href={dashboardUrl}>
+          Update Payment Method
+        </Button>
+      </Section>
+
+      <Text style={muted}>
+        If you are experiencing financial difficulty, please reach out to our support team. We are
+        here to help find a solution.
+      </Text>
+    </EmailLayout>
+  );
+}

--- a/server/emails/payment-reminder.tsx
+++ b/server/emails/payment-reminder.tsx
@@ -1,0 +1,80 @@
+import { Button, Section, Text } from '@react-email/components';
+import { EmailLayout } from '@/server/emails/components/layout';
+import {
+  heading,
+  infoBox,
+  muted,
+  paragraph,
+  primaryButton,
+  tableContainer,
+  tableRow,
+  tableRowBold,
+} from '@/server/emails/components/styles';
+import { formatCents, formatDate } from '@/server/emails/helpers';
+
+export interface PaymentReminderProps {
+  ownerName: string;
+  petName: string;
+  clinicName: string;
+  amountCents: number;
+  scheduledDate: Date;
+  installmentNumber: number;
+  totalInstallments: number;
+  remainingBalanceCents: number;
+  dashboardUrl: string;
+}
+
+export function PaymentReminder({
+  ownerName,
+  petName,
+  clinicName,
+  amountCents,
+  scheduledDate,
+  installmentNumber,
+  totalInstallments,
+  remainingBalanceCents,
+  dashboardUrl,
+}: PaymentReminderProps) {
+  return (
+    <EmailLayout
+      preview={`Heads up -- your ${formatCents(amountCents)} payment for ${petName} is coming up on ${formatDate(scheduledDate)}`}
+    >
+      <Text style={heading}>Payment Reminder</Text>
+
+      <Text style={paragraph}>Hi {ownerName},</Text>
+
+      <Text style={paragraph}>
+        Just a friendly reminder that your upcoming payment for {petName}'s care at {clinicName} is
+        scheduled in 3 days. Please make sure your account has sufficient funds.
+      </Text>
+
+      <Section style={tableContainer}>
+        <Text style={tableRowBold}>Upcoming Payment</Text>
+        <Text style={tableRow}>Amount: {formatCents(amountCents)}</Text>
+        <Text style={tableRow}>Date: {formatDate(scheduledDate)}</Text>
+        <Text style={tableRow}>
+          Installment: {installmentNumber} of {totalInstallments}
+        </Text>
+        <Text style={tableRow}>Remaining balance: {formatCents(remainingBalanceCents)}</Text>
+      </Section>
+
+      <Section style={infoBox}>
+        <Text style={{ ...muted, color: '#1e40af', margin: '0' }}>
+          This payment will be automatically collected from your connected payment method on{' '}
+          {formatDate(scheduledDate)}.
+        </Text>
+      </Section>
+
+      <Section style={{ textAlign: 'center' as const, margin: '24px 0' }}>
+        <Button style={primaryButton} href={dashboardUrl}>
+          View Payment Details
+        </Button>
+      </Section>
+
+      <Text style={muted}>
+        If you need to update your payment method or have questions about your plan, please visit
+        your FuzzyCat dashboard.
+      </Text>
+    </EmailLayout>
+  );
+}

--- a/server/emails/payment-success.tsx
+++ b/server/emails/payment-success.tsx
@@ -1,0 +1,96 @@
+import { Button, Section, Text } from '@react-email/components';
+import { EmailLayout } from '@/server/emails/components/layout';
+import {
+  heading,
+  muted,
+  paragraph,
+  primaryButton,
+  successBox,
+  tableContainer,
+  tableRow,
+  tableRowBold,
+} from '@/server/emails/components/styles';
+import { formatCents, formatDate } from '@/server/emails/helpers';
+
+export interface PaymentSuccessProps {
+  ownerName: string;
+  petName: string;
+  clinicName: string;
+  amountCents: number;
+  paymentDate: Date;
+  paymentType: 'deposit' | 'installment';
+  installmentNumber: number;
+  totalInstallments: number;
+  remainingBalanceCents: number;
+  nextPaymentDate: Date | null;
+  nextPaymentAmountCents: number | null;
+  dashboardUrl: string;
+}
+
+export function PaymentSuccess({
+  ownerName,
+  petName,
+  clinicName,
+  amountCents,
+  paymentDate,
+  paymentType,
+  installmentNumber,
+  totalInstallments,
+  remainingBalanceCents,
+  nextPaymentDate,
+  nextPaymentAmountCents,
+  dashboardUrl,
+}: PaymentSuccessProps) {
+  const paymentLabel = paymentType === 'deposit' ? 'Deposit' : `Installment #${installmentNumber}`;
+
+  return (
+    <EmailLayout
+      preview={`Payment of ${formatCents(amountCents)} received for ${petName}'s plan at ${clinicName}`}
+    >
+      <Text style={heading}>Payment Received!</Text>
+
+      <Text style={paragraph}>Hi {ownerName},</Text>
+
+      <Section style={successBox}>
+        <Text style={{ ...paragraph, color: '#065f46', margin: '0' }}>
+          Your payment of {formatCents(amountCents)} has been successfully processed. Thank you for
+          taking care of {petName}!
+        </Text>
+      </Section>
+
+      <Section style={tableContainer}>
+        <Text style={tableRowBold}>Payment Details</Text>
+        <Text style={tableRow}>Payment: {paymentLabel}</Text>
+        <Text style={tableRow}>Amount: {formatCents(amountCents)}</Text>
+        <Text style={tableRow}>Date: {formatDate(paymentDate)}</Text>
+        <Text style={tableRow}>Clinic: {clinicName}</Text>
+        <Text style={tableRow}>Pet: {petName}</Text>
+      </Section>
+
+      <Section style={tableContainer}>
+        <Text style={tableRowBold}>Plan Progress</Text>
+        <Text style={tableRow}>
+          Payments completed: {paymentType === 'deposit' ? 1 : installmentNumber + 1} of{' '}
+          {totalInstallments + 1}
+        </Text>
+        <Text style={tableRow}>Remaining balance: {formatCents(remainingBalanceCents)}</Text>
+        {nextPaymentDate && nextPaymentAmountCents !== null ? (
+          <Text style={tableRow}>
+            Next payment: {formatCents(nextPaymentAmountCents)} on {formatDate(nextPaymentDate)}
+          </Text>
+        ) : null}
+      </Section>
+
+      <Section style={{ textAlign: 'center' as const, margin: '24px 0' }}>
+        <Button style={primaryButton} href={dashboardUrl}>
+          View Your Plan
+        </Button>
+      </Section>
+
+      <Text style={muted}>
+        A record of this payment has been saved to your FuzzyCat dashboard. If you believe this
+        payment was made in error, please contact our support team.
+      </Text>
+    </EmailLayout>
+  );
+}

--- a/server/emails/plan-completed.tsx
+++ b/server/emails/plan-completed.tsx
@@ -1,0 +1,79 @@
+import { Button, Section, Text } from '@react-email/components';
+import { EmailLayout } from '@/server/emails/components/layout';
+import {
+  heading,
+  muted,
+  paragraph,
+  primaryButton,
+  successBox,
+  tableContainer,
+  tableRow,
+  tableRowBold,
+} from '@/server/emails/components/styles';
+import { formatCents, formatDate } from '@/server/emails/helpers';
+
+export interface PlanCompletedProps {
+  ownerName: string;
+  petName: string;
+  clinicName: string;
+  totalPaidCents: number;
+  completedDate: Date;
+  enrollmentDate: Date;
+  dashboardUrl: string;
+}
+
+export function PlanCompleted({
+  ownerName,
+  petName,
+  clinicName,
+  totalPaidCents,
+  completedDate,
+  enrollmentDate,
+  dashboardUrl,
+}: PlanCompletedProps) {
+  return (
+    <EmailLayout
+      preview={`Congratulations! Your payment plan for ${petName} at ${clinicName} is complete`}
+    >
+      <Text style={heading}>All Paid Up -- You Did It!</Text>
+
+      <Text style={paragraph}>Hi {ownerName},</Text>
+
+      <Section style={successBox}>
+        <Text style={{ ...paragraph, color: '#065f46', margin: '0' }}>
+          Congratulations! All payments for {petName}'s care at {clinicName} have been successfully
+          completed. You are the cat's meow!
+        </Text>
+      </Section>
+
+      <Section style={tableContainer}>
+        <Text style={tableRowBold}>Plan Summary</Text>
+        <Text style={tableRow}>Pet: {petName}</Text>
+        <Text style={tableRow}>Clinic: {clinicName}</Text>
+        <Text style={tableRow}>Total paid: {formatCents(totalPaidCents)}</Text>
+        <Text style={tableRow}>Enrolled: {formatDate(enrollmentDate)}</Text>
+        <Text style={tableRow}>Completed: {formatDate(completedDate)}</Text>
+      </Section>
+
+      <Text style={paragraph}>
+        Thank you for choosing FuzzyCat to help manage {petName}'s veterinary care. We hope the
+        experience was smooth and stress-free.
+      </Text>
+
+      <Text style={paragraph}>
+        If {petName} needs veterinary care in the future, FuzzyCat will be here to help. You can
+        start a new payment plan at any time.
+      </Text>
+
+      <Section style={{ textAlign: 'center' as const, margin: '24px 0' }}>
+        <Button style={primaryButton} href={dashboardUrl}>
+          View Payment History
+        </Button>
+      </Section>
+
+      <Text style={muted}>
+        A complete record of all payments is available in your FuzzyCat dashboard.
+      </Text>
+    </EmailLayout>
+  );
+}

--- a/server/services/email.ts
+++ b/server/services/email.ts
@@ -1,0 +1,174 @@
+import type { ReactNode } from 'react';
+import { resend } from '@/lib/resend';
+import type { ClinicPayoutProps } from '@/server/emails/clinic-payout';
+import { ClinicPayout } from '@/server/emails/clinic-payout';
+import type { ClinicWelcomeProps } from '@/server/emails/clinic-welcome';
+import { ClinicWelcome } from '@/server/emails/clinic-welcome';
+import type { EnrollmentConfirmationProps } from '@/server/emails/enrollment-confirmation';
+import { EnrollmentConfirmation } from '@/server/emails/enrollment-confirmation';
+import type { PaymentFailedProps } from '@/server/emails/payment-failed';
+import { PaymentFailed } from '@/server/emails/payment-failed';
+import type { PaymentReminderProps } from '@/server/emails/payment-reminder';
+import { PaymentReminder } from '@/server/emails/payment-reminder';
+import type { PaymentSuccessProps } from '@/server/emails/payment-success';
+import { PaymentSuccess } from '@/server/emails/payment-success';
+import type { PlanCompletedProps } from '@/server/emails/plan-completed';
+import { PlanCompleted } from '@/server/emails/plan-completed';
+
+// ── Constants ────────────────────────────────────────────────────────
+
+const FROM_ADDRESS = 'FuzzyCat <noreply@fuzzycatapp.com>';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface SendEmailResult {
+  id: string;
+}
+
+// ── Internal helper ──────────────────────────────────────────────────
+
+/**
+ * Send an email via Resend and return the email ID.
+ * Throws a descriptive error if the Resend API returns an error.
+ */
+async function sendEmail(options: {
+  to: string;
+  subject: string;
+  react: ReactNode;
+  errorContext: string;
+}): Promise<SendEmailResult> {
+  const { data, error } = await resend().emails.send({
+    from: FROM_ADDRESS,
+    to: options.to,
+    subject: options.subject,
+    react: options.react,
+  });
+
+  if (error) {
+    throw new Error(`Failed to send ${options.errorContext} email: ${error.message}`);
+  }
+
+  if (!data) {
+    throw new Error(`Failed to send ${options.errorContext} email: no data returned`);
+  }
+
+  return { id: data.id };
+}
+
+// ── Email send functions ─────────────────────────────────────────────
+
+/**
+ * Send enrollment confirmation email to a pet owner.
+ * Includes plan summary, payment schedule, and disclosures.
+ */
+export async function sendEnrollmentConfirmation(
+  to: string,
+  props: EnrollmentConfirmationProps,
+): Promise<SendEmailResult> {
+  return sendEmail({
+    to,
+    subject: `Purrfect -- Your Payment Plan for ${props.petName} Is Confirmed`,
+    react: EnrollmentConfirmation(props),
+    errorContext: 'enrollment confirmation',
+  });
+}
+
+/**
+ * Send payment reminder email to a pet owner.
+ * Sent 3 days before each installment.
+ */
+export async function sendPaymentReminder(
+  to: string,
+  props: PaymentReminderProps,
+): Promise<SendEmailResult> {
+  const dateStr = props.scheduledDate.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+  return sendEmail({
+    to,
+    subject: `Reminder: ${props.petName}'s Payment Due on ${dateStr}`,
+    react: PaymentReminder(props),
+    errorContext: 'payment reminder',
+  });
+}
+
+/**
+ * Send payment success email to a pet owner.
+ * Confirms each successful payment with remaining balance info.
+ */
+export async function sendPaymentSuccess(
+  to: string,
+  props: PaymentSuccessProps,
+): Promise<SendEmailResult> {
+  return sendEmail({
+    to,
+    subject: `Payment Received for ${props.petName}'s Care`,
+    react: PaymentSuccess(props),
+    errorContext: 'payment success',
+  });
+}
+
+/**
+ * Send payment failed email to a pet owner.
+ * Includes failure reason, retry info, and next steps.
+ */
+export async function sendPaymentFailed(
+  to: string,
+  props: PaymentFailedProps,
+): Promise<SendEmailResult> {
+  return sendEmail({
+    to,
+    subject: `Action Needed: Payment for ${props.petName}'s Plan Was Not Successful`,
+    react: PaymentFailed(props),
+    errorContext: 'payment failed',
+  });
+}
+
+/**
+ * Send plan completed email to a pet owner.
+ * Congratulations message when all payments are done.
+ */
+export async function sendPlanCompleted(
+  to: string,
+  props: PlanCompletedProps,
+): Promise<SendEmailResult> {
+  return sendEmail({
+    to,
+    subject: `All Paid Up -- ${props.petName}'s Payment Plan Is Complete!`,
+    react: PlanCompleted(props),
+    errorContext: 'plan completed',
+  });
+}
+
+/**
+ * Send welcome email to a newly registered clinic.
+ * Includes onboarding steps and Stripe Connect setup link.
+ */
+export async function sendClinicWelcome(
+  to: string,
+  props: ClinicWelcomeProps,
+): Promise<SendEmailResult> {
+  return sendEmail({
+    to,
+    subject: `Welcome to FuzzyCat, ${props.clinicName}!`,
+    react: ClinicWelcome(props),
+    errorContext: 'clinic welcome',
+  });
+}
+
+/**
+ * Send payout notification email to a clinic.
+ * Confirms funds transferred with amount and plan reference.
+ */
+export async function sendClinicPayoutNotification(
+  to: string,
+  props: ClinicPayoutProps,
+): Promise<SendEmailResult> {
+  return sendEmail({
+    to,
+    subject: `Payout Sent: ${props.ownerName}'s Payment for ${props.petName}`,
+    react: ClinicPayout(props),
+    errorContext: 'clinic payout notification',
+  });
+}


### PR DESCRIPTION
## Summary
- Integrate Resend for transactional emails with 7 React Email templates covering all FuzzyCat email flows
- Add lazy singleton Resend client (`lib/resend.ts`) following the same pattern as `lib/stripe.ts`
- Add `RESEND_API_KEY` to server environment validation with `re_` prefix check
- Create email service (`server/services/email.ts`) with dedicated send functions for each template
- Add 25 unit tests mocking the Resend API

## Email Templates
| Template | Purpose | Recipient |
|----------|---------|-----------|
| **Enrollment Confirmation** | Plan summary, payment schedule, disclosures | Pet owner |
| **Payment Reminder** | 3 days before each installment (amount, date, plan summary) | Pet owner |
| **Payment Success** | Confirmation after successful payment (amount, remaining balance) | Pet owner |
| **Payment Failed** | Failure notification with retry info (amount, next retry date) | Pet owner |
| **Plan Completed** | Congratulations when all payments are done | Pet owner |
| **Clinic Welcome** | Onboarding confirmation for new clinics | Clinic |
| **Clinic Payout Notification** | Funds transferred (amount, plan reference) | Clinic |

## Files Changed
- `lib/env.ts` — Added `RESEND_API_KEY` to server env schema
- `lib/resend.ts` — Lazy singleton Resend client
- `lib/__tests__/env.test.ts` — Added `RESEND_API_KEY` to test setup
- `package.json` / `bun.lock` — Added `resend` and `@react-email/components`
- `server/emails/components/layout.tsx` — Shared email layout with FuzzyCat branding
- `server/emails/components/styles.ts` — Reusable inline style objects
- `server/emails/helpers.ts` — formatCents, formatDate, formatShortDate for templates
- `server/emails/*.tsx` — 7 email template components
- `server/services/email.ts` — Email service with send functions
- `server/__tests__/email.test.ts` — 25 unit tests

## Test plan
- [x] All 25 email service tests pass (`bun test server/__tests__/email.test.ts`)
- [x] Full test suite passes (256 tests across 18 files)
- [x] Biome check passes (lint + format)
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] Pre-commit hooks pass (biome, secrets, typecheck)
- [x] Pre-push hooks pass (circular deps, security scan, build)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)