### PR TITLE
fix: replace "guaranteed payment" messaging sitewide

### DIFF
--- a/app/(marketing)/layout.tsx
+++ b/app/(marketing)/layout.tsx
@@ -8,7 +8,7 @@ import { Separator } from '@/components/ui/separator';
 export const metadata: Metadata = {
   title: {
     template: '%s | FuzzyCat',
-    default: 'FuzzyCat - Guaranteed Payment Plans for Veterinary Care',
+    default: 'FuzzyCat - Flexible Payment Plans for Veterinary Care',
   },
   description:
     'Pay your vet bill in easy biweekly installments. No credit check. Flat 6% fee. Clinics earn 3% on every enrollment.',
@@ -72,7 +72,7 @@ function Footer() {
               <span className="text-lg font-bold">FuzzyCat</span>
             </div>
             <p className="mt-3 text-sm text-muted-foreground">
-              Guaranteed payment plans for veterinary care. No credit check. No surprises.
+              Flexible payment plans for veterinary care. No credit check. No surprises.
             </p>
           </div>
           <div>

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -23,11 +23,11 @@ import {
 } from '@/lib/constants';
 
 export const metadata: Metadata = {
-  title: 'FuzzyCat - Guaranteed Payment Plans for Veterinary Care',
+  title: 'FuzzyCat - Flexible Payment Plans for Veterinary Care',
   description:
-    'Pay your vet bill in easy biweekly installments over 12 weeks. No credit check. Flat 6% fee. Clinics earn 3% on every enrollment. Guaranteed payment plans for veterinary care.',
+    'Pay your vet bill in easy biweekly installments over 12 weeks. No credit check. Flat 6% fee. Clinics earn 3% on every enrollment. Flexible payment plans for veterinary care.',
   openGraph: {
-    title: 'FuzzyCat - Guaranteed Payment Plans for Veterinary Care',
+    title: 'FuzzyCat - Flexible Payment Plans for Veterinary Care',
     description:
       'Pay your vet bill in easy biweekly installments. No credit check. No hidden fees.',
     type: 'website',
@@ -218,8 +218,8 @@ export default function LandingPage() {
                   />
                   <ClinicBenefit
                     icon={<Shield className="h-5 w-5" />}
-                    title="Guaranteed payment"
-                    description="If a pet owner defaults, FuzzyCat's risk pool covers your payout."
+                    title="Built-in default protection"
+                    description="25% upfront deposit and automated collection reduce your default risk."
                   />
                   <ClinicBenefit
                     icon={<BadgeCheck className="h-5 w-5" />}

--- a/app/clinic/onboarding/page.tsx
+++ b/app/clinic/onboarding/page.tsx
@@ -12,7 +12,7 @@ export default function ClinicOnboardingPage() {
       <div className="mb-8">
         <h1 className="text-2xl font-semibold tracking-tight">Welcome to FuzzyCat</h1>
         <p className="mt-2 text-muted-foreground">
-          Complete the steps below to start offering Guaranteed Payment Plans to your clients.
+          Complete the steps below to start offering payment plans to your clients.
         </p>
       </div>
       <OnboardingChecklist />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,7 +23,7 @@ export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://fuzzycatapp.com'),
-  title: 'FuzzyCat — Guaranteed Payment Plans for Veterinary Care',
+  title: 'FuzzyCat — Flexible Payment Plans for Veterinary Care',
   description:
     'Pay your vet bill in easy biweekly installments. No credit check. Flat 6% fee. Clinics earn 3% on every enrollment.',
   openGraph: {

--- a/e2e/tests/clinic/onboarding.spec.ts
+++ b/e2e/tests/clinic/onboarding.spec.ts
@@ -35,9 +35,7 @@ test.describe('Clinic Onboarding', () => {
   });
 
   test('shows description', async ({ page }) => {
-    const description = page.getByText(
-      /complete the steps below to start offering guaranteed payment plans/i,
-    );
+    const description = page.getByText(/complete the steps below to start offering payment plans/i);
     await expect(description).toBeVisible();
   });
 

--- a/e2e/tests/public/how-it-works.spec.ts
+++ b/e2e/tests/public/how-it-works.spec.ts
@@ -49,7 +49,7 @@ test.describe('How It Works page', () => {
 
     // Multiple elements contain "3%" so use first() to avoid strict mode violation
     await expect(page.getByText('3%', { exact: false }).first()).toBeVisible();
-    await expect(page.getByText('Guaranteed payment').first()).toBeVisible();
+    await expect(page.getByText('Automated payment recovery').first()).toBeVisible();
 
     const screenshot = await page.screenshot({ fullPage: true });
     await testInfo.attach('clinic-benefits', {

--- a/server/emails/clinic-welcome.tsx
+++ b/server/emails/clinic-welcome.tsx
@@ -31,7 +31,7 @@ export function ClinicWelcome({
 
       <Text style={paragraph}>
         We are thrilled to have {clinicName} join the FuzzyCat family! Your clinic is now registered
-        on our platform and ready to offer Guaranteed Payment Plans to your clients.
+        on our platform and ready to offer payment plans to your clients.
       </Text>
 
       <Section style={tableContainer}>
@@ -44,7 +44,7 @@ export function ClinicWelcome({
         <Text style={tableRow}>
           2. Clients pay 25% upfront and the rest in 6 biweekly installments
         </Text>
-        <Text style={tableRow}>3. Your clinic receives payments as they come in -- guaranteed</Text>
+        <Text style={tableRow}>3. Your clinic receives payments as each installment clears</Text>
         <Text style={tableRow}>4. Earn a 3% revenue share on every enrollment</Text>
       </Section>
 

--- a/server/emails/components/layout.tsx
+++ b/server/emails/components/layout.tsx
@@ -63,7 +63,7 @@ export function EmailLayout({ preview, children }: EmailLayoutProps) {
           <Section style={content}>{children}</Section>
           <Hr style={{ borderColor: '#e6ebf1', margin: '20px 48px' }} />
           <Section style={footer}>
-            <Text style={footerText}>FuzzyCat - Guaranteed Payment Plans for Veterinary Care</Text>
+            <Text style={footerText}>FuzzyCat - Flexible Payment Plans for Veterinary Care</Text>
             <Text style={footerText}>
               This is an automated message from FuzzyCat. Please do not reply directly to this
               email.

--- a/server/emails/soft-collection-day14.tsx
+++ b/server/emails/soft-collection-day14.tsx
@@ -41,9 +41,9 @@ export function SoftCollectionDay14({
 
       <Section style={warningBox}>
         <Text style={{ ...paragraph, color: '#92400e', margin: '0', fontWeight: 'bold' }}>
-          If your payment method is not updated within the next few days, the guarantee claim for
-          your remaining balance will be finalized. This is your last opportunity to resolve this
-          matter directly.
+          If your payment method is not updated within the next few days, your remaining balance
+          will be referred to the clinic for direct collection. This is your last opportunity to
+          resolve this matter directly.
         </Text>
       </Section>
 

--- a/server/emails/soft-collection-day7.tsx
+++ b/server/emails/soft-collection-day7.tsx
@@ -41,7 +41,8 @@ export function SoftCollectionDay7({
       <Section style={warningBox}>
         <Text style={{ ...paragraph, color: '#92400e', margin: '0' }}>
           To avoid further complications with your payment plan, please update your payment method
-          as soon as possible. Continued non-payment may result in a guarantee claim being filed.
+          as soon as possible. Continued non-payment may result in your balance being referred to
+          the clinic for collection.
         </Text>
       </Section>
 

--- a/server/services/sms.ts
+++ b/server/services/sms.ts
@@ -374,7 +374,7 @@ export async function sendSoftCollectionReminder(
   const messages: Record<string, string> = {
     day_1_reminder: `FuzzyCat: Your payment plan for ${params.petName} has been paused. Please update your payment method at ${params.updatePaymentUrl} to resume.`,
     day_7_followup: `FuzzyCat: Action required -- your payment plan for ${params.petName} has been paused for 7 days. Update your payment method at ${params.updatePaymentUrl} to avoid further action.`,
-    day_14_final: `FuzzyCat: Final notice -- your payment plan for ${params.petName} will have a guarantee claim finalized soon. Update your payment method now at ${params.updatePaymentUrl}`,
+    day_14_final: `FuzzyCat: Final notice -- your payment plan for ${params.petName} will be referred to the clinic for collection soon. Update your payment method now at ${params.updatePaymentUrl}`,
   };
 
   const body = messages[params.stage];


### PR DESCRIPTION
## Summary

- Replace all "Guaranteed Payment Plans" language with accurate alternatives across homepage, footer, email templates, and SMS
- FuzzyCat does **not** guarantee clinic payment — clinics are responsible for collecting from defaulting owners (per CLAUDE.md)
- The old ClinicBenefit card ("If a pet owner defaults, FuzzyCat's risk pool covers your payout") was factually false and a legal liability

## Changes

**Marketing pages (homepage, footer, onboarding):**
- Metadata titles: "Guaranteed" → "Flexible"
- ClinicBenefit card: "Guaranteed payment" → "Built-in default protection" with accurate description about 25% deposit + automated collection
- Footer tagline: "Guaranteed" → "Flexible"
- Clinic onboarding: "Guaranteed Payment Plans" → "payment plans"

**Email templates:**
- Email layout footer: "Guaranteed" → "Flexible"
- Clinic welcome: remove guarantee claims from body and step list
- Soft collection day 7: "guarantee claim being filed" → "balance referred to clinic for collection"
- Soft collection day 14: "guarantee claim finalized" → "referred to clinic for direct collection"

**SMS:**
- Day 14 final notice: "guarantee claim finalized" → "referred to clinic for collection"

**E2E tests:**
- Updated assertions to match new copy

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun run check` — no new errors (pre-existing only)
- [x] `bun run test` — 543/543 pass
- [x] Pre-push hooks: biome, secrets, typecheck, circular deps, security, full build all pass
- [ ] Visual check on `localhost:3000` (homepage hero, clinic section, footer)
- [ ] E2E tests pass against dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)