### PR TITLE
fix: resolve dashboard identity resolution failures

### DIFF
--- a/scripts/e2e-create-test-users.ts
+++ b/scripts/e2e-create-test-users.ts
@@ -1,23 +1,29 @@
 #!/usr/bin/env bun
 /**
- * Standalone script to provision E2E test users in Supabase.
+ * Standalone script to provision E2E test users in Supabase AND create
+ * corresponding identity rows in the database (clinics/owners tables).
+ *
  * Run manually: `bun run scripts/e2e-create-test-users.ts`
  *
  * Requires NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY in .env.local
  */
 
+import { eq } from 'drizzle-orm';
+import { db } from '@/server/db';
+import { clinics, owners } from '@/server/db/schema';
+
 const USERS = [
   {
     email: process.env.E2E_OWNER_EMAIL ?? 'e2e-owner@fuzzycatapp.com',
-    role: 'owner',
+    role: 'owner' as const,
   },
   {
     email: process.env.E2E_CLINIC_EMAIL ?? 'e2e-clinic@fuzzycatapp.com',
-    role: 'clinic',
+    role: 'clinic' as const,
   },
   {
     email: process.env.E2E_ADMIN_EMAIL ?? 'e2e-admin@fuzzycatapp.com',
-    role: 'admin',
+    role: 'admin' as const,
   },
 ];
 
@@ -33,7 +39,10 @@ if (!SUPABASE_URL || !SERVICE_KEY) {
 
 const validatedKey = SERVICE_KEY;
 
-async function createUser(email: string, role: string) {
+type AuthUser = { id: string; email?: string };
+
+async function createOrGetUser(email: string, role: string): Promise<string | null> {
+  // Try to create the user
   const createRes = await fetch(`${SUPABASE_URL}/auth/v1/admin/users`, {
     method: 'POST',
     headers: {
@@ -50,27 +59,114 @@ async function createUser(email: string, role: string) {
   });
 
   if (createRes.ok) {
-    const created = (await createRes.json()) as { id: string };
-    console.log(`✓ ${email} (${role}) — created (${created.id})`);
-    return;
+    const created = (await createRes.json()) as AuthUser;
+    console.log(`  Auth: created (${created.id})`);
+    return created.id;
   }
 
   const responseText = await createRes.text();
 
-  if (createRes.status === 422 && responseText.includes('already registered')) {
-    console.log(`✓ ${email} (${role}) — already exists`);
+  if (
+    createRes.status === 422 &&
+    (responseText.includes('email_exists') || responseText.includes('already'))
+  ) {
+    // User exists — look up their ID
+    const listRes = await fetch(`${SUPABASE_URL}/auth/v1/admin/users?page=1&per_page=50`, {
+      headers: {
+        Authorization: `Bearer ${validatedKey}`,
+        apikey: validatedKey,
+      },
+    });
+
+    if (listRes.ok) {
+      const data = (await listRes.json()) as { users: AuthUser[] };
+      const existing = data.users.find((u) => u.email === email);
+      if (existing) {
+        console.log(`  Auth: already exists (${existing.id})`);
+        return existing.id;
+      }
+    }
+
+    console.log(`  Auth: already exists (ID unknown)`);
+    return null;
+  }
+
+  console.error(`  Auth: FAILED — ${createRes.status}: ${responseText}`);
+  return null;
+}
+
+async function ensureClinicRow(authId: string, email: string) {
+  const [existing] = await db
+    .select({ id: clinics.id })
+    .from(clinics)
+    .where(eq(clinics.authId, authId))
+    .limit(1);
+
+  if (existing) {
+    console.log(`  DB: clinic row exists (${existing.id})`);
     return;
   }
 
-  console.error(`✗ ${email} (${role}) — ${createRes.status}: ${responseText}`);
+  const [created] = await db
+    .insert(clinics)
+    .values({
+      authId,
+      name: 'E2E Test Clinic',
+      email,
+      phone: '(555) 000-0000',
+      addressState: 'CA',
+      addressZip: '90210',
+    })
+    .returning({ id: clinics.id });
+
+  console.log(`  DB: clinic row created (${created.id})`);
+}
+
+async function ensureOwnerRow(authId: string, email: string) {
+  const [existing] = await db
+    .select({ id: owners.id })
+    .from(owners)
+    .where(eq(owners.authId, authId))
+    .limit(1);
+
+  if (existing) {
+    console.log(`  DB: owner row exists (${existing.id})`);
+    return;
+  }
+
+  const [created] = await db
+    .insert(owners)
+    .values({
+      authId,
+      name: 'E2E Test Owner',
+      email,
+      phone: '(555) 000-0001',
+      petName: 'TestPet',
+      paymentMethod: 'debit_card',
+    })
+    .returning({ id: owners.id });
+
+  console.log(`  DB: owner row created (${created.id})`);
 }
 
 console.log('Provisioning E2E test users...\n');
 
 for (const user of USERS) {
-  await createUser(user.email, user.role);
+  console.log(`${user.email} (${user.role}):`);
+
+  const authId = await createOrGetUser(user.email, user.role);
+
+  if (authId) {
+    if (user.role === 'clinic') {
+      await ensureClinicRow(authId, user.email);
+    } else if (user.role === 'owner') {
+      await ensureOwnerRow(authId, user.email);
+    } else {
+      console.log(`  DB: admin role — no identity row needed`);
+    }
+  }
+
+  console.log();
 }
 
-console.log('\nDone.');
-
-export {};
+console.log('Done.');

--- a/server/__tests__/trpc-context.test.ts
+++ b/server/__tests__/trpc-context.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+// ── Mocks ────────────────────────────────────────────────────────────
+// Only mock modules that won't affect other test files.
+// Do NOT mock @/lib/supabase/mfa or @/lib/env — use process.env instead
+// to avoid cross-contamination (see CLAUDE.md Testing Requirements).
+
+const mockGetUser = mock();
+
+mock.module('@/lib/supabase/server', () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: { getUser: mockGetUser },
+    }),
+}));
+
+mock.module('@/server/db', () => ({
+  db: {},
+}));
+
+mock.module('@/server/db/schema', () => ({
+  clinics: { id: 'clinics.id', authId: 'clinics.auth_id' },
+  owners: { id: 'owners.id', authId: 'owners.auth_id' },
+}));
+
+import { createTRPCContext } from '@/server/trpc';
+
+function makeRequest(headers: Record<string, string> = {}): Request {
+  const h = new Headers(headers);
+  return new Request('http://localhost:3000/api/trpc', { headers: h });
+}
+
+describe('createTRPCContext', () => {
+  beforeEach(() => {
+    mockGetUser.mockReset();
+  });
+
+  it('uses middleware headers when x-user-id and x-user-role are present', async () => {
+    const ctx = await createTRPCContext({
+      req: makeRequest({
+        'x-user-id': 'user-123',
+        'x-user-role': 'clinic',
+        'x-request-id': 'req-abc',
+      }),
+      resHeaders: new Headers(),
+    });
+
+    expect(ctx.session).toEqual({ userId: 'user-123', role: 'clinic' });
+    expect(ctx.requestId).toBe('req-abc');
+    // getUser should NOT have been called
+    expect(mockGetUser).not.toHaveBeenCalled();
+  });
+
+  it('falls back to getUser when middleware headers are missing', async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: {
+        user: {
+          id: 'supabase-user-456',
+          app_metadata: { role: 'owner' },
+        },
+      },
+    });
+
+    const ctx = await createTRPCContext({
+      req: makeRequest({}),
+      resHeaders: new Headers(),
+    });
+
+    expect(ctx.session).toEqual({ userId: 'supabase-user-456', role: 'owner' });
+    expect(mockGetUser).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to getUser when x-user-role is invalid', async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: {
+        user: {
+          id: 'supabase-user-789',
+          app_metadata: { role: 'admin' },
+        },
+      },
+    });
+
+    const ctx = await createTRPCContext({
+      req: makeRequest({
+        'x-user-id': 'user-789',
+        'x-user-role': 'superadmin', // invalid role
+      }),
+      resHeaders: new Headers(),
+    });
+
+    expect(ctx.session).toEqual({ userId: 'supabase-user-789', role: 'admin' });
+    expect(mockGetUser).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null session when no auth is available', async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: null },
+    });
+
+    const ctx = await createTRPCContext({
+      req: makeRequest({}),
+      resHeaders: new Headers(),
+    });
+
+    expect(ctx.session).toBeNull();
+  });
+
+  it('accepts all valid roles from middleware headers', async () => {
+    for (const role of ['owner', 'clinic', 'admin'] as const) {
+      const ctx = await createTRPCContext({
+        req: makeRequest({
+          'x-user-id': `user-${role}`,
+          'x-user-role': role,
+        }),
+        resHeaders: new Headers(),
+      });
+
+      expect(ctx.session).toEqual({ userId: `user-${role}`, role });
+    }
+
+    expect(mockGetUser).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- **Optimize tRPC context auth**: Read `x-user-id` and `x-user-role` headers from middleware to skip redundant `supabase.auth.getUser()` call (~100-200ms savings per tRPC request). Falls back to `getUser()` for non-middleware routes.
- **Fix E2E user setup**: Update `scripts/e2e-create-test-users.ts` to create DB identity rows (`clinics`/`owners` tables) alongside Supabase auth users. Previously, E2E users had auth accounts but no DB identity, causing `clinicProcedure`/`ownerProcedure` to throw NOT_FOUND on every request.
- **Add tests**: 5 new unit tests for tRPC context auth deduplication.

### Root cause

All dashboards showed "Unable to load" because `clinicProcedure` and `ownerProcedure` in `server/trpc.ts` query `clinics`/`owners` by `authId`. E2E test users only had Supabase auth accounts — no corresponding DB rows — so the middleware threw `NOT_FOUND` before any business query could run.

Closes #151, closes #152

## Test plan

- [x] `bun run test` — 498 tests pass (5 new)
- [x] `bun run check:fix` — Biome passes
- [x] `bun run typecheck` — TypeScript passes
- [x] `bun run build` — Production build succeeds
- [x] Ran `e2e-create-test-users.ts` against production — DB rows created for clinic and owner users
- [ ] After deploy: verify dashboards no longer show "Unable to load"

🤖 Generated with [Claude Code](https://claude.com/claude-code)