### PR TITLE
fix(e2e): align public page test assertions with DOM

### DIFF
--- a/e2e/tests/public/landing.spec.ts
+++ b/e2e/tests/public/landing.spec.ts
@@ -49,7 +49,7 @@ test.describe('Landing page', () => {
     await page.goto('/');
 
     await expect(page.getByText('Get paid to offer payment plans')).toBeVisible();
-    await expect(page.getByText('3% revenue share')).toBeVisible();
+    await expect(page.getByText('Earn 3% on every plan')).toBeVisible();
 
     const screenshot = await page.screenshot({ fullPage: true });
     await testInfo.attach('clinic-cta-section', {
@@ -88,10 +88,12 @@ test.describe('Landing page', () => {
 
     const realErrors = errors.filter(
       (e) =>
-        !e.includes('posthog') &&
-        !e.includes('sentry') &&
+        !e.toLowerCase().includes('posthog') &&
+        !e.toLowerCase().includes('sentry') &&
         !e.includes('favicon') &&
-        !e.includes('monitoring'),
+        !e.includes('monitoring') &&
+        !e.includes('next-dev-overlay') &&
+        !e.includes('__nextjs'),
     );
     expect(realErrors).toHaveLength(0);
 


### PR DESCRIPTION
## Summary
- Fix clinic CTA assertion in `landing.spec.ts`: change `'3% revenue share'` to `'Earn 3% on every plan'` to match the actual rendered `ClinicBenefit` title text
- Harden console error filter with case-insensitive PostHog/Sentry matching and Next.js dev overlay exclusions (`next-dev-overlay`, `__nextjs`)

## Context
All other test files (`how-it-works.spec.ts`, `calculator-interaction.spec.ts`, `forgot-password.spec.ts`, `reset-password.spec.ts`) were verified against the actual page source and their assertions already match the rendered DOM correctly.

Closes #216

## Test plan
- [ ] CI E2E `public` project tests pass
- [ ] No new test failures introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)