### PR TITLE
feat: enable self-service payment method update

### DIFF
--- a/app/owner/settings/_components/payment-method-section.tsx
+++ b/app/owner/settings/_components/payment-method-section.tsx
@@ -1,15 +1,41 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
-import { CreditCard, Landmark } from 'lucide-react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { CheckCircle2, CreditCard, Landmark } from 'lucide-react';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useTRPC } from '@/lib/trpc/client';
+import { cn } from '@/lib/utils';
+
+type PaymentMethod = 'debit_card' | 'bank_account';
 
 export function PaymentMethodSection() {
   const trpc = useTRPC();
+  const queryClient = useQueryClient();
   const { data: profile, isLoading } = useQuery(trpc.owner.getProfile.queryOptions());
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+
+  const updateMutation = useMutation(
+    trpc.owner.updatePaymentMethod.mutationOptions({
+      onSuccess: () => {
+        setSaveStatus('saved');
+        queryClient.invalidateQueries({ queryKey: trpc.owner.getProfile.queryKey() });
+        setTimeout(() => setSaveStatus('idle'), 2000);
+      },
+      onError: () => {
+        setSaveStatus('error');
+        setTimeout(() => setSaveStatus('idle'), 3000);
+      },
+    }),
+  );
+
+  function handleSelect(method: PaymentMethod) {
+    if (method === profile?.paymentMethod) return;
+    setSaveStatus('saving');
+    updateMutation.mutate({ paymentMethod: method });
+  }
 
   if (isLoading) {
     return (
@@ -25,39 +51,86 @@ export function PaymentMethodSection() {
     );
   }
 
-  const method = profile?.paymentMethod;
+  const currentMethod = profile?.paymentMethod;
 
   return (
     <Card>
       <CardHeader>
         <CardTitle>Payment Method</CardTitle>
-        <CardDescription>Your current payment method for installment payments.</CardDescription>
+        <CardDescription>Choose how your installment payments are collected.</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="flex items-center gap-3 rounded-md border p-4">
-          {method === 'bank_account' ? (
-            <Landmark className="h-5 w-5 text-muted-foreground" />
-          ) : (
-            <CreditCard className="h-5 w-5 text-muted-foreground" />
-          )}
-          <div>
-            <p className="text-sm font-medium">
-              {method === 'bank_account' ? 'Bank Account (ACH)' : 'Debit Card'}
-            </p>
-            <p className="text-xs text-muted-foreground">
-              {method === 'bank_account'
-                ? 'Installments are debited from your connected bank account.'
-                : 'Installments are charged to your debit card on file.'}
-            </p>
-          </div>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <MethodOption
+            method="debit_card"
+            label="Debit Card"
+            description="Installments are charged to your debit card."
+            icon={<CreditCard className="h-5 w-5" />}
+            selected={currentMethod === 'debit_card'}
+            disabled={saveStatus === 'saving'}
+            onSelect={handleSelect}
+          />
+          <MethodOption
+            method="bank_account"
+            label="Bank Account (ACH)"
+            description="Installments are debited from your bank account."
+            icon={<Landmark className="h-5 w-5" />}
+            selected={currentMethod === 'bank_account'}
+            disabled={saveStatus === 'saving'}
+            onSelect={handleSelect}
+          />
         </div>
-        <Button variant="outline" disabled>
-          Update Payment Method
-        </Button>
-        <p className="text-xs text-muted-foreground">
-          To update your payment method, please contact your veterinary clinic.
-        </p>
+        {saveStatus === 'saved' && (
+          <p className="flex items-center gap-1 text-sm text-green-600 dark:text-green-400">
+            <CheckCircle2 className="h-3.5 w-3.5" />
+            Payment method updated.
+          </p>
+        )}
+        {saveStatus === 'error' && (
+          <p className="text-sm text-destructive">
+            Failed to update payment method. Please try again.
+          </p>
+        )}
       </CardContent>
     </Card>
+  );
+}
+
+function MethodOption({
+  method,
+  label,
+  description,
+  icon,
+  selected,
+  disabled,
+  onSelect,
+}: {
+  method: PaymentMethod;
+  label: string;
+  description: string;
+  icon: React.ReactNode;
+  selected: boolean;
+  disabled: boolean;
+  onSelect: (method: PaymentMethod) => void;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      disabled={disabled}
+      className={cn(
+        'flex h-auto items-start gap-3 p-4 text-left',
+        selected && 'border-primary bg-primary/5',
+      )}
+      onClick={() => onSelect(method)}
+    >
+      <span className={cn('mt-0.5', selected ? 'text-primary' : 'text-muted-foreground')}>
+        {icon}
+      </span>
+      <span className="flex flex-col gap-0.5">
+        <span className="text-sm font-medium">{label}</span>
+        <span className="text-xs font-normal text-muted-foreground">{description}</span>
+      </span>
+    </Button>
   );
 }

--- a/server/routers/owner.ts
+++ b/server/routers/owner.ts
@@ -78,6 +78,28 @@ export const ownerRouter = router({
     }),
 
   /**
+   * Update the authenticated owner's payment method preference.
+   */
+  updatePaymentMethod: ownerProcedure
+    .input(
+      z.object({
+        paymentMethod: z.enum(['debit_card', 'bank_account']),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const [updated] = await ctx.db
+        .update(owners)
+        .set({ paymentMethod: input.paymentMethod })
+        .where(eq(owners.id, ctx.ownerId))
+        .returning({
+          id: owners.id,
+          paymentMethod: owners.paymentMethod,
+        });
+
+      return updated;
+    }),
+
+  /**
    * Get all payment plans for the authenticated owner, with payment progress.
    */
   getPlans: ownerProcedure.query(async ({ ctx }) => {


### PR DESCRIPTION
## Summary
- **Enabled** the previously disabled "Update Payment Method" button in owner settings
- Owners can now switch between **Debit Card** and **Bank Account** directly from their settings page
- Added `owner.updatePaymentMethod` tRPC mutation to the backend
- Replaced the static display with an interactive card selector that saves immediately on click
- Shows success/error feedback inline

Closes #125

## Test plan
- [x] TypeScript strict mode passes
- [x] All 498 unit tests pass
- [x] Biome lint/format passes
- [x] Production build succeeds
- [ ] Manual: visit `/owner/settings` → payment method cards are clickable
- [ ] Manual: click the non-selected method → switches and shows "Payment method updated"
- [ ] Manual: selected card has primary border highlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)