### PR TITLE
chore: update knip config for shadcn/ui components

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -9,13 +9,12 @@
     "e2e/**/*.ts"
   ],
   "project": ["**/*.{ts,tsx}"],
-  "ignore": ["drizzle/**", "drizzle.config.ts"],
+  "ignore": ["drizzle/**", "drizzle.config.ts", "components/ui/**"],
   "ignoreBinaries": ["gitleaks", "semgrep"],
   "drizzle": false,
   "ignoreDependencies": [
     "@commitlint/cli",
-    "class-variance-authority",
-    "lucide-react",
+    "@radix-ui/*",
     "postcss",
     "radix-ui",
     "shadcn",


### PR DESCRIPTION
## Summary
- Ignore `components/ui/**` directory in Knip since shadcn/ui generates component files that may not all be imported immediately
- Replace `class-variance-authority` and `lucide-react` with `@radix-ui/*` in `ignoreDependencies` (Knip now detects CVA and Lucide as used; radix-ui deps are used by shadcn components in the ignored directory)

Follow-up fix from PR #76 to resolve the Knip CI failure.

## Test plan
- [ ] `bun run check:unused` passes locally
- [ ] CI Knip check passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>