### PR TITLE
fix: make Turnstile env vars optional to prevent middleware crash (#85)

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -23,7 +23,7 @@ const serverSchema = z.object({
   TWILIO_PHONE_NUMBER: z
     .string()
     .startsWith('+', 'TWILIO_PHONE_NUMBER must be in E.164 format (start with +)'),
-  TURNSTILE_SECRET_KEY: z.string().min(1, 'TURNSTILE_SECRET_KEY is required'),
+  TURNSTILE_SECRET_KEY: z.string().optional(),
   SENTRY_AUTH_TOKEN: z.string().optional(),
   SENTRY_ORG: z.string().optional(),
   SENTRY_PROJECT: z.string().optional(),
@@ -39,7 +39,7 @@ const publicSchema = z.object({
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z
     .string()
     .startsWith('pk_', 'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY must start with pk_'),
-  NEXT_PUBLIC_TURNSTILE_SITE_KEY: z.string().min(1, 'NEXT_PUBLIC_TURNSTILE_SITE_KEY is required'),
+  NEXT_PUBLIC_TURNSTILE_SITE_KEY: z.string().optional(),
   NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),
   NEXT_PUBLIC_POSTHOG_KEY: z.string().optional(),
   NEXT_PUBLIC_POSTHOG_HOST: z.string().optional(),


### PR DESCRIPTION
## Summary
- Make `NEXT_PUBLIC_TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY` optional in the Zod env schema
- Fixes `500: MIDDLEWARE_INVOCATION_FAILED` on production caused by strict validation of unconfigured Turnstile env vars

## Root Cause
PR #83 (issue #29) added Cloudflare Turnstile CAPTCHA integration and made the env vars **required** in `lib/env.ts`. The middleware calls `publicEnv()` on every request, which validates `NEXT_PUBLIC_TURNSTILE_SITE_KEY`. Since this was never configured in Vercel production, the Zod validation threw on every request, crashing the middleware.

## Fix
Changed both Turnstile env vars from required to optional in the Zod schema, matching the existing pattern for Sentry/PostHog. The CAPTCHA components already handle missing keys gracefully (returning `null` / skipping validation).

## Test plan
- [x] 400 tests pass (`bun test`)
- [x] TypeScript clean (`bun run typecheck`)
- [x] Build succeeds locally
- [x] Existing env tests still pass

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)