### PR TITLE
fix(e2e): use precise selectors for signup tab tests

### DIFF
--- a/e2e/tests/auth/signup-interaction.spec.ts
+++ b/e2e/tests/auth/signup-interaction.spec.ts
@@ -32,11 +32,9 @@ test.describe('Signup Form — Interactions', () => {
 
   test('clinic signup form is accessible via tab', async ({ page }) => {
     // Click Veterinary Clinic tab
-    const clinicTab = page
-      .getByRole('tab', { name: /veterinary clinic|clinic/i })
-      .or(page.getByText(/veterinary clinic/i));
-    await expect(clinicTab.first()).toBeVisible();
-    await clinicTab.first().click();
+    const clinicTab = page.getByRole('tab', { name: /veterinary clinic|clinic/i });
+    await expect(clinicTab).toBeVisible();
+    await clinicTab.click();
 
     // Clinic-specific fields should appear
     const clinicNameInput = page.locator('#clinicName');
@@ -70,18 +68,14 @@ test.describe('Signup Form — Interactions', () => {
     await emailInput.fill('test@example.com');
 
     // Switch to clinic tab
-    const clinicTab = page
-      .getByRole('tab', { name: /veterinary clinic|clinic/i })
-      .or(page.getByText(/veterinary clinic/i));
-    await clinicTab.first().click();
+    const clinicTab = page.getByRole('tab', { name: /veterinary clinic|clinic/i });
+    await clinicTab.click();
 
     await page.waitForTimeout(500);
 
     // Switch back to owner tab
-    const ownerTab = page
-      .getByRole('tab', { name: /pet owner|owner/i })
-      .or(page.getByText(/pet owner/i));
-    await ownerTab.first().click();
+    const ownerTab = page.getByRole('tab', { name: /pet owner|owner/i });
+    await ownerTab.click();
 
     await page.waitForTimeout(500);
   });

--- a/e2e/tests/mobile/auth-mobile.spec.ts
+++ b/e2e/tests/mobile/auth-mobile.spec.ts
@@ -60,17 +60,10 @@ test.describe('Auth Pages — Mobile', () => {
     await page.goto('/signup');
 
     // Tab switching works on mobile
-    const clinicTab = page
-      .getByRole('tab', { name: /veterinary clinic|clinic/i })
-      .or(page.getByText(/veterinary clinic/i));
+    const clinicTab = page.getByRole('tab', { name: /veterinary clinic|clinic/i });
 
-    if (
-      await clinicTab
-        .first()
-        .isVisible({ timeout: 3000 })
-        .catch(() => false)
-    ) {
-      await clinicTab.first().click();
+    if (await clinicTab.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await clinicTab.click();
 
       // Clinic fields visible
       const clinicNameInput = page.locator('#clinicName');
@@ -78,17 +71,10 @@ test.describe('Auth Pages — Mobile', () => {
     }
 
     // Switch back to owner tab
-    const ownerTab = page
-      .getByRole('tab', { name: /pet owner|owner/i })
-      .or(page.getByText(/pet owner/i));
+    const ownerTab = page.getByRole('tab', { name: /pet owner|owner/i });
 
-    if (
-      await ownerTab
-        .first()
-        .isVisible({ timeout: 3000 })
-        .catch(() => false)
-    ) {
-      await ownerTab.first().click();
+    if (await ownerTab.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await ownerTab.click();
     }
 
     // Fill form on mobile


### PR DESCRIPTION
## Summary
- Removed overly-broad `.or(page.getByText(...))` fallback locators from signup tab E2E tests
- The fallback matched the page subtitle "Sign up as a pet owner or veterinary clinic" (a `<p>` element) instead of the actual `<button role="tab">` elements, because the subtitle appears first in the DOM
- Using `.first()` on the unioned locator selected the non-interactive subtitle, so clicking it never triggered a tab switch and `#clinicName` was never rendered
- Now uses only `getByRole('tab', { name: ... })` which precisely targets the tab buttons

## Test plan
- [x] `bun run check` passes (no lint/format errors in changed files)
- [x] `bun run typecheck` passes
- [x] `bun run test` passes (525 unit tests)
- [ ] CI E2E tests should now pass for `signup-interaction.spec.ts:33` and `auth-mobile.spec.ts:52`

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)