### PR TITLE
fix(e2e): increase navigation timeout to 30s

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,7 +37,8 @@ export default defineConfig({
     trace: 'on-first-retry',
     screenshot: isProduction || isCI ? 'on' : 'only-on-failure',
     video: isProduction || isCI ? 'on-first-retry' : 'off',
-    navigationTimeout: 15_000,
+    navigationTimeout: 30_000,
+    actionTimeout: 15_000,
   },
   projects: [
     // ── Public pages (no auth) ────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Increased `navigationTimeout` from 15s to 30s in `playwright.config.ts`
- Added `actionTimeout: 15s` for click/fill actions
- Fixes spurious timeouts when the dev server is cold-starting on first page loads

## Test plan
- [x] Landing page tests: 6/6 pass (previously 2/6 due to timeouts)
- [x] All CI checks should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)