### PR TITLE
fix(e2e): improve test reliability with retries and timeouts

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: isCI,
   retries: isProduction ? 1 : isCI ? 2 : 0,
-  workers: isProduction ? 8 : isCI ? 1 : undefined,
+  workers: isProduction ? 8 : isCI ? 1 : 4,
   reporter: isProduction
     ? [
         ['html', { open: 'never', outputFolder: 'playwright-report' }],
@@ -37,6 +37,7 @@ export default defineConfig({
     trace: 'on-first-retry',
     screenshot: isProduction || isCI ? 'on' : 'only-on-failure',
     video: isProduction || isCI ? 'on-first-retry' : 'off',
+    navigationTimeout: 15_000,
   },
   projects: [
     // ── Public pages (no auth) ────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Fix global setup login failures by adding retry logic (3 attempts), dev server warm-up via health check, and graceful fallback to existing auth state files
- Fix page load timeouts by capping local workers to 4 (dev server can't handle 8) and setting a 15s `navigationTimeout` globally

## Changes

**`e2e/global-setup.ts`:**
- Add `warmUpServer()` — hits `/api/health` before login attempts to ensure dev server is ready
- Add retry loop (3 attempts) to `loginAndSaveState()` with progressive logging
- Wait for form inputs to be visible before filling (prevents racing the DOM)
- On final failure, gracefully fall back to existing auth state files instead of erroring

**`playwright.config.ts`:**
- Local workers: `undefined` (CPU/2) → `4` — prevents overwhelming the dev server
- Add `navigationTimeout: 15_000` to global `use` config — fail fast on stuck navigations instead of waiting for the full 30s test timeout

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun run check` — no new lint errors
- [x] `bun run test` — 543/543 pass
- [x] Pre-push hooks pass (circular deps, security, build)
- [ ] CI E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)