### PR TITLE
refactor: modernize Drizzle queries with native count() helper

### DIFF
--- a/server/routers/admin.ts
+++ b/server/routers/admin.ts
@@ -84,7 +84,7 @@ export const adminRouter = router({
       // Plan counts by status
       ctx.db
         .select({
-          totalEnrollments: sql<number>`count(*)`,
+          totalEnrollments: count(),
           activePlans: sql<number>`count(*) filter (where ${plans.status} in ('active', 'deposit_paid'))`,
           completedPlans: sql<number>`count(*) filter (where ${plans.status} = 'completed')`,
           defaultedPlans: sql<number>`count(*) filter (where ${plans.status} = 'defaulted')`,
@@ -600,7 +600,7 @@ export const adminRouter = router({
     const stageCounts = await ctx.db
       .select({
         stage: softCollections.stage,
-        count: sql<number>`count(*)`,
+        count: count(),
       })
       .from(softCollections)
       .groupBy(softCollections.stage);

--- a/server/routers/clinic.ts
+++ b/server/routers/clinic.ts
@@ -408,7 +408,7 @@ export const clinicRouter = router({
             activePlans: sql<number>`count(*) filter (where ${plans.status} in ('active', 'deposit_paid'))`,
             completedPlans: sql<number>`count(*) filter (where ${plans.status} = 'completed')`,
             defaultedPlans: sql<number>`count(*) filter (where ${plans.status} = 'defaulted')`,
-            totalPlans: sql<number>`count(*)`,
+            totalPlans: count(),
           })
           .from(plans)
           .where(eq(plans.clinicId, clinicId)),
@@ -425,7 +425,7 @@ export const clinicRouter = router({
         // Pending payouts count and amount
         ctx.db
           .select({
-            pendingCount: sql<number>`count(*)`,
+            pendingCount: count(),
             pendingAmountCents: sql<number>`coalesce(sum(${payouts.amountCents}), 0)`,
           })
           .from(payouts)
@@ -645,7 +645,7 @@ export const clinicRouter = router({
         month: sql<string>`to_char(${payouts.createdAt}, 'YYYY-MM')`,
         totalPayoutCents: sql<number>`coalesce(sum(${payouts.amountCents}), 0)`,
         totalShareCents: sql<number>`coalesce(sum(${payouts.clinicShareCents}), 0)`,
-        payoutCount: sql<number>`count(*)`,
+        payoutCount: count(),
       })
       .from(payouts)
       .where(
@@ -690,7 +690,7 @@ export const clinicRouter = router({
           month: sql<string>`to_char(${payouts.createdAt}, 'YYYY-MM')`,
           revenueCents: sql<number>`coalesce(sum(${payouts.amountCents}), 0)`,
           clinicShareCents: sql<number>`coalesce(sum(${payouts.clinicShareCents}), 0)`,
-          payoutCount: sql<number>`count(*)`,
+          payoutCount: count(),
         })
         .from(payouts)
         .where(
@@ -708,7 +708,7 @@ export const clinicRouter = router({
       const enrollmentData = await ctx.db
         .select({
           month: sql<string>`to_char(${plans.createdAt}, 'YYYY-MM')`,
-          enrollments: sql<number>`count(*)`,
+          enrollments: count(),
         })
         .from(plans)
         .where(
@@ -768,7 +768,7 @@ export const clinicRouter = router({
       const trendData = await ctx.db
         .select({
           month: sql<string>`to_char(${plans.createdAt}, 'YYYY-MM')`,
-          enrollments: sql<number>`count(*)`,
+          enrollments: count(),
         })
         .from(plans)
         .where(
@@ -794,7 +794,7 @@ export const clinicRouter = router({
 
     const [result] = await ctx.db
       .select({
-        totalPlans: sql<number>`count(*)`,
+        totalPlans: count(),
         defaultedPlans: sql<number>`count(*) filter (where ${plans.status} = 'defaulted')`,
       })
       .from(plans)
@@ -877,7 +877,7 @@ export const clinicRouter = router({
           month: sql<string>`to_char(${payouts.createdAt}, 'YYYY-MM')`,
           revenueCents: sql<number>`coalesce(sum(${payouts.amountCents}), 0)`,
           clinicShareCents: sql<number>`coalesce(sum(${payouts.clinicShareCents}), 0)`,
-          payoutCount: sql<number>`count(*)`,
+          payoutCount: count(),
         })
         .from(payouts)
         .where(

--- a/server/services/guarantee.ts
+++ b/server/services/guarantee.ts
@@ -13,7 +13,7 @@
 // `amountCents` to reflect its general purpose. A schema migration to
 // rename it is deferred to a future PR to avoid unnecessary risk here.
 
-import { eq, sql } from 'drizzle-orm';
+import { count, eq, sql } from 'drizzle-orm';
 import type { PgTransaction } from 'drizzle-orm/pg-core';
 import { RISK_POOL_RATE } from '@/lib/constants';
 import { percentOfCents } from '@/lib/utils/money';
@@ -222,7 +222,7 @@ export async function getRiskPoolHealth(): Promise<RiskPoolHealth> {
     db
       .select({
         outstandingCents: sql<number>`coalesce(sum(${plans.remainingCents}), 0)`,
-        activePlanCount: sql<number>`count(*)`,
+        activePlanCount: count(),
       })
       .from(plans)
       .where(eq(plans.status, 'active')),


### PR DESCRIPTION
## Summary

- Replace raw `sql<number>`count(*)`` snippets with Drizzle's native `count()` helper in `server/routers/clinic.ts`, `server/routers/admin.ts`, and `server/services/guarantee.ts`
- Add `count` import from `drizzle-orm` to `server/services/guarantee.ts` (already imported in the router files)
- Conditional counts using PostgreSQL `FILTER` clauses and `sum` aggregations are left as raw SQL since they have no native Drizzle equivalent

Closes #114

## Test plan

- [x] `bun run check:fix` passes (Biome lint + format)
- [x] `bun run typecheck` passes (TypeScript strict mode)
- [x] All 22 guarantee service tests pass (`bun test server/__tests__/guarantee.test.ts`)
- [x] All 32 admin/clinic router tests pass (`bun test server/__tests__/admin-router.test.ts server/__tests__/clinic-router.test.ts`)
- [x] Pre-commit hooks pass (secrets, biome, typecheck, commitlint)
- [x] Pre-push hooks pass (circular deps, security scan, full production build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)