### PR TITLE
fix: open mobile menu before clicking sidebar links in E2E tests

### DIFF
--- a/e2e/helpers/portal-test-base.ts
+++ b/e2e/helpers/portal-test-base.ts
@@ -129,6 +129,27 @@ export async function mockExternalServices(page: Page) {
 }
 
 /**
+ * Open the mobile hamburger menu if it exists (i.e. the viewport is narrow enough
+ * for the sidebar to be collapsed into a slide-out drawer).
+ *
+ * Both `AdminSidebar` and `ClinicSidebar` render a button with
+ * `aria-label="Open menu"` that is only visible on viewports below the `md`
+ * breakpoint. This helper clicks that button and waits for the sidebar to
+ * slide open so that nav links become interactable.
+ *
+ * Safe to call on desktop viewports — the button won't be visible and the
+ * helper simply returns without doing anything.
+ */
+export async function openMobileMenuIfNeeded(page: Page) {
+  const openMenuBtn = page.locator('button[aria-label="Open menu"]');
+  if (await openMenuBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await openMenuBtn.click();
+    // Wait for the slide-out animation to complete
+    await page.waitForTimeout(500);
+  }
+}
+
+/**
  * Navigate to a portal page with standard waits.
  * Asserts the page is not redirected to /login and waits for hydration.
  */

--- a/e2e/tests/cross-cutting/navigation-portals.spec.ts
+++ b/e2e/tests/cross-cutting/navigation-portals.spec.ts
@@ -3,6 +3,7 @@ import {
   gotoPortalPage,
   mockAllTrpc,
   mockExternalServices,
+  openMobileMenuIfNeeded,
   setupPortalMocks,
 } from '../../helpers/portal-test-base';
 
@@ -27,6 +28,9 @@ test.describe('Navigation — Clinic Portal', () => {
     ];
 
     for (const { pattern, url } of clinicRoutes) {
+      // On mobile viewports the sidebar is hidden — open the hamburger menu first
+      await openMobileMenuIfNeeded(page);
+
       const link = page
         .locator('nav a, aside a, [role="navigation"] a')
         .filter({ hasText: pattern });
@@ -74,6 +78,9 @@ test.describe('Navigation — Admin Portal', () => {
     ];
 
     for (const { pattern, url } of adminRoutes) {
+      // On mobile viewports the sidebar is hidden — open the hamburger menu first
+      await openMobileMenuIfNeeded(page);
+
       const link = page
         .locator('nav a, aside a, [role="navigation"] a')
         .filter({ hasText: pattern });
@@ -101,6 +108,9 @@ test.describe('Navigation — Owner Portal', () => {
     await mockAllTrpc(page);
 
     await gotoPortalPage(page, '/owner/payments');
+
+    // On mobile viewports, open hamburger menu if present
+    await openMobileMenuIfNeeded(page);
 
     // Owner navigation links
     const settingsLink = page.getByRole('link', { name: /setting/i });

--- a/e2e/tests/mobile/clinic-mobile.spec.ts
+++ b/e2e/tests/mobile/clinic-mobile.spec.ts
@@ -19,6 +19,7 @@ import {
   gotoPortalPage,
   mockAllTrpc,
   mockExternalServices,
+  openMobileMenuIfNeeded,
   setupPortalMocks,
 } from '../../helpers/portal-test-base';
 import { mockTrpcMutation, mockTrpcQuery } from '../../helpers/trpc-mock';
@@ -298,28 +299,14 @@ test.describe('Clinic Portal — Mobile', () => {
 
     await gotoPortalPage(page, '/clinic/dashboard');
 
-    // On mobile, sidebar may be collapsed into a hamburger menu
-    const hamburger = page
-      .getByRole('button', { name: /menu|navigation|toggle/i })
-      .or(page.locator('[aria-label*="menu"]'))
-      .or(page.locator('[aria-label*="Menu"]'));
-
-    if (await hamburger.isVisible({ timeout: 3000 }).catch(() => false)) {
-      await hamburger.click();
-      await page.waitForTimeout(500);
-    }
+    // Open the mobile hamburger menu so sidebar links become visible
+    await openMobileMenuIfNeeded(page);
 
     // Navigate to clients
     const clientsLink = page.getByRole('link', { name: /client/i });
-    if (
-      await clientsLink
-        .first()
-        .isVisible({ timeout: 3000 })
-        .catch(() => false)
-    ) {
-      await clientsLink.first().click();
-      await page.waitForLoadState('domcontentloaded');
-      expect(page.url()).toContain('clients');
-    }
+    await expect(clientsLink.first()).toBeVisible({ timeout: 5000 });
+    await clientsLink.first().click();
+    await page.waitForLoadState('domcontentloaded');
+    expect(page.url()).toContain('clients');
   });
 });


### PR DESCRIPTION
## Summary
- Adds a reusable `openMobileMenuIfNeeded()` helper to `e2e/helpers/portal-test-base.ts` that clicks the exact `button[aria-label="Open menu"]` hamburger button on mobile viewports
- Replaces the flaky `.or()` chain selector in admin and clinic mobile sidebar tests that matched both "Open menu" and "Close menu" buttons, causing Playwright strict mode violations silently swallowed by `.catch(() => false)`
- Adds `openMobileMenuIfNeeded()` calls to navigation-portals cross-cutting tests so they work regardless of viewport size
- Also fixes the admin "sign out accessible on mobile" test which requires the sidebar to be open

## Test plan
- [x] `bun run check` passes (Biome lint + format)
- [x] `bun run typecheck` passes (tsc --noEmit)
- [x] `bun run test` passes (525 unit tests)
- [ ] CI E2E tests pass for all 5 failing specs

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)