### PR TITLE
test: add E2E tests for public pages, auth flows, and navigation

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -4,46 +4,39 @@ test.describe('Cross-page navigation', () => {
   test('landing page → signup via CTA', async ({ page }) => {
     await page.goto('/');
     await page.getByRole('link', { name: /split my vet bill/i }).click();
-    await page.waitForURL(/\/signup/);
-    expect(page.url()).toContain('/signup');
+    await expect(page).toHaveURL(/\/signup/);
   });
 
   test('landing page → how it works via CTA', async ({ page }) => {
     await page.goto('/');
     await page.getByRole('link', { name: /see how it works/i }).click();
-    await page.waitForURL(/\/how-it-works/);
-    expect(page.url()).toContain('/how-it-works');
+    await expect(page).toHaveURL(/\/how-it-works/);
   });
 
   test('login page → signup link', async ({ page }) => {
     await page.goto('/login');
     await page.getByRole('link', { name: /sign up|create an account/i }).click();
-    await page.waitForURL(/\/signup/);
-    expect(page.url()).toContain('/signup');
+    await expect(page).toHaveURL(/\/signup/);
   });
 
   test('signup page → login link', async ({ page }) => {
     await page.goto('/signup');
     await page.getByRole('link', { name: /log in|sign in/i }).click();
-    await page.waitForURL(/\/login/);
-    expect(page.url()).toContain('/login');
+    await expect(page).toHaveURL(/\/login/);
   });
 
   test('login page → forgot password', async ({ page }) => {
     await page.goto('/login');
     await page.getByRole('link', { name: /forgot your password/i }).click();
-    await page.waitForURL(/\/forgot-password/);
-    expect(page.url()).toContain('/forgot-password');
+    await expect(page).toHaveURL(/\/forgot-password/);
   });
 
   test('how-it-works → signup via clinic CTA', async ({ page }) => {
     await page.goto('/how-it-works');
     const partnerBtn = page.getByRole('link', { name: /become a partner clinic/i });
-    if (await partnerBtn.isVisible()) {
-      await partnerBtn.click();
-      await page.waitForURL(/\/signup/);
-      expect(page.url()).toContain('/signup');
-    }
+    await expect(partnerBtn).toBeVisible();
+    await partnerBtn.click();
+    await expect(page).toHaveURL(/\/signup/);
   });
 });
 

--- a/e2e/public-pages.spec.ts
+++ b/e2e/public-pages.spec.ts
@@ -46,8 +46,7 @@ test.describe('Landing page', () => {
     page.on('console', (msg) => {
       if (msg.type() === 'error') errors.push(msg.text());
     });
-    await page.goto('/', { waitUntil: 'domcontentloaded' });
-    await page.waitForTimeout(1000);
+    await page.goto('/', { waitUntil: 'load' });
     const real = errors.filter(
       (e) => !e.includes('monitoring') && !e.includes('posthog') && !e.includes('favicon'),
     );
@@ -110,11 +109,15 @@ test.describe('Forgot Password page', () => {
     await expect(page.getByRole('button', { name: /send reset link/i })).toBeVisible();
   });
 
-  test('shows validation for empty email submission', async ({ page }) => {
+  test('prevents empty email submission', async ({ page }) => {
     await page.goto('/forgot-password');
-    // HTML5 validation should prevent empty submission
     const emailInput = page.locator('input[type="email"]');
     await expect(emailInput).toHaveAttribute('required', '');
+
+    // Attempt to submit with empty email — HTML5 validation prevents it
+    await page.getByRole('button', { name: /send reset link/i }).click();
+    await expect(page.getByText('Check your email')).not.toBeVisible();
+    await expect(page).toHaveURL('/forgot-password');
   });
 
   test('has back to login link', async ({ page }) => {


### PR DESCRIPTION
## Summary
- **public-pages.spec.ts** (15 tests): Landing page hero/CTAs/pricing/steps/clinic section, How It Works 4-step flow/calculator/FAQ accordion/clinic benefits, Forgot Password form/validation/links
- **auth-pages.spec.ts** (18 tests): Login form fields/error handling/loading state/autocomplete attrs, Signup tab switching/owner+clinic fields/validation attrs, Auth redirects for all 3 portals with redirectTo preservation
- **navigation.spec.ts** (8 tests): Cross-page link navigation (landing↔signup, landing→how-it-works, login↔signup, login→forgot-password, how-it-works→signup), API health endpoint JSON response, 404 handling

Total: **44 new E2E tests**, all passing alongside the existing 12 smoke + comprehensive tests (52 pass, 4 skipped for missing auth credentials).

## Test plan
- [x] All 44 new tests pass locally against production build
- [x] All 56 total E2E tests pass (52 passed, 4 correctly skipped)
- [x] Biome lint clean
- [x] TypeScript clean
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)