### PR TITLE
fix: add coming soon placeholders to empty clinic report sections

### DIFF
--- a/app/clinic/reports/_components/enrollment-trends.tsx
+++ b/app/clinic/reports/_components/enrollment-trends.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+import { TrendingUp } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
@@ -25,7 +26,13 @@ export function EnrollmentTrends() {
         <CardTitle>Enrollment Trends</CardTitle>
         <CardDescription>Monthly enrollment counts over the last 12 months.</CardDescription>
       </CardHeader>
-      <CardContent>
+      <CardContent className="space-y-4">
+        {/* Chart placeholder */}
+        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-8 text-center">
+          <TrendingUp className="mb-3 h-10 w-10 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">Chart coming soon</p>
+        </div>
+
         {isLoading ? (
           <div className="space-y-3">
             {[1, 2, 3].map((i) => (

--- a/app/clinic/reports/_components/revenue-report.tsx
+++ b/app/clinic/reports/_components/revenue-report.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+import { BarChart3 } from 'lucide-react';
 import { useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -78,6 +79,12 @@ export function RevenueReport() {
               className="w-40"
             />
           </div>
+        </div>
+
+        {/* Chart placeholder */}
+        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-8 text-center">
+          <BarChart3 className="mb-3 h-10 w-10 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">Chart coming soon</p>
         </div>
 
         {isLoading ? (


### PR DESCRIPTION
## Summary
- Adds "Chart coming soon" placeholder with `BarChart3` icon to the **Revenue Report** section on the clinic Reports page
- Adds "Chart coming soon" placeholder with `TrendingUp` icon to the **Enrollment Trends** section
- Matches the visual treatment used by the admin dashboard's Platform Growth placeholder (dashed border, centered icon + text)
- Existing data tables, date range pickers, and export buttons remain fully functional

Closes #268

## Test plan
- [ ] Navigate to `/clinic/reports` and verify both Revenue Report and Enrollment Trends sections display "Chart coming soon" placeholders with icons
- [ ] Verify the date range picker in Revenue Report still works and data tables render when data is available
- [ ] Verify Export buttons (Clients, Revenue, Payouts) still function correctly
- [ ] Compare with admin dashboard Platform Growth placeholder for visual consistency
- [ ] Run `bun run check`, `bun run typecheck`, `bun run test` — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)