### PR TITLE
feat: add sign-out button to owner portal and fix sidebar sign-out

### DIFF
--- a/app/admin/_components/admin-sidebar.tsx
+++ b/app/admin/_components/admin-sidebar.tsx
@@ -3,6 +3,7 @@
 import { Building2, CreditCard, LayoutDashboard, LogOut, Shield } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { signOut } from '@/app/(auth)/signout/actions';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
@@ -56,7 +57,7 @@ export function AdminSidebar() {
 
       {/* Footer */}
       <div className="flex items-center justify-between p-3">
-        <form action="/api/auth/signout" method="POST">
+        <form action={signOut}>
           <Button variant="ghost" className="justify-start gap-3 text-muted-foreground">
             <LogOut className="h-4 w-4" />
             Sign Out

--- a/app/clinic/_components/clinic-sidebar.tsx
+++ b/app/clinic/_components/clinic-sidebar.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { signOut } from '@/app/(auth)/signout/actions';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
@@ -65,7 +66,7 @@ export function ClinicSidebar() {
 
       {/* Footer */}
       <div className="flex items-center justify-between p-3">
-        <form action="/api/auth/signout" method="POST">
+        <form action={signOut}>
           <Button variant="ghost" className="justify-start gap-3 text-muted-foreground">
             <LogOut className="h-4 w-4" />
             Sign Out

--- a/app/owner/layout.tsx
+++ b/app/owner/layout.tsx
@@ -1,7 +1,9 @@
-import { Cat } from 'lucide-react';
+import { Cat, LogOut } from 'lucide-react';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
+import { signOut } from '@/app/(auth)/signout/actions';
 import { ThemeToggle } from '@/components/theme-toggle';
+import { Button } from '@/components/ui/button';
 import { getUserRole } from '@/lib/auth';
 import { createClient } from '@/lib/supabase/server';
 
@@ -36,6 +38,12 @@ export default async function OwnerLayout({ children }: { children: React.ReactN
             >
               Settings
             </Link>
+            <form action={signOut}>
+              <Button variant="ghost" size="sm" className="gap-1.5 text-muted-foreground">
+                <LogOut className="h-4 w-4" />
+                Sign Out
+              </Button>
+            </form>
           </div>
         </div>
       </header>


### PR DESCRIPTION
## Summary
- Adds a sign-out button to the owner portal header, next to Settings and ThemeToggle
- Fixes broken sign-out buttons in admin and clinic sidebars that referenced a nonexistent `/api/auth/signout` route
- All three portals now use the existing `signOut` server action from `app/(auth)/signout/actions.ts`

Closes #124

## Test plan
- [ ] Verify owner portal header shows Sign Out button
- [ ] Click Sign Out in owner portal — should redirect to /login
- [ ] Click Sign Out in clinic sidebar — should redirect to /login
- [ ] Click Sign Out in admin sidebar — should redirect to /login

🤖 Generated with [Claude Code](https://claude.com/claude-code)