### PR TITLE
chore: remove duplicate SpeedInsights from tRPC provider

### DIFF
--- a/lib/trpc/provider.tsx
+++ b/lib/trpc/provider.tsx
@@ -2,7 +2,6 @@
 
 import { QueryClientProvider } from '@tanstack/react-query';
 import { createTRPCClient, httpBatchLink } from '@trpc/client';
-import { SpeedInsights } from '@vercel/speed-insights/next';
 import { useState } from 'react';
 import superjson from 'superjson';
 import { SentryUserSync } from '@/components/sentry-user-sync';
@@ -43,7 +42,6 @@ export function Providers({ children }: { children: React.ReactNode }) {
         <TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
           {children}
           <SentryUserSync />
-          <SpeedInsights />
         </TRPCProvider>
       </QueryClientProvider>
     </PostHogProvider>


### PR DESCRIPTION
## Summary
- Removed duplicate `<SpeedInsights />` component from `lib/trpc/provider.tsx`
- The component is already rendered in `app/layout.tsx`, so having it in both places caused double script injection

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run check` passes (no new warnings)
- [x] `bun run test` passes (567 tests, 0 failures)
- [x] Production build succeeds

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)