### PR TITLE
fix(e2e): registry-based tRPC mocks for batch support

### DIFF
--- a/e2e/helpers/trpc-mock.ts
+++ b/e2e/helpers/trpc-mock.ts
@@ -1,6 +1,26 @@
 import type { Page } from '@playwright/test';
 
 /**
+ * Registry-based tRPC mock system for Playwright E2E tests.
+ *
+ * Solves two bugs in the previous per-route mock approach:
+ *
+ * 1. **Route ordering**: Playwright matches routes in LIFO (reverse registration)
+ *    order. The old `mockAllTrpc()` catch-all was registered last, so it was
+ *    checked first and overrode all specific mocks with null data.
+ *
+ * 2. **Batch requests**: tRPC's `httpBatchLink` combines multiple queries into
+ *    a single HTTP request (e.g. `/api/trpc/a,b,c?batch=1&input=...`). The old
+ *    per-procedure route handlers returned a single-element array for a batched
+ *    request that expected multiple results, causing all but the first procedure
+ *    in the batch to receive undefined data.
+ *
+ * This new approach uses a per-page registry (WeakMap keyed by Page) to store
+ * mock data, and a single page.route handler matching all /api/trpc/ URLs that
+ * parses procedure names from the URL and returns the correct number of results.
+ */
+
+/**
  * Wrap response data in the superjson envelope expected by the tRPC client.
  * The tRPC client is configured with `transformer: superjson` (see lib/trpc/provider.tsx),
  * so all successful responses must use the `{ json: data }` wire format.
@@ -9,17 +29,128 @@ function superjsonResult(data: unknown) {
   return { result: { data: { json: data } } };
 }
 
+type MockEntry =
+  | { type: 'data'; data: unknown; delayMs?: number }
+  | { type: 'error'; errorCode: string; message: string; procedure: string };
+
+type MutationMockEntry =
+  | { type: 'data'; data: unknown }
+  | { type: 'error'; errorCode: string; message: string; procedure: string };
+
+const queryMocks = new WeakMap<Page, Map<string, MockEntry>>();
+const mutationMocks = new WeakMap<Page, Map<string, MutationMockEntry>>();
+const routeInstalled = new WeakMap<Page, boolean>();
+
+function getQueryRegistry(page: Page): Map<string, MockEntry> {
+  let registry = queryMocks.get(page);
+  if (!registry) {
+    registry = new Map();
+    queryMocks.set(page, registry);
+  }
+  return registry;
+}
+
+function getMutationRegistry(page: Page): Map<string, MutationMockEntry> {
+  let registry = mutationMocks.get(page);
+  if (!registry) {
+    registry = new Map();
+    mutationMocks.set(page, registry);
+  }
+  return registry;
+}
+
 /**
- * Intercepts a tRPC query and returns a mock response.
- * Matches GET requests to /api/trpc/<procedure>
+ * Build a single tRPC result entry from a mock registry entry.
+ * Returns a default superjson-wrapped null for unmocked procedures.
  */
-export async function mockTrpcQuery(page: Page, procedure: string, response: unknown) {
-  await page.route(`**/api/trpc/${procedure}*`, async (route, request) => {
+function buildQueryResult(entry: MockEntry | undefined): unknown {
+  if (!entry) {
+    return superjsonResult(null);
+  }
+  if (entry.type === 'error') {
+    return {
+      error: {
+        message: entry.message,
+        code: -32603,
+        data: { code: entry.errorCode, httpStatus: 500, path: entry.procedure },
+      },
+    };
+  }
+  return superjsonResult(entry.data);
+}
+
+function buildMutationResult(entry: MutationMockEntry | undefined): unknown {
+  if (!entry) {
+    return superjsonResult({ success: true });
+  }
+  if (entry.type === 'error') {
+    return {
+      error: {
+        message: entry.message,
+        code: -32603,
+        data: { code: entry.errorCode, httpStatus: 500, path: entry.procedure },
+      },
+    };
+  }
+  return superjsonResult(entry.data);
+}
+
+/**
+ * Extract procedure names from a tRPC URL.
+ *
+ * Handles both single and batched request URLs:
+ * - Single: /api/trpc/owner.getPlans?input=...
+ * - Batched: /api/trpc/owner.getDashboardSummary,owner.getPlans?batch=1&input=...
+ */
+function parseProcedures(url: string): string[] {
+  const match = url.match(/\/api\/trpc\/([^?]+)/);
+  if (!match) return [];
+  return match[1].split(',');
+}
+
+/**
+ * Install the single route handler that serves all tRPC mocks for a page.
+ * Called automatically on first mock registration. Safe to call multiple times.
+ */
+async function ensureRouteInstalled(page: Page): Promise<void> {
+  if (routeInstalled.get(page)) return;
+  routeInstalled.set(page, true);
+
+  await page.route('**/api/trpc/**', async (route, request) => {
+    const url = request.url();
+    const procedures = parseProcedures(url);
+
     if (request.method() === 'GET') {
+      const registry = getQueryRegistry(page);
+
+      // Check if any procedure in the batch has a delay
+      const maxDelay = procedures.reduce((max, proc) => {
+        const entry = registry.get(proc);
+        if (entry?.type === 'data' && entry.delayMs) {
+          return Math.max(max, entry.delayMs);
+        }
+        return max;
+      }, 0);
+
+      if (maxDelay > 0) {
+        await new Promise((resolve) => setTimeout(resolve, maxDelay));
+      }
+
+      const results = procedures.map((proc) => buildQueryResult(registry.get(proc)));
+
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify([superjsonResult(response)]),
+        body: JSON.stringify(results),
+      });
+    } else if (request.method() === 'POST') {
+      const registry = getMutationRegistry(page);
+      const results = procedures.map((proc) => buildMutationResult(registry.get(proc)));
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(results),
       });
     } else {
       await route.fallback();
@@ -28,113 +159,84 @@ export async function mockTrpcQuery(page: Page, procedure: string, response: unk
 }
 
 /**
- * Intercepts a tRPC mutation and returns a mock response.
- * Matches POST requests to /api/trpc/<procedure>
+ * Register a mock response for a tRPC query procedure.
+ * Automatically installs the route handler on first call.
  */
-export async function mockTrpcMutation(page: Page, procedure: string, response: unknown) {
-  await page.route(`**/api/trpc/${procedure}*`, async (route, request) => {
-    if (request.method() === 'POST') {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify([superjsonResult(response)]),
-      });
-    } else {
-      await route.fallback();
-    }
-  });
+export async function mockTrpcQuery(
+  page: Page,
+  procedure: string,
+  response: unknown,
+): Promise<void> {
+  getQueryRegistry(page).set(procedure, { type: 'data', data: response });
+  await ensureRouteInstalled(page);
 }
 
 /**
- * Intercepts a tRPC query and returns a tRPC-formatted error response.
+ * Register a mock response for a tRPC mutation procedure.
+ * Automatically installs the route handler on first call.
+ */
+export async function mockTrpcMutation(
+  page: Page,
+  procedure: string,
+  response: unknown,
+): Promise<void> {
+  getMutationRegistry(page).set(procedure, { type: 'data', data: response });
+  await ensureRouteInstalled(page);
+}
+
+/**
+ * Register a mock error response for a tRPC query procedure.
  */
 export async function mockTrpcQueryError(
   page: Page,
   procedure: string,
   errorCode: string,
   message: string,
-) {
-  await page.route(`**/api/trpc/${procedure}*`, async (route, request) => {
-    if (request.method() === 'GET') {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify([
-          {
-            error: {
-              message,
-              code: -32603,
-              data: { code: errorCode, httpStatus: 500, path: procedure },
-            },
-          },
-        ]),
-      });
-    } else {
-      await route.fallback();
-    }
-  });
+): Promise<void> {
+  getQueryRegistry(page).set(procedure, { type: 'error', errorCode, message, procedure });
+  await ensureRouteInstalled(page);
 }
 
 /**
- * Intercepts a tRPC mutation and returns a tRPC-formatted error response.
+ * Register a mock error response for a tRPC mutation procedure.
  */
 export async function mockTrpcMutationError(
   page: Page,
   procedure: string,
   errorCode: string,
   message: string,
-) {
-  await page.route(`**/api/trpc/${procedure}*`, async (route, request) => {
-    if (request.method() === 'POST') {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify([
-          {
-            error: {
-              message,
-              code: -32603,
-              data: { code: errorCode, httpStatus: 500, path: procedure },
-            },
-          },
-        ]),
-      });
-    } else {
-      await route.fallback();
-    }
-  });
+): Promise<void> {
+  getMutationRegistry(page).set(procedure, { type: 'error', errorCode, message, procedure });
+  await ensureRouteInstalled(page);
 }
 
 /**
- * Intercepts a tRPC query and returns empty data (null, [], or {}).
+ * Register a mock empty response for a tRPC query procedure.
  */
 export async function mockTrpcQueryEmpty(
   page: Page,
   procedure: string,
   emptyValue: unknown = null,
-) {
+): Promise<void> {
   await mockTrpcQuery(page, procedure, emptyValue);
 }
 
 /**
- * Intercepts a tRPC query and returns data after a simulated delay.
+ * Register a mock delayed response for a tRPC query procedure.
  */
 export async function mockTrpcQueryDelayed(
   page: Page,
   procedure: string,
   data: unknown,
   delayMs: number,
-) {
-  await page.route(`**/api/trpc/${procedure}*`, async (route, request) => {
-    if (request.method() === 'GET') {
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify([superjsonResult(data)]),
-      });
-    } else {
-      await route.fallback();
-    }
-  });
+): Promise<void> {
+  getQueryRegistry(page).set(procedure, { type: 'data', data, delayMs });
+  await ensureRouteInstalled(page);
 }
+
+/**
+ * Ensure the tRPC route handler is installed for the given page.
+ * Exported for `mockAllTrpc()` in portal-test-base.ts.
+ * Prefer using `mockTrpcQuery()` etc. which call this automatically.
+ */
+export { ensureRouteInstalled as _ensureRouteInstalled };


### PR DESCRIPTION
## Summary

Fixes #192 — All authenticated portal pages (owner, clinic, admin) show "Unable to load" instead of data due to E2E tRPC mock system failures.

**Root cause:** Two interrelated bugs in the Playwright tRPC mock system:

1. **Route ordering (LIFO override):** Playwright matches `page.route()` handlers in reverse registration order (LIFO). The `mockAllTrpc()` catch-all was registered *last* (after specific mocks), so it was checked *first* and fulfilled all tRPC requests with `null` data — completely overriding the specific mock data.

2. **Batch request mismatch:** tRPC's `httpBatchLink` combines multiple queries into a single HTTP request (e.g. `/api/trpc/a,b,c?batch=1&input=...`). The old per-procedure route handlers returned a single-element array `[{result:{data:...}}]` for batched requests that expected multiple results, causing all but the first procedure in the batch to receive `undefined`.

**Fix:** Replaced the per-route mock approach with a registry-based system:
- Mock data is stored in a per-page `WeakMap<Page, Map<string, MockEntry>>` registry
- A single `page.route('**/api/trpc/**')` handler is installed once per page (auto-installed on first mock call)
- The handler parses all procedure names from the URL (handles both single and comma-separated batch formats)
- Returns a correctly-sized result array with one entry per procedure
- Unmocked procedures get safe defaults (`null` for queries, `{success: true}` for mutations)
- Registration order no longer matters — `mockAllTrpc()` can be called before or after specific mocks

## Test plan

- [x] `bun run check` — Biome lint + format passes (0 errors)
- [x] `bun run typecheck` — TypeScript compilation clean
- [x] `bun run test` — All 525 unit tests pass
- [ ] CI E2E tests pass — the 59 previously-failing portal data tests should now work

🤖 Generated with [Claude Code](https://claude.com/claude-code)