### PR TITLE
perf: add server-side caching for Tier 1 tRPC data

### DIFF
--- a/lib/__tests__/cache.test.ts
+++ b/lib/__tests__/cache.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+// ── Mocks ────────────────────────────────────────────────────────────
+
+const mockUnstableCache = mock();
+const mockNextRevalidateTag = mock();
+
+mock.module('next/cache', () => ({
+  unstable_cache: mockUnstableCache,
+  revalidateTag: mockNextRevalidateTag,
+}));
+
+// Import after mocking
+const { cachedQuery, revalidateTag } = await import('@/lib/cache');
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe('cachedQuery', () => {
+  beforeEach(() => {
+    mockUnstableCache.mockClear();
+    mockNextRevalidateTag.mockClear();
+  });
+
+  afterEach(() => {
+    mockUnstableCache.mockClear();
+    mockNextRevalidateTag.mockClear();
+  });
+
+  it('wraps a function with unstable_cache and calls it immediately', async () => {
+    const mockData = { id: 'clinic-1', name: 'Happy Paws' };
+    const mockFn = mock(() => Promise.resolve(mockData));
+    const cachedFn = mock(() => Promise.resolve(mockData));
+
+    mockUnstableCache.mockReturnValue(cachedFn);
+
+    const result = await cachedQuery(mockFn, ['clinic-profile', 'clinic-1'], {
+      revalidate: 300,
+      tags: ['clinic:clinic-1:profile'],
+    });
+
+    expect(result).toEqual(mockData);
+    expect(mockUnstableCache).toHaveBeenCalledTimes(1);
+    expect(mockUnstableCache).toHaveBeenCalledWith(mockFn, ['clinic-profile', 'clinic-1'], {
+      revalidate: 300,
+      tags: ['clinic:clinic-1:profile'],
+    });
+    expect(cachedFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes key parts including entity IDs for scoped caching', async () => {
+    const mockFn = mock(() => Promise.resolve({ id: 'owner-42' }));
+    const cachedFn = mock(() => Promise.resolve({ id: 'owner-42' }));
+    mockUnstableCache.mockReturnValue(cachedFn);
+
+    await cachedQuery(mockFn, ['owner-profile', 'owner-42'], {
+      revalidate: 300,
+      tags: ['owner:owner-42:profile'],
+    });
+
+    const keyParts = mockUnstableCache.mock.calls[0][1] as string[];
+    expect(keyParts).toContain('owner-42');
+    expect(keyParts).toContain('owner-profile');
+  });
+
+  it('passes cache options including TTL and tags', async () => {
+    const mockFn = mock(() => Promise.resolve([]));
+    const cachedFn = mock(() => Promise.resolve([]));
+    mockUnstableCache.mockReturnValue(cachedFn);
+
+    await cachedQuery(mockFn, ['admin-clinics'], {
+      revalidate: 120,
+      tags: ['admin:clinics'],
+    });
+
+    const options = mockUnstableCache.mock.calls[0][2] as {
+      revalidate?: number;
+      tags?: string[];
+    };
+    expect(options.revalidate).toBe(120);
+    expect(options.tags).toEqual(['admin:clinics']);
+  });
+
+  it('falls back to direct call when unstable_cache throws', async () => {
+    const mockData = { id: 'fallback-1', name: 'Fallback Clinic' };
+    const mockFn = mock(() => Promise.resolve(mockData));
+
+    // Simulate Next.js runtime missing (throws invariant error)
+    mockUnstableCache.mockImplementation(() => {
+      throw new Error('Invariant: incrementalCache missing');
+    });
+
+    const result = await cachedQuery(mockFn, ['clinic-profile', 'clinic-1'], {
+      revalidate: 300,
+      tags: ['clinic:clinic-1:profile'],
+    });
+
+    expect(result).toEqual(mockData);
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates errors from the underlying function', async () => {
+    const error = new Error('Database connection failed');
+    const cachedFn = mock(() => Promise.reject(error));
+    mockUnstableCache.mockReturnValue(cachedFn);
+
+    await expect(
+      cachedQuery(() => Promise.reject(error), ['test'], { revalidate: 60 }),
+    ).rejects.toThrow('Database connection failed');
+  });
+
+  it('supports composite key parts for parameterized queries', async () => {
+    const mockFn = mock(() => Promise.resolve({ clinics: [] }));
+    const cachedFn = mock(() => Promise.resolve({ clinics: [] }));
+    mockUnstableCache.mockReturnValue(cachedFn);
+
+    await cachedQuery(mockFn, ['admin-clinics', 'active', '', '20', '0'], {
+      revalidate: 120,
+      tags: ['admin:clinics'],
+    });
+
+    const keyParts = mockUnstableCache.mock.calls[0][1] as string[];
+    expect(keyParts).toEqual(['admin-clinics', 'active', '', '20', '0']);
+  });
+});
+
+describe('revalidateTag', () => {
+  beforeEach(() => {
+    mockNextRevalidateTag.mockClear();
+  });
+
+  it('calls next/cache revalidateTag with default profile', () => {
+    revalidateTag('clinic:123:profile');
+    expect(mockNextRevalidateTag).toHaveBeenCalledWith('clinic:123:profile', 'default');
+  });
+
+  it('can invalidate multiple tags', () => {
+    revalidateTag('clinic:abc:profile');
+    revalidateTag('admin:clinics');
+
+    expect(mockNextRevalidateTag).toHaveBeenCalledTimes(2);
+    expect(mockNextRevalidateTag).toHaveBeenCalledWith('clinic:abc:profile', 'default');
+    expect(mockNextRevalidateTag).toHaveBeenCalledWith('admin:clinics', 'default');
+  });
+
+  it('silently skips when revalidateTag throws (non-Next.js runtime)', () => {
+    mockNextRevalidateTag.mockImplementation(() => {
+      throw new Error('Invariant: static generation store missing');
+    });
+
+    // Should not throw
+    expect(() => revalidateTag('test:tag')).not.toThrow();
+  });
+});

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -1,0 +1,41 @@
+import { revalidateTag as nextRevalidateTag, unstable_cache } from 'next/cache';
+
+/**
+ * Invalidate cached data by tag.
+ * Wrapper around Next.js revalidateTag with the default cache life profile.
+ * No-ops outside the Next.js server runtime (e.g., in tests).
+ *
+ * @param tag - Cache tag to invalidate (e.g., "clinic:123:profile")
+ */
+export function revalidateTag(tag: string): void {
+  try {
+    nextRevalidateTag(tag, 'default');
+  } catch {
+    // Outside Next.js runtime (tests, scripts) — silently skip
+  }
+}
+
+/**
+ * Cached wrapper for database queries.
+ * Uses Next.js unstable_cache for server-side caching with tag-based revalidation.
+ * Falls back to direct execution outside the Next.js server runtime (e.g., in tests).
+ *
+ * Tier 1 (conservative): clinic profiles, owner profiles, admin clinic list.
+ * NEVER cache financial/payment data, auth data, or session data.
+ *
+ * @param fn - Async function that fetches data (e.g., a Drizzle query)
+ * @param keyParts - Unique cache key parts (must include entity IDs for user-scoped data)
+ * @param options - Cache options: `revalidate` (TTL in seconds), `tags` (for invalidation)
+ */
+export async function cachedQuery<T>(
+  fn: () => Promise<T>,
+  keyParts: string[],
+  options: { revalidate?: number; tags?: string[] },
+): Promise<T> {
+  try {
+    return await unstable_cache(fn, keyParts, options)();
+  } catch {
+    // Outside Next.js runtime (tests, scripts) — fall back to direct call
+    return fn();
+  }
+}


### PR DESCRIPTION
## Summary

- Add `lib/cache.ts` utility wrapping Next.js `unstable_cache` with `cachedQuery()` and `revalidateTag()` for server-side caching with tag-based invalidation
- Cache clinic profile reads (5 min TTL), owner profile reads (5 min TTL), and admin clinic list (2 min TTL) — Tier 1 only, conservative approach
- Add tag-based cache invalidation to all related mutations: `clinic.updateProfile`, `clinic.completeOnboarding`, `owner.updateProfile`, `admin.updateClinicStatus`
- Graceful fallback to direct DB queries outside Next.js runtime (tests, scripts)

### Cache targets (Tier 1)

| Procedure | Cache TTL | Tag Pattern |
|-----------|-----------|-------------|
| `clinic.getProfile` | 5 min (300s) | `clinic:{id}:profile` |
| `owner.getProfile` | 5 min (300s) | `owner:{id}:profile` |
| `admin.getClinics` | 2 min (120s) | `admin:clinics` |

### Safety

- Financial/payment data is **never cached**
- Auth/session data is **never cached**
- All cache keys are scoped by entity ID to prevent cross-user data leaks
- Short TTLs ensure staleness is bounded even without explicit invalidation

Closes #237

## Test plan

- [x] `lib/__tests__/cache.test.ts` — unit tests for `cachedQuery` and `revalidateTag` including fallback behavior
- [x] All existing router tests pass (576 pass, 0 fail)
- [x] `bun run typecheck` passes
- [x] `bun run check` passes (no new warnings)
- [x] Pre-push hooks pass (build, circular, security, fast-tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)