### PR TITLE
fix: clinic enrollment search returns no results (#193)

### DIFF
--- a/e2e/helpers/portal-test-base.ts
+++ b/e2e/helpers/portal-test-base.ts
@@ -80,13 +80,13 @@ export async function mockAllTrpc(page: Page) {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify([{ result: { data: null } }]),
+        body: JSON.stringify([{ result: { data: { json: null } } }]),
       });
     } else if (request.method() === 'POST') {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify([{ result: { data: { success: true } } }]),
+        body: JSON.stringify([{ result: { data: { json: { success: true } } } }]),
       });
     } else {
       await route.fallback();

--- a/e2e/helpers/trpc-mock.ts
+++ b/e2e/helpers/trpc-mock.ts
@@ -1,6 +1,15 @@
 import type { Page } from '@playwright/test';
 
 /**
+ * Wrap response data in the superjson envelope expected by the tRPC client.
+ * The tRPC client is configured with `transformer: superjson` (see lib/trpc/provider.tsx),
+ * so all successful responses must use the `{ json: data }` wire format.
+ */
+function superjsonResult(data: unknown) {
+  return { result: { data: { json: data } } };
+}
+
+/**
  * Intercepts a tRPC query and returns a mock response.
  * Matches GET requests to /api/trpc/<procedure>
  */
@@ -10,7 +19,7 @@ export async function mockTrpcQuery(page: Page, procedure: string, response: unk
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify([{ result: { data: response } }]),
+        body: JSON.stringify([superjsonResult(response)]),
       });
     } else {
       await route.fallback();
@@ -28,7 +37,7 @@ export async function mockTrpcMutation(page: Page, procedure: string, response: 
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify([{ result: { data: response } }]),
+        body: JSON.stringify([superjsonResult(response)]),
       });
     } else {
       await route.fallback();
@@ -122,7 +131,7 @@ export async function mockTrpcQueryDelayed(
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify([{ result: { data } }]),
+        body: JSON.stringify([superjsonResult(data)]),
       });
     } else {
       await route.fallback();


### PR DESCRIPTION
## Summary
- Fix E2E tRPC mock helpers to wrap response data in the superjson `{ json: data }` wire format
- The tRPC client uses `httpBatchLink` with `transformer: superjson` (see `lib/trpc/provider.tsx`), which expects all successful response data in `{ json: data }` format
- Without this wrapper, `superjson.deserialize()` failed silently, causing all mocked tRPC queries (including `clinic.search`) to return `undefined` instead of mock data
- This affected 22+ E2E tests across enrollment workflow, edge cases, and mobile tests

## Test plan
- [x] `bun run check` passes (Biome lint + format)
- [x] `bun run typecheck` passes (tsc --noEmit)
- [x] `bun run test` passes (525 unit tests)
- [ ] CI E2E tests pass — clinic search returns results, full enrollment wizard flows work

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)