### PR TITLE
fix: update E2E tests for platform reserve rename

### DIFF
--- a/e2e/tests/admin/dashboard-data.spec.ts
+++ b/e2e/tests/admin/dashboard-data.spec.ts
@@ -27,7 +27,7 @@ test.describe('Admin Dashboard — Data Assertions', () => {
     await expect(page.getByText('87').first()).toBeVisible({ timeout: 5000 });
   });
 
-  test('risk pool health metrics render', async ({ page }) => {
+  test('platform reserve health metrics render', async ({ page }) => {
     await mockTrpcQuery(page, 'admin.getPlatformStats', adminPlatformStats);
     await mockTrpcQuery(page, 'admin.riskPoolHealth', adminRiskPoolHealth);
     await mockTrpcQuery(page, 'admin.getRecentAuditLog', adminRecentAuditLog);
@@ -35,8 +35,8 @@ test.describe('Admin Dashboard — Data Assertions', () => {
 
     await gotoPortalPage(page, '/admin/dashboard');
 
-    // Risk pool section
-    await expect(page.getByText(/risk pool/i).first()).toBeVisible({ timeout: 5000 });
+    // Platform reserve section
+    await expect(page.getByText(/platform reserve/i).first()).toBeVisible({ timeout: 5000 });
 
     // Balance: $12,500.00
     await expect(page.getByText(/\$12,500/).first()).toBeVisible({ timeout: 5000 });

--- a/e2e/tests/admin/dashboard.spec.ts
+++ b/e2e/tests/admin/dashboard.spec.ts
@@ -37,7 +37,7 @@ test.describe('Admin Dashboard', () => {
     // Check for navigation links to other admin pages
     await expect(page.getByRole('link', { name: /clinics/i })).toBeVisible();
     await expect(page.getByRole('link', { name: /payments/i })).toBeVisible();
-    await expect(page.getByRole('link', { name: /risk/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /platform reserve/i })).toBeVisible();
   });
 
   test('captures screenshot', async ({ page }, testInfo) => {

--- a/e2e/tests/admin/risk.spec.ts
+++ b/e2e/tests/admin/risk.spec.ts
@@ -7,7 +7,7 @@ test.describe('Admin Risk', () => {
 
   test('loads risk page', async ({ page }) => {
     await expect(page).toHaveURL(/\/admin\/risk/);
-    await expect(page.getByRole('heading', { name: /risk/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /platform reserve/i })).toBeVisible();
   });
 
   test('shows platform reserve dashboard', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Update 3 E2E test files to match the "Risk Pool" to "Platform Reserve" rename from PR #191
- `dashboard-data.spec.ts`: Change `getByText(/risk pool/i)` to `getByText(/platform reserve/i)` and update test name
- `dashboard.spec.ts`: Change sidebar link assertion from `/risk/i` to `/platform reserve/i`
- `risk.spec.ts`: Change page heading assertion from `/risk/i` to `/platform reserve/i`

Closes #194

## Test plan
- [x] `bun run check` passes (Biome lint + format)
- [x] `bun run typecheck` passes (tsc --noEmit)
- [x] `bun run test` passes (525 unit tests)
- [x] All pre-push hooks pass (circular deps, Semgrep, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)