### PR TITLE
fix(e2e): align mobile, visual, and edge-case tests

### DIFF
--- a/e2e/tests/edge-cases/pagination-edge-cases.spec.ts
+++ b/e2e/tests/edge-cases/pagination-edge-cases.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { clinicClients } from '../../helpers/audit-mock-data';
+import { clinicClients, clinicClientsPage2 } from '../../helpers/audit-mock-data';
 import { gotoPortalPage, mockAllTrpc, mockExternalServices } from '../../helpers/portal-test-base';
 import { mockTrpcQuery } from '../../helpers/trpc-mock';
 
@@ -62,7 +62,6 @@ test.describe('Pagination — Edge Cases', () => {
     const nextBtn = page.getByRole('button', { name: /next/i });
     if (await nextBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
       // Navigate to page 2
-      const { clinicClientsPage2 } = await import('../../helpers/audit-mock-data');
       await mockTrpcQuery(page, 'clinic.getClients', clinicClientsPage2);
       await nextBtn.click();
       await page.waitForTimeout(1000);

--- a/e2e/tests/mobile/auth-mobile.spec.ts
+++ b/e2e/tests/mobile/auth-mobile.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Auth Pages — Mobile', () => {
   test('login form fully functional on mobile', async ({ page }, testInfo) => {
-    await page.goto('/login');
+    await page.goto('/login', { waitUntil: 'domcontentloaded' });
 
     // All form elements visible
     const emailInput = page.locator('input[type="email"]');
@@ -37,7 +37,7 @@ test.describe('Auth Pages — Mobile', () => {
   });
 
   test('login validation on mobile', async ({ page }) => {
-    await page.goto('/login');
+    await page.goto('/login', { waitUntil: 'domcontentloaded' });
 
     const emailInput = page.locator('input[type="email"]');
     const submitBtn = page.getByRole('button', { name: /sign in|log in|submit/i });
@@ -57,7 +57,7 @@ test.describe('Auth Pages — Mobile', () => {
         body: 'window.turnstile = { render: function(el, opts) { if (opts && opts.callback) opts.callback("mock-token"); return "mock-id"; }, reset: function() {}, remove: function() {} };',
       }),
     );
-    await page.goto('/signup');
+    await page.goto('/signup', { waitUntil: 'domcontentloaded' });
 
     // Tab switching works on mobile
     const clinicTab = page.getByRole('tab', { name: /veterinary clinic|clinic/i });
@@ -94,7 +94,16 @@ test.describe('Auth Pages — Mobile', () => {
   });
 
   test('forgot password flow on mobile', async ({ page }, testInfo) => {
-    await page.goto('/forgot-password');
+    // Mock the Supabase auth endpoint so "Send reset link" succeeds
+    await page.route('**/auth/v1/recover**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({}),
+      }),
+    );
+
+    await page.goto('/forgot-password', { waitUntil: 'domcontentloaded' });
 
     const emailInput = page.locator('#email');
     await expect(emailInput).toBeVisible();
@@ -116,7 +125,7 @@ test.describe('Auth Pages — Mobile', () => {
   });
 
   test('reset password form on mobile', async ({ page }, testInfo) => {
-    await page.goto('/reset-password');
+    await page.goto('/reset-password', { waitUntil: 'domcontentloaded' });
 
     const passwordInput = page.locator('#password');
     const confirmInput = page.locator('#confirm-password');

--- a/e2e/tests/mobile/public-mobile.spec.ts
+++ b/e2e/tests/mobile/public-mobile.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Public Pages — Mobile', () => {
   test('landing page hero renders on mobile', async ({ page }, testInfo) => {
-    await page.goto('/');
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
 
     await expect(page.locator('h1')).toBeVisible();
     await expect(page.getByText('No credit check required')).toBeVisible();
@@ -27,7 +27,7 @@ test.describe('Public Pages — Mobile', () => {
   });
 
   test('landing page pricing section on mobile', async ({ page }, testInfo) => {
-    await page.goto('/');
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
 
     // Pricing section
     const pricing = page.getByText(/transparent pricing/i);
@@ -46,7 +46,7 @@ test.describe('Public Pages — Mobile', () => {
   });
 
   test('landing page navigation CTAs work on mobile', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
 
     // CTA to signup
     const signupCta = page.getByRole('link', { name: /start my payment plan/i });
@@ -55,7 +55,7 @@ test.describe('Public Pages — Mobile', () => {
   });
 
   test('how-it-works page renders on mobile', async ({ page }, testInfo) => {
-    await page.goto('/how-it-works');
+    await page.goto('/how-it-works', { waitUntil: 'domcontentloaded' });
 
     await expect(page.locator('h1')).toBeVisible();
     await expect(page.getByText(/How FuzzyCat Works/i)).toBeVisible();
@@ -70,7 +70,7 @@ test.describe('Public Pages — Mobile', () => {
   });
 
   test('payment calculator on mobile', async ({ page }, testInfo) => {
-    await page.goto('/how-it-works');
+    await page.goto('/how-it-works', { waitUntil: 'domcontentloaded' });
 
     // Calculator section
     const billInput = page.locator('#bill-amount');
@@ -97,7 +97,7 @@ test.describe('Public Pages — Mobile', () => {
   });
 
   test('FAQ accordion on mobile', async ({ page }, testInfo) => {
-    await page.goto('/how-it-works');
+    await page.goto('/how-it-works', { waitUntil: 'domcontentloaded' });
 
     // FAQ section
     const faqSection = page.getByText(/frequently asked/i);
@@ -119,7 +119,7 @@ test.describe('Public Pages — Mobile', () => {
   });
 
   test('dark mode toggle on mobile', async ({ page }, testInfo) => {
-    await page.goto('/');
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
 
     const themeToggle = page
       .getByRole('button', { name: /toggle.*theme|dark.*mode|light.*mode|theme/i })

--- a/e2e/tests/visual/public-baselines.spec.ts
+++ b/e2e/tests/visual/public-baselines.spec.ts
@@ -12,8 +12,7 @@ test.describe('Visual Baselines — Public Pages', () => {
 
   for (const { url, name } of publicPages) {
     test(`${name} page visual baseline`, async ({ page }) => {
-      await page.goto(url);
-      await page.waitForLoadState('domcontentloaded');
+      await page.goto(url, { waitUntil: 'domcontentloaded' });
       await page.waitForTimeout(1000); // Wait for animations to settle
 
       await expect(page).toHaveScreenshot(`public-${name}.png`, {


### PR DESCRIPTION
## Summary
- Use `waitUntil: 'domcontentloaded'` for all `page.goto()` calls in auth-mobile, public-mobile, and public-baselines specs to prevent navigation timeouts when external scripts (analytics, Sentry, etc.) block the `load` event
- Mock Supabase `auth/v1/recover` endpoint in the forgot-password mobile test so the reset-link flow completes without a real backend
- Replace dynamic `import()` with a static import for `clinicClientsPage2` in pagination edge-case tests

Auth-dependent tests (owner/clinic/admin-mobile, portal-baselines, enrollment/pagination edge-cases) are structurally verified correct but remain blocked by #214 (auth cookie domain mismatch).

Closes #218

## Test plan
- [ ] `bun run typecheck` passes
- [ ] `bun run check` passes (no new warnings)
- [ ] CI passes (typecheck, lint, build, API e2e)
- [ ] Auth-mobile tests pass locally with dev server running
- [ ] Public-mobile tests pass locally with dev server running
- [ ] Public visual baselines pass locally with dev server running

🤖 Generated with [Claude Code](https://claude.com/claude-code)