### PR TITLE
refactor: remove clinic_id from owners, use plans table

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -105,7 +105,6 @@ async function seed() {
       {
         id: OWNER_1_ID,
         authId: OWNER_1_AUTH_ID,
-        clinicId: CLINIC_1_ID,
         name: 'Alice Johnson',
         email: 'alice@example.com',
         phone: '(415) 555-1001',
@@ -120,7 +119,6 @@ async function seed() {
       {
         id: OWNER_2_ID,
         authId: OWNER_2_AUTH_ID,
-        clinicId: CLINIC_1_ID,
         name: 'Bob Martinez',
         email: 'bob@example.com',
         phone: '(415) 555-1002',
@@ -135,7 +133,6 @@ async function seed() {
       {
         id: OWNER_3_ID,
         authId: OWNER_3_AUTH_ID,
-        clinicId: CLINIC_2_ID,
         name: 'Carol Chen',
         email: 'carol@example.com',
         phone: '(310) 555-2001',

--- a/server/__tests__/clinic-router.test.ts
+++ b/server/__tests__/clinic-router.test.ts
@@ -42,7 +42,6 @@ const extendedSchemaMock = {
     email: 'owners.email',
     phone: 'owners.phone',
     petName: 'owners.pet_name',
-    clinicId: 'owners.clinic_id',
     addressLine1: 'owners.address_line1',
     addressCity: 'owners.address_city',
     addressState: 'owners.address_state',

--- a/server/__tests__/owner-router.test.ts
+++ b/server/__tests__/owner-router.test.ts
@@ -32,7 +32,6 @@ const extendedSchemaMock = {
     addressCity: 'owners.address_city',
     addressState: 'owners.address_state',
     addressZip: 'owners.address_zip',
-    clinicId: 'owners.clinic_id',
     createdAt: 'owners.created_at',
     updatedAt: 'owners.updated_at',
   },

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -65,7 +65,6 @@ export const clinics = pgTable('clinics', {
 export const owners = pgTable('owners', {
   id: uuid('id').primaryKey().defaultRandom(),
   authId: text('auth_id').unique(),
-  clinicId: uuid('clinic_id').references(() => clinics.id),
   name: text('name').notNull(),
   email: text('email').notNull().unique(),
   phone: text('phone').notNull(),
@@ -217,13 +216,11 @@ export const auditLog = pgTable(
 // ── Relations (for db.query API — no SQL impact) ────────────────────
 
 export const clinicsRelations = relations(clinics, ({ many }) => ({
-  owners: many(owners),
   plans: many(plans),
   payouts: many(payouts),
 }));
 
-export const ownersRelations = relations(owners, ({ one, many }) => ({
-  clinic: one(clinics, { fields: [owners.clinicId], references: [clinics.id] }),
+export const ownersRelations = relations(owners, ({ many }) => ({
   plans: many(plans),
 }));
 

--- a/server/services/enrollment.ts
+++ b/server/services/enrollment.ts
@@ -123,11 +123,10 @@ export async function createEnrollment(
 
     if (existingOwner) {
       ownerId = existingOwner.id;
-      // Update owner details (including clinicId) in case they changed or are enrolling at a new clinic
+      // Update owner details in case they changed
       await tx
         .update(owners)
         .set({
-          clinicId,
           name: ownerData.name,
           phone: ownerData.phone,
           petName: ownerData.petName,
@@ -142,7 +141,6 @@ export async function createEnrollment(
       const [newOwner] = await tx
         .insert(owners)
         .values({
-          clinicId,
           name: ownerData.name,
           email: ownerData.email,
           phone: ownerData.phone,


### PR DESCRIPTION
## Summary

- Removed the `clinic_id` foreign key column from the `owners` table in the Drizzle schema, since the `plans` table already links owners to clinics via `owner_id` + `clinic_id`
- Updated the enrollment service to no longer set `clinic_id` on owner records during creation or update
- Removed the `clinic` relation from `ownersRelations` and the `owners` relation from `clinicsRelations` (the owner-clinic relationship is now derived through plans)
- Updated seed data and test mocks to remove references to `owners.clinicId`

This enables a pet owner to be associated with multiple clinics simultaneously through their plans, rather than being locked to a single clinic via a direct foreign key.

Closes #108

## Test plan

- [x] `bun run check:fix` passes (Biome)
- [x] `bun run typecheck` passes (tsc --noEmit)
- [x] All 481 unit tests pass (8 pre-existing failures in auth/env/captcha tests are unrelated)
- [x] Verified that all queries referencing owner-clinic relationships use `plans.clinicId` (not `owners.clinicId`)
- [x] Verified that the authorization service already uses `plans.clinicId` for plan access checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)