### PR TITLE
fix: resolve production E2E and smoke test CI failures

### DIFF
--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Check /api/health
         run: |
-          url="${{ github.event.deployment_status.target_url }}"
+          url="https://fuzzycatapp.com"
           status=$(curl -s -o /dev/null -w '%{http_code}' "${url}/api/health")
           echo "GET /api/health → HTTP $status"
           if [ "$status" -ne 200 ]; then
@@ -29,7 +29,7 @@ jobs:
 
       - name: Check / (landing page)
         run: |
-          url="${{ github.event.deployment_status.target_url }}"
+          url="https://fuzzycatapp.com"
           status=$(curl -s -o /dev/null -w '%{http_code}' "${url}/")
           echo "GET / → HTTP $status"
           if [ "$status" -ne 200 ]; then

--- a/e2e/tests/production/login-flow.spec.ts
+++ b/e2e/tests/production/login-flow.spec.ts
@@ -48,7 +48,7 @@ test.describe('Production login flow', () => {
   });
 
   test('captures screenshots', async ({ page }, testInfo) => {
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await testInfo.attach('prod-login-page', {
       body: await page.screenshot({ fullPage: true }),

--- a/e2e/tests/production/public-pages.spec.ts
+++ b/e2e/tests/production/public-pages.spec.ts
@@ -69,7 +69,7 @@ test.describe('Production public pages', () => {
 
     for (const { url, name } of pages) {
       await page.goto(url);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await testInfo.attach(name, {
         body: await page.screenshot({ fullPage: true }),
         contentType: 'image/png',


### PR DESCRIPTION
## Summary

- **Post-deploy smoke test (401)**: The workflow used `github.event.deployment_status.target_url` which resolves to a Vercel deployment URL protected by Vercel Deployment Protection (returns 401). Switched to `https://fuzzycatapp.com` since the workflow already filters on `environment == 'Production'`.
- **E2E production screenshot tests (timeout)**: `waitForLoadState('networkidle')` times out because PostHog/Sentry analytics maintain persistent connections. Replaced with `domcontentloaded` in both `public-pages.spec.ts` and `login-flow.spec.ts`.

## Test plan

- [x] Unit tests pass (493/493)
- [x] Biome clean, typecheck clean, build succeeds
- [ ] CI E2E Production Tests should pass after merge (networkidle removed)
- [ ] Post-deploy smoke test should pass after merge (uses fuzzycatapp.com directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)