### PR TITLE
feat: enable Vercel Web Analytics and Speed Insights

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,5 @@
+import { Analytics } from '@vercel/analytics/next';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import { headers } from 'next/headers';
@@ -43,6 +45,8 @@ export default async function RootLayout({
         <ThemeProvider nonce={nonce}>
           <Providers>{children}</Providers>
         </ThemeProvider>
+        <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "@trpc/tanstack-react-query": "^11.10.0",
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.36.2",
+        "@vercel/analytics": "^1.6.1",
         "@vercel/speed-insights": "^1.3.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -932,6 +933,8 @@
     "@upstash/ratelimit": ["@upstash/ratelimit@2.0.8", "", { "dependencies": { "@upstash/core-analytics": "^0.0.10" }, "peerDependencies": { "@upstash/redis": "^1.34.3" } }, "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w=="],
 
     "@upstash/redis": ["@upstash/redis@1.36.2", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-C0Yt8hc12vLaQYRG1fMci8iPrLtnTdbJG0HR5T8vKnvEP/1RdMMblsOJs5/jp0JXZJ1oSzMnQz4J9EVezNpI6A=="],
+
+    "@vercel/analytics": ["@vercel/analytics@1.6.1", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "react", "svelte", "vue", "vue-router"] }, "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg=="],
 
     "@vercel/speed-insights": ["@vercel/speed-insights@1.3.1", "", { "peerDependencies": { "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@sveltejs/kit", "next", "react", "svelte", "vue", "vue-router"] }, "sha512-PbEr7FrMkUrGYvlcLHGkXdCkxnylCWePx7lPxxq36DNdfo9mcUjLOmqOyPDHAOgnfqgGGdmE3XI9L/4+5fr+vQ=="],
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@trpc/tanstack-react-query": "^11.10.0",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.36.2",
+    "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.3.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary

- Add `<Analytics />` and `<SpeedInsights />` components to root layout (`app/layout.tsx`)
- Install `@vercel/analytics` package (`@vercel/speed-insights` was already installed)
- Both use first-party routing on Vercel (`/_vercel/insights/*` and `/_vercel/speed-insights/*`), so no CSP changes needed — `'self'` in `connect-src` and `'strict-dynamic'` with nonce handle everything

Closes #154, closes #155. Supersedes draft PRs #147 and #149.

## Test plan

- [x] `bun run check:fix` — Biome passes
- [x] `bun run typecheck` — TypeScript passes
- [x] `bun run build` — Production build succeeds
- [x] `bun run test` — 493 tests pass
- [ ] After deploy: verify data appears in Vercel Analytics dashboard
- [ ] After deploy: verify data appears in Vercel Speed Insights dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)