### PR TITLE
chore: fix Knip config and enforce all CI checks as required

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -5,7 +5,6 @@
     "components/**/*.{ts,tsx}",
     "lib/**/*.{ts,tsx}",
     "server/**/*.ts",
-    "types/**/*.ts",
     "scripts/*.ts",
     "e2e/**/*.ts",
     "*.test.ts"
@@ -16,7 +15,7 @@
   "drizzle": false,
   "ignoreDependencies": [
     "@commitlint/cli",
-    "@radix-ui/*",
+    "@next/env",
     "postcss",
     "radix-ui",
     "shadcn",


### PR DESCRIPTION
## Summary
- Fix 3 Knip issues: remove stale `@radix-ui/*` from ignoreDependencies, add `@next/env` (transitive dep via next), remove `types/**/*.ts` entry pattern (dir doesn't exist)
- After this merges, branch protection will be updated to require **all 14 CI checks** to pass before merge (currently only 3 are required)

## New required checks (added after merge)
| Check | Currently Required |
|---|---|
| `Lint & Format (Biome)` | Yes |
| `Type Check` | Yes |
| `Build` | Yes |
| `Unit Tests` | **No** -> Yes |
| `Unused Code (Knip)` | **No** -> Yes |
| `Circular Dependencies` | **No** -> Yes |
| `Secret Detection (Gitleaks)` | **No** -> Yes |
| `Security Scan (Semgrep)` | **No** -> Yes |
| `No Direct process.env` | **No** -> Yes |
| `Dependency Audit` | **No** -> Yes |
| `License Compliance` | **No** -> Yes |
| `Type Coverage (≥95%)` | **No** -> Yes |
| `E2E Tests (Playwright)` | **No** -> Yes |
| `codecov/patch` | **No** -> Yes |

## Test plan
- [x] `bun run check:unused` (Knip) passes locally
- [x] All pre-push hooks pass (circular deps, semgrep, build)
- [ ] CI: Knip check passes
- [ ] After merge: update branch protection via GitHub API

🤖 Generated with [Claude Code](https://claude.com/claude-code)