### PR TITLE
fix: resolve HIGH audit findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
       - run: bun install --frozen-lockfile
-      - run: bun run build
+      - name: Build
+        run: bun run build
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder
+          NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: pk_test_placeholder
 
   e2e:
     name: E2E Tests (Playwright)

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -83,7 +83,10 @@ export default function ForgotPasswordPage() {
         </div>
 
         {error && (
-          <div className="rounded-md bg-destructive/10 p-3 text-center text-sm text-destructive">
+          <div
+            role="alert"
+            className="rounded-md bg-destructive/10 p-3 text-center text-sm text-destructive"
+          >
             {error}
           </div>
         )}

--- a/app/(auth)/loading.tsx
+++ b/app/(auth)/loading.tsx
@@ -1,0 +1,9 @@
+import { Loader2 } from 'lucide-react';
+
+export default function AuthLoading() {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  );
+}

--- a/app/(auth)/login/login-form.tsx
+++ b/app/(auth)/login/login-form.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
-import { getUserRole, ROLE_HOME } from '@/lib/auth';
+import { getUserRole, ROLE_HOME, SAFE_REDIRECT_PREFIXES } from '@/lib/auth';
 import { createClient } from '@/lib/supabase/client';
 
 export function LoginForm({ redirectTo }: { redirectTo?: string }) {
@@ -34,7 +34,9 @@ export function LoginForm({ redirectTo }: { redirectTo?: string }) {
       }
 
       const role = data.user ? getUserRole(data.user) : 'owner';
-      const destination = redirectTo ?? ROLE_HOME[role];
+      const isSafeRedirect =
+        redirectTo && SAFE_REDIRECT_PREFIXES.some((p) => redirectTo.startsWith(p));
+      const destination = isSafeRedirect ? redirectTo : ROLE_HOME[role];
       router.push(destination);
       router.refresh();
     } catch (error) {
@@ -48,7 +50,9 @@ export function LoginForm({ redirectTo }: { redirectTo?: string }) {
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       {error && (
-        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
+        <div role="alert" className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
       )}
       <div>
         <label htmlFor="email" className="block text-sm font-medium text-foreground">

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -17,7 +17,10 @@ export default async function LoginPage({
           </p>
         </div>
         {error && (
-          <div className="rounded-md bg-destructive/10 p-3 text-center text-sm text-destructive">
+          <div
+            role="alert"
+            className="rounded-md bg-destructive/10 p-3 text-center text-sm text-destructive"
+          >
             {error === 'auth_callback_failed'
               ? 'Authentication failed. Please try again.'
               : 'An error occurred. Please try again.'}

--- a/app/(auth)/mfa/setup/page.tsx
+++ b/app/(auth)/mfa/setup/page.tsx
@@ -81,7 +81,9 @@ export default function MfaSetupPage() {
         </div>
 
         {error && (
-          <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
+          <div role="alert" className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+            {error}
+          </div>
         )}
 
         {qrCode && (

--- a/app/(auth)/mfa/verify/page.tsx
+++ b/app/(auth)/mfa/verify/page.tsx
@@ -63,7 +63,9 @@ export default function MfaVerifyPage() {
         </div>
 
         {error && (
-          <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
+          <div role="alert" className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+            {error}
+          </div>
         )}
 
         <form onSubmit={handleVerify} className="space-y-4">

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -87,7 +87,10 @@ export default function ResetPasswordPage() {
         </div>
 
         {error && (
-          <div className="rounded-md bg-destructive/10 p-3 text-center text-sm text-destructive">
+          <div
+            role="alert"
+            className="rounded-md bg-destructive/10 p-3 text-center text-sm text-destructive"
+          >
             {error}
           </div>
         )}

--- a/app/(auth)/signup/signup-form.tsx
+++ b/app/(auth)/signup/signup-form.tsx
@@ -125,7 +125,9 @@ export function SignupForm() {
 
       <form onSubmit={handleSubmit} className="space-y-4">
         {error && (
-          <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
+          <div role="alert" className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+            {error}
+          </div>
         )}
 
         <div>

--- a/app/admin/_components/admin-sidebar.tsx
+++ b/app/admin/_components/admin-sidebar.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { Building2, CreditCard, LayoutDashboard, LogOut, Shield } from 'lucide-react';
+import { Building2, CreditCard, LayoutDashboard, LogOut, Menu, Shield, X } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import { signOut } from '@/app/(auth)/signout/actions';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { Button } from '@/components/ui/button';
@@ -18,53 +19,95 @@ const NAV_ITEMS = [
 
 export function AdminSidebar() {
   const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+
+  // Close mobile menu on route change
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally re-run on pathname change
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
 
   return (
-    <aside className="flex h-full w-64 flex-col border-r bg-card">
-      {/* Logo / Brand */}
-      <div className="flex h-16 items-center px-6">
-        <Link href="/admin/dashboard" className="flex items-center gap-2">
-          <Shield className="h-6 w-6 text-primary" />
-          <span className="text-lg font-bold tracking-tight">FuzzyCat Admin</span>
-        </Link>
+    <>
+      {/* Mobile header bar */}
+      <div className="flex h-14 items-center border-b bg-card px-4 md:hidden">
+        <Button variant="ghost" size="icon" onClick={() => setOpen(true)} aria-label="Open menu">
+          <Menu className="h-5 w-5" />
+        </Button>
+        <span className="ml-2 text-sm font-bold">FuzzyCat Admin</span>
       </div>
 
-      <Separator />
+      {/* Backdrop */}
+      {open && (
+        <button
+          type="button"
+          aria-label="Close menu"
+          className="fixed inset-0 z-40 bg-black/50 md:hidden"
+          onClick={() => setOpen(false)}
+        />
+      )}
 
-      {/* Navigation */}
-      <nav className="flex-1 space-y-1 px-3 py-4">
-        {NAV_ITEMS.map((item) => {
-          const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
-          return (
-            <Link
-              key={item.href}
-              href={item.href}
-              className={cn(
-                'flex items-center gap-3 rounded-md px-3 py-2.5 text-sm font-medium transition-colors',
-                isActive
-                  ? 'bg-primary/10 text-primary'
-                  : 'text-muted-foreground hover:bg-muted hover:text-foreground',
-              )}
-            >
-              <item.icon className="h-4 w-4" />
-              {item.label}
-            </Link>
-          );
-        })}
-      </nav>
-
-      <Separator />
-
-      {/* Footer */}
-      <div className="flex items-center justify-between p-3">
-        <form action={signOut}>
-          <Button variant="ghost" className="justify-start gap-3 text-muted-foreground">
-            <LogOut className="h-4 w-4" />
-            Sign Out
+      {/* Sidebar */}
+      <aside
+        className={cn(
+          'fixed inset-y-0 left-0 z-50 flex w-64 flex-col border-r bg-card transition-transform md:static md:translate-x-0',
+          open ? 'translate-x-0' : '-translate-x-full',
+        )}
+      >
+        {/* Logo / Brand */}
+        <div className="flex h-16 items-center justify-between px-6">
+          <Link href="/admin/dashboard" className="flex items-center gap-2">
+            <Shield className="h-6 w-6 text-primary" />
+            <span className="text-lg font-bold tracking-tight">FuzzyCat Admin</span>
+          </Link>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="md:hidden"
+            onClick={() => setOpen(false)}
+            aria-label="Close menu"
+          >
+            <X className="h-4 w-4" />
           </Button>
-        </form>
-        <ThemeToggle />
-      </div>
-    </aside>
+        </div>
+
+        <Separator />
+
+        {/* Navigation */}
+        <nav className="flex-1 space-y-1 px-3 py-4">
+          {NAV_ITEMS.map((item) => {
+            const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={cn(
+                  'flex items-center gap-3 rounded-md px-3 py-2.5 text-sm font-medium transition-colors',
+                  isActive
+                    ? 'bg-primary/10 text-primary'
+                    : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                )}
+              >
+                <item.icon className="h-4 w-4" />
+                {item.label}
+              </Link>
+            );
+          })}
+        </nav>
+
+        <Separator />
+
+        {/* Footer */}
+        <div className="flex items-center justify-between p-3">
+          <form action={signOut}>
+            <Button variant="ghost" className="justify-start gap-3 text-muted-foreground">
+              <LogOut className="h-4 w-4" />
+              Sign Out
+            </Button>
+          </form>
+          <ThemeToggle />
+        </div>
+      </aside>
+    </>
   );
 }

--- a/app/admin/loading.tsx
+++ b/app/admin/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from '@/components/shared/loading-skeleton';
+
+export default function AdminLoading() {
+  return <PageSkeleton />;
+}

--- a/app/api/cron/__tests__/process-payouts.test.ts
+++ b/app/api/cron/__tests__/process-payouts.test.ts
@@ -77,14 +77,14 @@ describe('GET /api/cron/process-payouts', () => {
     expect(body.results).toHaveLength(2);
   });
 
-  it('skips auth check when CRON_SECRET is not configured', async () => {
+  it('returns 401 when CRON_SECRET is not configured', async () => {
     mockCronSecret = undefined;
 
     const request = new Request('http://localhost/api/cron/process-payouts');
     const response = await GET(request);
 
-    expect(response.status).toBe(200);
-    expect(mockProcessPendingPayouts).toHaveBeenCalled();
+    expect(response.status).toBe(401);
+    expect(mockProcessPendingPayouts).not.toHaveBeenCalled();
   });
 
   it('returns 500 when processPendingPayouts throws', async () => {

--- a/app/api/cron/collect-payments/route.ts
+++ b/app/api/cron/collect-payments/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from 'next/server';
+import { serverEnv } from '@/lib/env';
+import { logger } from '@/lib/logger';
+import {
+  escalateDefault,
+  identifyDuePayments,
+  identifyPlansForEscalation,
+} from '@/server/services/collection';
+import { processInstallment } from '@/server/services/payment';
+import {
+  escalateSoftCollection,
+  identifyPendingEscalations,
+} from '@/server/services/soft-collection';
+
+interface CollectionResults {
+  duePayments: number;
+  processed: number;
+  failed: number;
+  softCollectionEscalations: number;
+  planEscalations: number;
+}
+
+async function processDuePayments(results: CollectionResults) {
+  const duePayments = await identifyDuePayments();
+  results.duePayments = duePayments.length;
+
+  for (const payment of duePayments) {
+    try {
+      await processInstallment({ paymentId: payment.id });
+      results.processed++;
+    } catch (err) {
+      results.failed++;
+      logger.error('Failed to process installment', {
+        paymentId: payment.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+async function processSoftCollections(results: CollectionResults) {
+  const pendingEscalations = await identifyPendingEscalations();
+  for (const collection of pendingEscalations) {
+    try {
+      await escalateSoftCollection(collection.id);
+      results.softCollectionEscalations++;
+    } catch (err) {
+      logger.error('Failed to escalate soft collection', {
+        collectionId: collection.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+async function processPlanEscalations(results: CollectionResults) {
+  const plansForEscalation = await identifyPlansForEscalation();
+  for (const planId of plansForEscalation) {
+    try {
+      await escalateDefault(planId);
+      results.planEscalations++;
+    } catch (err) {
+      logger.error('Failed to escalate plan to default', {
+        planId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+/**
+ * Cron endpoint for payment collection cycle.
+ *
+ * Runs the following steps in order:
+ * 1. Identify and process due installment payments
+ * 2. Escalate soft collections that are overdue
+ * 3. Escalate plans to defaulted where appropriate
+ */
+export async function GET(request: Request) {
+  const { CRON_SECRET } = serverEnv();
+
+  if (!CRON_SECRET) {
+    logger.error('CRON_SECRET not configured — rejecting cron request');
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${CRON_SECRET}`) {
+    logger.warn('Unauthorized cron request', { endpoint: '/api/cron/collect-payments' });
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const results: CollectionResults = {
+    duePayments: 0,
+    processed: 0,
+    failed: 0,
+    softCollectionEscalations: 0,
+    planEscalations: 0,
+  };
+
+  try {
+    await processDuePayments(results);
+    await processSoftCollections(results);
+    await processPlanEscalations(results);
+
+    logger.info('Collection cron completed', { ...results });
+    return NextResponse.json({ ok: true, ...results });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    logger.error('Cron collect-payments failed', { error: message });
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/cron/process-payouts/route.ts
+++ b/app/api/cron/process-payouts/route.ts
@@ -6,14 +6,17 @@ import { processPendingPayouts } from '@/server/services/payout';
 export async function GET(request: Request) {
   const { CRON_SECRET } = serverEnv();
 
-  if (CRON_SECRET) {
-    const authHeader = request.headers.get('authorization');
-    if (authHeader !== `Bearer ${CRON_SECRET}`) {
-      logger.warn('Unauthorized cron request', {
-        endpoint: '/api/cron/process-payouts',
-      });
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+  if (!CRON_SECRET) {
+    logger.error('CRON_SECRET not configured — rejecting cron request');
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${CRON_SECRET}`) {
+    logger.warn('Unauthorized cron request', {
+      endpoint: '/api/cron/process-payouts',
+    });
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   try {

--- a/app/api/webhooks/plaid/route.ts
+++ b/app/api/webhooks/plaid/route.ts
@@ -48,11 +48,8 @@ type PlaidWebhook = PlaidItemWebhook | PlaidAuthWebhook | PlaidWebhookBase;
  */
 async function verifyWebhook(body: string, verificationHeader: string | null): Promise<boolean> {
   if (!verificationHeader) {
-    if (process.env.NODE_ENV === 'production') {
-      logger.error('Plaid webhook: Plaid-Verification header missing in production');
-      return false;
-    }
-    return true;
+    logger.error('Plaid webhook: Plaid-Verification header missing');
+    return false;
   }
 
   try {

--- a/app/clinic/_components/clinic-sidebar.tsx
+++ b/app/clinic/_components/clinic-sidebar.tsx
@@ -5,12 +5,15 @@ import {
   FileBarChart,
   LayoutDashboard,
   LogOut,
+  Menu,
   Settings,
   Users,
   Wallet,
+  X,
 } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import { signOut } from '@/app/(auth)/signout/actions';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { Button } from '@/components/ui/button';
@@ -27,53 +30,95 @@ const NAV_ITEMS = [
 
 export function ClinicSidebar() {
   const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+
+  // Close mobile menu on route change
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally re-run on pathname change
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
 
   return (
-    <aside className="flex h-full w-64 flex-col border-r bg-card">
-      {/* Logo / Brand */}
-      <div className="flex h-16 items-center px-6">
-        <Link href="/clinic/dashboard" className="flex items-center gap-2">
-          <BarChart3 className="h-6 w-6 text-primary" />
-          <span className="text-lg font-bold tracking-tight">FuzzyCat</span>
-        </Link>
+    <>
+      {/* Mobile header bar */}
+      <div className="flex h-14 items-center border-b bg-card px-4 md:hidden">
+        <Button variant="ghost" size="icon" onClick={() => setOpen(true)} aria-label="Open menu">
+          <Menu className="h-5 w-5" />
+        </Button>
+        <span className="ml-2 text-sm font-bold">FuzzyCat</span>
       </div>
 
-      <Separator />
+      {/* Backdrop */}
+      {open && (
+        <button
+          type="button"
+          aria-label="Close menu"
+          className="fixed inset-0 z-40 bg-black/50 md:hidden"
+          onClick={() => setOpen(false)}
+        />
+      )}
 
-      {/* Navigation */}
-      <nav className="flex-1 space-y-1 px-3 py-4">
-        {NAV_ITEMS.map((item) => {
-          const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
-          return (
-            <Link
-              key={item.href}
-              href={item.href}
-              className={cn(
-                'flex items-center gap-3 rounded-md px-3 py-2.5 text-sm font-medium transition-colors',
-                isActive
-                  ? 'bg-primary/10 text-primary'
-                  : 'text-muted-foreground hover:bg-muted hover:text-foreground',
-              )}
-            >
-              <item.icon className="h-4 w-4" />
-              {item.label}
-            </Link>
-          );
-        })}
-      </nav>
-
-      <Separator />
-
-      {/* Footer */}
-      <div className="flex items-center justify-between p-3">
-        <form action={signOut}>
-          <Button variant="ghost" className="justify-start gap-3 text-muted-foreground">
-            <LogOut className="h-4 w-4" />
-            Sign Out
+      {/* Sidebar */}
+      <aside
+        className={cn(
+          'fixed inset-y-0 left-0 z-50 flex w-64 flex-col border-r bg-card transition-transform md:static md:translate-x-0',
+          open ? 'translate-x-0' : '-translate-x-full',
+        )}
+      >
+        {/* Logo / Brand */}
+        <div className="flex h-16 items-center justify-between px-6">
+          <Link href="/clinic/dashboard" className="flex items-center gap-2">
+            <BarChart3 className="h-6 w-6 text-primary" />
+            <span className="text-lg font-bold tracking-tight">FuzzyCat</span>
+          </Link>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="md:hidden"
+            onClick={() => setOpen(false)}
+            aria-label="Close menu"
+          >
+            <X className="h-4 w-4" />
           </Button>
-        </form>
-        <ThemeToggle />
-      </div>
-    </aside>
+        </div>
+
+        <Separator />
+
+        {/* Navigation */}
+        <nav className="flex-1 space-y-1 px-3 py-4">
+          {NAV_ITEMS.map((item) => {
+            const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={cn(
+                  'flex items-center gap-3 rounded-md px-3 py-2.5 text-sm font-medium transition-colors',
+                  isActive
+                    ? 'bg-primary/10 text-primary'
+                    : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                )}
+              >
+                <item.icon className="h-4 w-4" />
+                {item.label}
+              </Link>
+            );
+          })}
+        </nav>
+
+        <Separator />
+
+        {/* Footer */}
+        <div className="flex items-center justify-between p-3">
+          <form action={signOut}>
+            <Button variant="ghost" className="justify-start gap-3 text-muted-foreground">
+              <LogOut className="h-4 w-4" />
+              Sign Out
+            </Button>
+          </form>
+          <ThemeToggle />
+        </div>
+      </aside>
+    </>
   );
 }

--- a/app/clinic/loading.tsx
+++ b/app/clinic/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from '@/components/shared/loading-skeleton';
+
+export default function ClinicLoading() {
+  return <PageSkeleton />;
+}

--- a/app/owner/enroll/_components/step-deposit-payment.tsx
+++ b/app/owner/enroll/_components/step-deposit-payment.tsx
@@ -2,7 +2,7 @@
 
 import { useMutation } from '@tanstack/react-query';
 import { AlertCircle, CheckCircle2, Loader2 } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
@@ -36,6 +36,7 @@ export function StepDepositPayment({ data, onBack }: StepDepositPaymentProps) {
         setPlanId(result.planId);
       },
       onError: (err) => {
+        submittingRef.current = false;
         setError(err.message || 'Failed to create enrollment. Please try again.');
       },
     }),
@@ -50,14 +51,18 @@ export function StepDepositPayment({ data, onBack }: StepDepositPaymentProps) {
         }
       },
       onError: (err) => {
+        submittingRef.current = false;
         setError(err.message || 'Failed to create checkout session. Please try again.');
       },
     }),
   );
 
   const isProcessing = createEnrollment.isPending || initiateDeposit.isPending;
+  const submittingRef = useRef(false);
 
   function handlePayDeposit() {
+    if (submittingRef.current) return;
+    submittingRef.current = true;
     setError(null);
 
     if (!planId) {

--- a/app/owner/loading.tsx
+++ b/app/owner/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from '@/components/shared/loading-skeleton';
+
+export default function OwnerLoading() {
+  return <PageSkeleton />;
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -135,6 +135,7 @@ export const payments = pgTable(
     index('idx_payments_plan').on(table.planId),
     index('idx_payments_scheduled').on(table.scheduledAt),
     index('idx_payments_status').on(table.status),
+    index('idx_payments_stripe_pi').on(table.stripePaymentIntentId),
     unique('uq_payments_plan_sequence').on(table.planId, table.sequenceNum),
     check('ck_payments_amount_positive', sql`${table.amountCents} > 0`),
   ],

--- a/server/routers/clinic.ts
+++ b/server/routers/clinic.ts
@@ -787,7 +787,7 @@ export const clinicRouter = router({
         .where(
           and(
             eq(plans.clinicId, clinicId),
-            sql`${plans.createdAt} >= now() - interval '${sql.raw(String(monthsBack))} months'`,
+            sql`${plans.createdAt} >= now() - make_interval(months => ${monthsBack})`,
           ),
         )
         .groupBy(sql`to_char(${plans.createdAt}, 'YYYY-MM')`)

--- a/server/routers/payment.ts
+++ b/server/routers/payment.ts
@@ -21,9 +21,10 @@ export const paymentRouter = router({
         cancelUrl: z.string().url(),
       }),
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
       const result = await processDeposit({
         planId: input.planId,
+        ownerId: ctx.ownerId,
         successUrl: input.successUrl,
         cancelUrl: input.cancelUrl,
       });

--- a/server/services/payment.ts
+++ b/server/services/payment.ts
@@ -22,6 +22,7 @@ const MAX_RETRIES = 3;
  */
 export async function processDeposit(params: {
   planId: string;
+  ownerId?: string;
   successUrl: string;
   cancelUrl: string;
 }): Promise<{ sessionId: string; sessionUrl: string }> {
@@ -47,6 +48,11 @@ export async function processDeposit(params: {
 
   if (!plan.ownerId) {
     throw new Error(`Plan ${params.planId} has no owner`);
+  }
+
+  // Verify the caller owns this plan (IDOR protection)
+  if (params.ownerId && plan.ownerId !== params.ownerId) {
+    throw new Error('Not authorized to initiate deposit for this plan');
   }
 
   // Fetch the deposit payment record

--- a/vercel.json
+++ b/vercel.json
@@ -37,6 +37,16 @@
       ]
     }
   ],
+  "crons": [
+    {
+      "path": "/api/cron/process-payouts",
+      "schedule": "0 6 * * *"
+    },
+    {
+      "path": "/api/cron/collect-payments",
+      "schedule": "0 7 * * *"
+    }
+  ],
   "github": {
     "silent": true
   }


### PR DESCRIPTION
## Summary

Resolves 15 of 16 HIGH findings from the codebase audit (#138).

### Security
- **H-01**: Add plan ownership check to `initiateDeposit` (IDOR prevention)
- **H-02**: Replace `sql.raw()` with parameterized `make_interval()` (SQLi prevention)
- **H-03**: Always require Plaid webhook signature verification (was bypassed in non-production)
- **H-04**: Reject cron requests when `CRON_SECRET` is not configured
- **H-14**: Validate `redirectTo` against `SAFE_REDIRECT_PREFIXES` (open redirect fix)
- **H-16**: Add `useRef`-based double-submit protection on enrollment deposit

### Reliability
- **H-05**: Add database index on `payments.stripePaymentIntentId` (webhook perf)
- **H-06**: Wrap DB updates in try/catch after Stripe API calls (reconciliation logging)
- **H-07**: Batch payout processing (5 concurrent) to avoid Stripe rate limits
- **H-08**: Add `collect-payments` cron endpoint for payment collection cycle
- **H-09**: Add Vercel cron config for payouts (6am) and collection (7am)
- **H-15**: Add placeholder `NEXT_PUBLIC_*` env vars to CI build step

### UX
- **H-11**: Add `loading.tsx` files for auth, clinic, owner, admin routes
- **H-12**: Make admin and clinic sidebars responsive with mobile hamburger drawer
- **H-13**: Add `role="alert"` to all form error messages for screen readers

### Deferred
- **H-10**: Login rate limiting requires refactoring client-side Supabase auth to server actions

## Test plan

- [x] Cron payout test updated for new CRON_SECRET behavior
- [x] `bun test` — all unit tests pass (458/458)
- [x] `bun run check:fix` — Biome lint/format clean
- [x] `bun run typecheck` — TypeScript strict pass
- [x] `bun run build` — production build succeeds
- [x] Pre-push hooks pass (circular deps, semgrep, build)

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)