### PR TITLE
fix: resolve Playwright strict mode violations in E2E tests

### DIFF
--- a/e2e/tests/clinic/reports.spec.ts
+++ b/e2e/tests/clinic/reports.spec.ts
@@ -12,7 +12,7 @@ test.describe('Clinic Reports', () => {
 
   test('shows report content', async ({ page }) => {
     // The reports page contains: RevenueReport, EnrollmentTrends, ExportButtons
-    const revenueReport = page.getByText(/revenue report/i);
+    const revenueReport = page.getByRole('heading', { name: /revenue report/i });
     await expect(revenueReport).toBeVisible({ timeout: 10000 });
 
     const enrollmentTrends = page.getByText(/enrollment trends/i);

--- a/e2e/tests/mobile/public-mobile.spec.ts
+++ b/e2e/tests/mobile/public-mobile.spec.ts
@@ -36,7 +36,7 @@ test.describe('Public Pages — Mobile', () => {
     }
 
     // Pricing cards should stack
-    await expect(page.getByText(/flat 6% fee/i)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText(/flat 6% fee/i).first()).toBeVisible({ timeout: 5000 });
     await expect(page.getByText(/no credit check/i).first()).toBeVisible({ timeout: 3000 });
 
     await testInfo.attach('mobile-landing-pricing', {


### PR DESCRIPTION
## Summary
- Use `getByRole('heading', ...)` instead of `getByText(...)` in `e2e/tests/clinic/reports.spec.ts` to disambiguate "Revenue Report" heading from its description paragraph
- Add `.first()` to `getByText(/flat 6% fee/i)` in `e2e/tests/mobile/public-mobile.spec.ts` to resolve ambiguity between subtitle and card heading

Closes #195

## Test plan
- [x] `bun run check` passes (no new warnings)
- [x] `bun run typecheck` passes
- [x] `bun run test` passes (525 tests, 0 failures)
- [ ] CI E2E tests pass with the updated locators

🤖 Generated with [Claude Code](https://claude.com/claude-code)