### PR TITLE
fix: add descriptive page titles across all portal pages

### DIFF
--- a/app/(auth)/forgot-password/layout.tsx
+++ b/app/(auth)/forgot-password/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Forgot Password | FuzzyCat',
+};
+
+export default function ForgotPasswordLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/(auth)/login/clinic/page.tsx
+++ b/app/(auth)/login/clinic/page.tsx
@@ -1,6 +1,11 @@
 import { Cat } from 'lucide-react';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { ClinicLoginForm } from './_components/clinic-login-form';
+
+export const metadata: Metadata = {
+  title: 'Clinic Login | FuzzyCat',
+};
 
 export default function ClinicLoginPage() {
   return (

--- a/app/(auth)/login/owner/page.tsx
+++ b/app/(auth)/login/owner/page.tsx
@@ -1,6 +1,11 @@
 import { Cat } from 'lucide-react';
+import type { Metadata } from 'next';
 import Image from 'next/image';
 import { OwnerLoginForm } from './_components/owner-login-form';
+
+export const metadata: Metadata = {
+  title: 'Pet Owner Login | FuzzyCat',
+};
 
 export default function OwnerLoginPage() {
   return (

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,7 +1,12 @@
 import { Building2, User } from 'lucide-react';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { LoginForm } from './login-form';
+
+export const metadata: Metadata = {
+  title: 'Log In | FuzzyCat',
+};
 
 export default async function LoginPage({
   searchParams,

--- a/app/(auth)/mfa/setup/layout.tsx
+++ b/app/(auth)/mfa/setup/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Set Up MFA | FuzzyCat',
+};
+
+export default function MfaSetupLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/(auth)/mfa/verify/layout.tsx
+++ b/app/(auth)/mfa/verify/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Verify MFA | FuzzyCat',
+};
+
+export default function MfaVerifyLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/(auth)/reset-password/layout.tsx
+++ b/app/(auth)/reset-password/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Reset Password | FuzzyCat',
+};
+
+export default function ResetPasswordLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/(auth)/signup/clinic/layout.tsx
+++ b/app/(auth)/signup/clinic/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Clinic Registration | FuzzyCat',
+};
+
+export default function ClinicSignupLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/(auth)/signup/owner/layout.tsx
+++ b/app/(auth)/signup/owner/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Pet Owner Sign Up | FuzzyCat',
+};
+
+export default function OwnerSignupLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -1,7 +1,12 @@
 import { Building2, User } from 'lucide-react';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { SignupForm } from './signup-form';
+
+export const metadata: Metadata = {
+  title: 'Sign Up | FuzzyCat',
+};
 
 export default function SignupPage() {
   return (

--- a/app/admin/clinics/page.tsx
+++ b/app/admin/clinics/page.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from 'next';
 import { ClinicList } from './_components/clinic-list';
+
+export const metadata: Metadata = {
+  title: 'Clinics | FuzzyCat Admin',
+};
 
 export default function AdminClinicsPage() {
   return (

--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import { Suspense } from 'react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { FailedPaymentsBanner } from './_components/failed-payments-banner';
@@ -6,6 +7,10 @@ import { PlatformStats } from './_components/platform-stats';
 import { RecentActivity } from './_components/recent-activity';
 import { RecentClaims } from './_components/recent-claims';
 import { RecentClinics } from './_components/recent-clinics';
+
+export const metadata: Metadata = {
+  title: 'Admin | FuzzyCat',
+};
 
 function WidgetSkeleton({ className }: { className?: string }) {
   return <Skeleton className={className ?? 'h-64 w-full'} />;

--- a/app/admin/payments/page.tsx
+++ b/app/admin/payments/page.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from 'next';
 import { PaymentList } from './_components/payment-list';
+
+export const metadata: Metadata = {
+  title: 'Payments | FuzzyCat Admin',
+};
 
 export default function AdminPaymentsPage() {
   return (

--- a/app/admin/risk/page.tsx
+++ b/app/admin/risk/page.tsx
@@ -1,7 +1,12 @@
+import type { Metadata } from 'next';
 import { DefaultedPlansList } from './_components/defaulted-plans-list';
 import { RiskPoolDashboard } from './_components/risk-pool-dashboard';
 import { RiskPoolHistory } from './_components/risk-pool-history';
 import { SoftCollectionsList } from './_components/soft-collections-list';
+
+export const metadata: Metadata = {
+  title: 'Platform Reserve | FuzzyCat Admin',
+};
 
 export default function AdminRiskPage() {
   return (

--- a/app/clinic/clients/[clientId]/layout.tsx
+++ b/app/clinic/clients/[clientId]/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Client Details | FuzzyCat',
+};
+
+export default function ClientDetailLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/clinic/clients/[clientId]/plans/[planId]/layout.tsx
+++ b/app/clinic/clients/[clientId]/plans/[planId]/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Plan Details | FuzzyCat',
+};
+
+export default function PlanDetailLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/clinic/clients/page.tsx
+++ b/app/clinic/clients/page.tsx
@@ -1,7 +1,12 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { ClientList } from './_components/client-list';
 import { ClientStats } from './_components/client-stats';
+
+export const metadata: Metadata = {
+  title: 'Clients | FuzzyCat',
+};
 
 export default function ClinicClientsPage() {
   return (

--- a/app/clinic/dashboard/page.tsx
+++ b/app/clinic/dashboard/page.tsx
@@ -1,8 +1,13 @@
 import { HydrationBoundary } from '@tanstack/react-query';
+import type { Metadata } from 'next';
 import { createServerHelpers } from '@/lib/trpc/server';
 import { DashboardContent } from './_components/dashboard-content';
 import { InitiateEnrollmentButton } from './_components/initiate-enrollment-button';
 import { RevenueTable } from './_components/revenue-table';
+
+export const metadata: Metadata = {
+  title: 'Clinic Dashboard | FuzzyCat',
+};
 
 export default async function ClinicDashboardPage() {
   const { trpc, queryClient, dehydrate } = await createServerHelpers();

--- a/app/clinic/enroll/layout.tsx
+++ b/app/clinic/enroll/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Initiate Enrollment | FuzzyCat',
+};
+
+export default function ClinicEnrollLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/clinic/payouts/page.tsx
+++ b/app/clinic/payouts/page.tsx
@@ -1,5 +1,10 @@
+import type { Metadata } from 'next';
 import { PayoutEarnings } from './_components/payout-earnings';
 import { PayoutHistory } from './_components/payout-history';
+
+export const metadata: Metadata = {
+  title: 'Payouts | FuzzyCat',
+};
 
 export default function ClinicPayoutsPage() {
   return (

--- a/app/clinic/reports/page.tsx
+++ b/app/clinic/reports/page.tsx
@@ -1,7 +1,12 @@
+import type { Metadata } from 'next';
 import { DefaultRateCard } from './_components/default-rate-card';
 import { EnrollmentTrends } from './_components/enrollment-trends';
 import { ExportButtons } from './_components/export-buttons';
 import { RevenueReport } from './_components/revenue-report';
+
+export const metadata: Metadata = {
+  title: 'Reports | FuzzyCat',
+};
 
 export default function ClinicReportsPage() {
   return (

--- a/app/clinic/settings/page.tsx
+++ b/app/clinic/settings/page.tsx
@@ -1,7 +1,12 @@
+import type { Metadata } from 'next';
 import { isMfaEnabled } from '@/lib/supabase/mfa';
 import { ClinicProfileForm } from './_components/clinic-profile-form';
 import { MfaSettingsSection } from './_components/mfa-settings-section';
 import { StripeConnectSection } from './_components/stripe-connect-section';
+
+export const metadata: Metadata = {
+  title: 'Clinic Settings | FuzzyCat',
+};
 
 export default function ClinicSettingsPage() {
   return (

--- a/app/owner/enroll/layout.tsx
+++ b/app/owner/enroll/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Enroll | FuzzyCat',
+};
+
+export default function EnrollLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/owner/enroll/success/layout.tsx
+++ b/app/owner/enroll/success/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Enrollment Success | FuzzyCat',
+};
+
+export default function EnrollSuccessLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/owner/payments/page.tsx
+++ b/app/owner/payments/page.tsx
@@ -1,9 +1,14 @@
 import { HydrationBoundary } from '@tanstack/react-query';
+import type { Metadata } from 'next';
 import { createServerHelpers } from '@/lib/trpc/server';
 import { DashboardSummary } from './_components/dashboard-summary';
 import { PlanList } from './_components/plan-list';
 import { QuickLinks } from './_components/quick-links';
 import { RecentPayments } from './_components/recent-payments';
+
+export const metadata: Metadata = {
+  title: 'Dashboard | FuzzyCat',
+};
 
 export default async function OwnerPaymentsPage() {
   const { trpc, queryClient, dehydrate } = await createServerHelpers();

--- a/app/owner/plans/[planId]/page.tsx
+++ b/app/owner/plans/[planId]/page.tsx
@@ -1,6 +1,11 @@
 import { HydrationBoundary } from '@tanstack/react-query';
+import type { Metadata } from 'next';
 import { createServerHelpers } from '@/lib/trpc/server';
 import { PlanDetailContent } from './_components/plan-detail-content';
+
+export const metadata: Metadata = {
+  title: 'Plan Details | FuzzyCat',
+};
 
 export default async function OwnerPlanDetailPage({
   params,

--- a/app/owner/plans/page.tsx
+++ b/app/owner/plans/page.tsx
@@ -1,6 +1,11 @@
 import { HydrationBoundary } from '@tanstack/react-query';
+import type { Metadata } from 'next';
 import { createServerHelpers } from '@/lib/trpc/server';
 import { PlansContent } from './_components/plans-content';
+
+export const metadata: Metadata = {
+  title: 'My Plans | FuzzyCat',
+};
 
 export default async function OwnerPlansPage() {
   const { trpc, queryClient, dehydrate } = await createServerHelpers();

--- a/app/owner/settings/page.tsx
+++ b/app/owner/settings/page.tsx
@@ -1,6 +1,11 @@
+import type { Metadata } from 'next';
 import { ActivePlansSection } from './_components/active-plans-section';
 import { PaymentMethodSection } from './_components/payment-method-section';
 import { ProfileForm } from './_components/profile-form';
+
+export const metadata: Metadata = {
+  title: 'Settings | FuzzyCat',
+};
 
 export default function OwnerSettingsPage() {
   return (


### PR DESCRIPTION
## Summary

- Adds unique, descriptive `<title>` metadata to all 28 pages across owner, clinic, admin portals and auth flows
- Server component pages export `metadata` directly from `page.tsx`
- Client component pages (`'use client'`) get metadata via a new sibling `layout.tsx` since Next.js does not allow metadata exports from client components

Closes #264

## Page Titles Added

### Owner Portal
| Page | Title |
|------|-------|
| `/owner/payments` | Dashboard \| FuzzyCat |
| `/owner/plans` | My Plans \| FuzzyCat |
| `/owner/plans/[planId]` | Plan Details \| FuzzyCat |
| `/owner/settings` | Settings \| FuzzyCat |
| `/owner/enroll` | Enroll \| FuzzyCat |
| `/owner/enroll/success` | Enrollment Success \| FuzzyCat |

### Clinic Portal
| Page | Title |
|------|-------|
| `/clinic/dashboard` | Clinic Dashboard \| FuzzyCat |
| `/clinic/clients` | Clients \| FuzzyCat |
| `/clinic/clients/[clientId]` | Client Details \| FuzzyCat |
| `/clinic/clients/.../[planId]` | Plan Details \| FuzzyCat |
| `/clinic/payouts` | Payouts \| FuzzyCat |
| `/clinic/reports` | Reports \| FuzzyCat |
| `/clinic/settings` | Clinic Settings \| FuzzyCat |
| `/clinic/enroll` | Initiate Enrollment \| FuzzyCat |

### Admin Portal
| Page | Title |
|------|-------|
| `/admin/dashboard` | Admin \| FuzzyCat |
| `/admin/clinics` | Clinics \| FuzzyCat Admin |
| `/admin/payments` | Payments \| FuzzyCat Admin |
| `/admin/risk` | Platform Reserve \| FuzzyCat Admin |

### Auth Pages
| Page | Title |
|------|-------|
| `/login` | Log In \| FuzzyCat |
| `/login/clinic` | Clinic Login \| FuzzyCat |
| `/login/owner` | Pet Owner Login \| FuzzyCat |
| `/signup` | Sign Up \| FuzzyCat |
| `/signup/owner` | Pet Owner Sign Up \| FuzzyCat |
| `/signup/clinic` | Clinic Registration \| FuzzyCat |
| `/forgot-password` | Forgot Password \| FuzzyCat |
| `/reset-password` | Reset Password \| FuzzyCat |
| `/mfa/verify` | Verify MFA \| FuzzyCat |
| `/mfa/setup` | Set Up MFA \| FuzzyCat |

## Test plan

- [x] `bun run test` — 601 tests pass
- [x] `bun run check` — Biome lint clean
- [x] `bun run typecheck` — TypeScript clean
- [ ] Verify page titles render correctly in browser tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)