### PR TITLE
feat: add Sentry user feedback widget

### DIFF
--- a/components/sentry-user-sync.tsx
+++ b/components/sentry-user-sync.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import * as Sentry from '@sentry/nextjs';
+import { useEffect } from 'react';
+import { createClient } from '@/lib/supabase/client';
+
+/**
+ * Syncs Supabase auth state to Sentry user context.
+ * When a user signs in, their email and role are set on Sentry so that
+ * error reports and feedback submissions are automatically attributed.
+ * Renders nothing — mount once near the root of the component tree.
+ */
+export function SentryUserSync() {
+  useEffect(() => {
+    const supabase = createClient();
+
+    // Set user from current session (if already signed in)
+    supabase.auth.getUser().then(({ data }) => {
+      if (data.user) {
+        Sentry.setUser({
+          id: data.user.id,
+          email: data.user.email,
+          username: data.user.user_metadata?.name as string | undefined,
+        });
+      }
+    });
+
+    // Listen for auth state changes (sign in / sign out)
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (session?.user) {
+        Sentry.setUser({
+          id: session.user.id,
+          email: session.user.email,
+          username: session.user.user_metadata?.name as string | undefined,
+        });
+      } else {
+        Sentry.setUser(null);
+      }
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  return null;
+}

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -6,7 +6,21 @@ Sentry.init({
   tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
-  integrations: [Sentry.replayIntegration()],
+  integrations: [
+    Sentry.replayIntegration(),
+    Sentry.feedbackIntegration({
+      colorScheme: 'system',
+      autoInject: true,
+      enableScreenshot: true,
+      showBranding: false,
+      triggerLabel: 'Feedback',
+      formTitle: 'Send us feedback',
+      submitButtonLabel: 'Send feedback',
+      messagePlaceholder: "What's on your mind? Bug reports, suggestions, anything.",
+      isEmailRequired: false,
+      isNameRequired: false,
+    }),
+  ],
 });
 
 export { captureRouterTransitionStart as onRouterTransitionStart } from '@sentry/nextjs';

--- a/lib/trpc/provider.tsx
+++ b/lib/trpc/provider.tsx
@@ -5,6 +5,7 @@ import { createTRPCClient, httpBatchLink } from '@trpc/client';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import { useState } from 'react';
 import superjson from 'superjson';
+import { SentryUserSync } from '@/components/sentry-user-sync';
 import { PostHogProvider } from '@/lib/posthog/provider';
 import type { AppRouter } from '@/server/routers';
 import { TRPCProvider } from './client';
@@ -41,6 +42,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       <QueryClientProvider client={queryClient}>
         <TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
           {children}
+          <SentryUserSync />
           <SpeedInsights />
         </TRPCProvider>
       </QueryClientProvider>


### PR DESCRIPTION
## Summary

- Add Sentry `feedbackIntegration` to `instrumentation-client.ts` — persistent "Feedback" button on every page with screenshot capture, crop, highlight, and redact tools
- Add `SentryUserSync` component that syncs Supabase auth state to `Sentry.setUser()` so feedback submissions are automatically attributed to the logged-in user
- Zero new dependencies — uses existing `@sentry/nextjs` SDK (v10.39+)

Closes #231

## Test plan

- [ ] Feedback button visible on all pages (public + portal)
- [ ] Clicking opens form with message + screenshot option
- [ ] Authenticated users have name/email pre-filled
- [ ] Widget styled with system color scheme, no Sentry branding
- [ ] All unit tests pass (`bun run test`)
- [ ] Typecheck clean (`bun run typecheck`)
- [ ] Biome clean (`bun run check`)
- [ ] No CSP violations in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)