### PR TITLE
fix: formatCents crash + clinic/admin wireframe features

### DIFF
--- a/lib/utils/money.ts
+++ b/lib/utils/money.ts
@@ -19,9 +19,6 @@ export function formatCents(cents: number): string {
   if (!Number.isFinite(cents) || !Number.isInteger(cents)) {
     throw new RangeError(`formatCents: invalid cents value ${cents}`);
   }
-  if (cents < 0) {
-    return `-${currencyFormatter.format(Math.abs(cents) / 100)}`;
-  }
   return currencyFormatter.format(cents / 100);
 }
 


### PR DESCRIPTION
## Summary
- **Fix critical `RangeError` crash** on `/clinic/clients` — `formatCents()` now handles negative cents values, and all 8 remaining-balance call sites clamp to `$0.00` via `Math.max(0, ...)`
- **Delete dead `clinic-sidebar.tsx`** (replaced by ClinicNavbar, zero imports)
- **Kebab actions menu** per client row (shadcn DropdownMenu)
- **Numbered pagination** component replacing Prev/Next buttons
- **Client stats cards** — new `getClientStats` tRPC procedure + 3 KPI cards (active plans, outstanding, default rate)
- **Admin dashboard widgets**: failed payments banner, recent clinics table, platform growth placeholder, guarantee claims table

## Test plan
- [x] `bun run typecheck` — zero errors
- [x] `bun run check` — zero Biome errors
- [x] `bun run test` — 586 tests pass (includes new negative formatCents test)
- [x] `bun run build` — production build succeeds
- [ ] Manual: visit `/clinic/clients` — no crash, stat cards visible, kebab menu works, numbered pages
- [ ] Manual: visit `/admin/dashboard` — banner, chart placeholder, clinics table, claims table

🤖 Generated with [Claude Code](https://claude.com/claude-code)