### PR TITLE
feat: add privacy, terms, support, and API docs pages

### DIFF
--- a/app/(marketing)/api-docs/page.tsx
+++ b/app/(marketing)/api-docs/page.tsx
@@ -1,0 +1,54 @@
+import { Code2, Mail } from 'lucide-react';
+import type { Metadata } from 'next';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+
+export const metadata: Metadata = {
+  title: 'API Documentation',
+  description:
+    'FuzzyCat API documentation for veterinary clinic integrations. Contact us for API access and integration support.',
+};
+
+export default function ApiDocsPage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
+      <div className="text-center">
+        <h1 className="text-4xl font-bold tracking-tight">API Documentation</h1>
+        <p className="mt-3 text-lg text-muted-foreground">
+          Integrate FuzzyCat payment plans into your veterinary practice management system.
+        </p>
+      </div>
+
+      <Separator className="my-10" />
+
+      <Card className="text-center">
+        <CardHeader>
+          <div className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+            <Code2 className="h-6 w-6" />
+          </div>
+          <CardTitle className="text-xl">Coming Soon</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-muted-foreground">
+            We are building a REST API that will allow veterinary practice management systems to
+            create payment plans, check plan status, and receive webhook notifications directly from
+            their existing software.
+          </p>
+          <p className="text-muted-foreground">
+            If you are interested in early access or have integration requirements, our team would
+            love to hear from you.
+          </p>
+          <div className="flex items-center justify-center pt-2">
+            <a href="mailto:support@fuzzycatapp.com?subject=API%20Integration%20Inquiry">
+              <Button>
+                <Mail className="mr-2 h-4 w-4" />
+                Contact Us for API Access
+              </Button>
+            </a>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/(marketing)/privacy/page.tsx
+++ b/app/(marketing)/privacy/page.tsx
@@ -1,0 +1,203 @@
+import type { Metadata } from 'next';
+import { Separator } from '@/components/ui/separator';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy',
+  description:
+    'FuzzyCat Privacy Policy. Learn how we collect, use, and protect your personal information.',
+};
+
+export default function PrivacyPolicyPage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
+      <h1 className="text-4xl font-bold tracking-tight">Privacy Policy</h1>
+      <p className="mt-3 text-sm text-muted-foreground">Last updated: February 1, 2026</p>
+
+      <Separator className="my-8" />
+
+      <div className="prose prose-neutral dark:prose-invert max-w-none space-y-8 text-sm leading-relaxed text-muted-foreground">
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">1. Introduction</h2>
+          <p className="mt-3">
+            FuzzyCat (&quot;we,&quot; &quot;us,&quot; or &quot;our&quot;) operates the FuzzyCat
+            payment facilitation platform at fuzzycatapp.com. This Privacy Policy explains how we
+            collect, use, disclose, and safeguard your personal information when you use our website
+            and services. By using FuzzyCat, you consent to the practices described in this policy.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">2. Information We Collect</h2>
+          <p className="mt-3">We collect the following categories of information:</p>
+          <ul className="mt-3 list-disc space-y-2 pl-6">
+            <li>
+              <strong className="text-foreground">Account information:</strong> Name, email address,
+              phone number, and role (pet owner or veterinary clinic) provided during registration.
+            </li>
+            <li>
+              <strong className="text-foreground">Financial information:</strong> We use Stripe to
+              process debit card payments and ACH transfers, and Plaid to verify bank account
+              ownership. FuzzyCat does not store your card numbers, bank account numbers, or routing
+              numbers on our servers. All payment credentials are handled directly by Stripe and
+              Plaid in compliance with PCI DSS standards.
+            </li>
+            <li>
+              <strong className="text-foreground">Payment plan data:</strong> Bill amounts, payment
+              schedules, payment statuses, and transaction history associated with your plans.
+            </li>
+            <li>
+              <strong className="text-foreground">Usage data:</strong> Pages visited, features used,
+              browser type, device type, IP address, and referring URLs collected automatically
+              through cookies and analytics tools.
+            </li>
+            <li>
+              <strong className="text-foreground">Communications:</strong> Records of support
+              inquiries, emails, and any other correspondence with us.
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">3. How We Use Your Information</h2>
+          <p className="mt-3">We use the information we collect to:</p>
+          <ul className="mt-3 list-disc space-y-2 pl-6">
+            <li>Create and manage your account and payment plans.</li>
+            <li>Process payments, including deposits and biweekly installments.</li>
+            <li>
+              Verify your bank account through Plaid to ensure you can make scheduled payments.
+            </li>
+            <li>
+              Send payment confirmations, reminders, and notifications about your plan status.
+            </li>
+            <li>Facilitate clinic payouts via Stripe Connect.</li>
+            <li>Respond to support requests and communicate with you about our services.</li>
+            <li>
+              Improve our platform, analyze usage patterns, and monitor performance using tools such
+              as PostHog and Sentry.
+            </li>
+            <li>Comply with legal obligations and prevent fraud.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">
+            4. How We Share Your Information
+          </h2>
+          <p className="mt-3">
+            We do not sell your personal information. We share information only in the following
+            circumstances:
+          </p>
+          <ul className="mt-3 list-disc space-y-2 pl-6">
+            <li>
+              <strong className="text-foreground">Payment processors:</strong> Stripe processes your
+              payments and receives the data necessary to complete transactions. Plaid verifies your
+              bank account ownership.
+            </li>
+            <li>
+              <strong className="text-foreground">Veterinary clinics:</strong> If you are a pet
+              owner, we share your name, plan status, and payment progress with the veterinary
+              clinic associated with your plan so they can track receivables.
+            </li>
+            <li>
+              <strong className="text-foreground">Service providers:</strong> We use Supabase for
+              authentication and data storage, Resend for transactional email, Twilio for SMS
+              notifications, and Vercel for hosting. These providers process data on our behalf
+              under contractual obligations.
+            </li>
+            <li>
+              <strong className="text-foreground">Legal requirements:</strong> We may disclose
+              information if required by law, regulation, legal process, or governmental request.
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">5. Data Security</h2>
+          <p className="mt-3">
+            We implement industry-standard security measures to protect your information. All data
+            transmitted between your browser and our servers is encrypted using TLS. Sensitive
+            financial data is handled exclusively by PCI-compliant third parties (Stripe and Plaid)
+            and is never stored on our servers. We use Supabase Auth with role-based access controls
+            and enforce Content Security Policy headers to prevent cross-site scripting attacks.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">6. Cookies and Analytics</h2>
+          <p className="mt-3">
+            We use cookies and similar technologies to maintain your session, remember your
+            preferences, and analyze how our platform is used. We use PostHog for product analytics
+            and Sentry for error monitoring. You can control cookie settings through your browser
+            preferences, though disabling cookies may affect the functionality of our platform.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">7. Data Retention</h2>
+          <p className="mt-3">
+            We retain your personal information for as long as your account is active or as needed
+            to provide services, comply with legal obligations, resolve disputes, and enforce our
+            agreements. Payment plan records and audit logs are retained for a minimum of seven
+            years to comply with financial record-keeping requirements.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">8. Your Rights</h2>
+          <p className="mt-3">Depending on your jurisdiction, you may have the right to:</p>
+          <ul className="mt-3 list-disc space-y-2 pl-6">
+            <li>Access the personal information we hold about you.</li>
+            <li>Request correction of inaccurate information.</li>
+            <li>
+              Request deletion of your personal information, subject to legal retention
+              requirements.
+            </li>
+            <li>Opt out of marketing communications at any time.</li>
+            <li>Request a copy of your data in a portable format.</li>
+          </ul>
+          <p className="mt-3">
+            To exercise any of these rights, contact us at{' '}
+            <a href="mailto:privacy@fuzzycatapp.com" className="text-primary hover:underline">
+              privacy@fuzzycatapp.com
+            </a>
+            .
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">9. Children&apos;s Privacy</h2>
+          <p className="mt-3">
+            FuzzyCat is not intended for use by individuals under the age of 18. We do not knowingly
+            collect personal information from children. If we become aware that we have collected
+            information from a minor, we will take steps to delete it promptly.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">10. Changes to This Policy</h2>
+          <p className="mt-3">
+            We may update this Privacy Policy from time to time. We will notify you of material
+            changes by posting the updated policy on this page and updating the &quot;Last
+            updated&quot; date. Your continued use of FuzzyCat after changes are posted constitutes
+            acceptance of the revised policy.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">11. Contact Us</h2>
+          <p className="mt-3">
+            If you have questions about this Privacy Policy or our data practices, contact us at:
+          </p>
+          <p className="mt-3">
+            <strong className="text-foreground">FuzzyCat</strong>
+            <br />
+            Email:{' '}
+            <a href="mailto:privacy@fuzzycatapp.com" className="text-primary hover:underline">
+              privacy@fuzzycatapp.com
+            </a>
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/(marketing)/support/page.tsx
+++ b/app/(marketing)/support/page.tsx
@@ -1,0 +1,174 @@
+import { Mail, MessageCircle } from 'lucide-react';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+
+export const metadata: Metadata = {
+  title: 'Support',
+  description:
+    'Get help with your FuzzyCat payment plan. Find answers to common questions or contact our support team.',
+};
+
+export default function SupportPage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
+      <div className="text-center">
+        <h1 className="text-4xl font-bold tracking-tight">Help &amp; Support</h1>
+        <p className="mt-3 text-lg text-muted-foreground">
+          Find answers to common questions or get in touch with our support team.
+        </p>
+      </div>
+
+      <Separator className="my-10" />
+
+      {/* FAQ Section */}
+      <section>
+        <h2 className="text-2xl font-bold tracking-tight">Frequently Asked Questions</h2>
+        <div className="mt-6">
+          <Accordion type="single" collapsible className="w-full">
+            <AccordionItem value="how-payments-work">
+              <AccordionTrigger>How do payment plans work?</AccordionTrigger>
+              <AccordionContent>
+                When you enroll in a FuzzyCat payment plan, you pay a 25% deposit upfront via debit
+                card. The remaining 75% is divided into 6 equal biweekly payments that are
+                automatically deducted from your bank account via ACH. Your plan is completed in 12
+                weeks. A flat 6% platform fee is added to your bill &mdash; there is no interest and
+                no credit check.
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="missed-payment">
+              <AccordionTrigger>What happens if I miss a payment?</AccordionTrigger>
+              <AccordionContent>
+                If a payment fails, we automatically retry up to 3 times with retries aligned to
+                common paydays. You will receive reminders via email and SMS at day 1, 7, and 14.
+                There are no late fees. If all retries fail, the plan is marked as defaulted and the
+                clinic is notified.
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="change-bank">
+              <AccordionTrigger>Can I change my bank account after enrolling?</AccordionTrigger>
+              <AccordionContent>
+                If you need to update your bank account, please contact our support team at{' '}
+                <a href="mailto:support@fuzzycatapp.com" className="text-primary hover:underline">
+                  support@fuzzycatapp.com
+                </a>{' '}
+                and we will help you through the process. For security, bank account changes require
+                verification.
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="cancel-plan">
+              <AccordionTrigger>Can I cancel my payment plan?</AccordionTrigger>
+              <AccordionContent>
+                Payment plans cannot be cancelled once the deposit has been processed, as the funds
+                have already been forwarded to the veterinary clinic. If you are experiencing
+                financial difficulty, please contact us and we will work with you to find a
+                solution.
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="payment-schedule">
+              <AccordionTrigger>When are my payments due?</AccordionTrigger>
+              <AccordionContent>
+                Your payment dates are set when you enroll and occur every two weeks. You can view
+                your full payment schedule in your owner portal under the plan details page. You
+                will also receive email reminders before each payment.
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="clinic-signup">
+              <AccordionTrigger>How does my clinic sign up for FuzzyCat?</AccordionTrigger>
+              <AccordionContent>
+                Veterinary clinics can register at{' '}
+                <Link href="/signup/clinic" className="text-primary hover:underline">
+                  fuzzycatapp.com/signup/clinic
+                </Link>
+                . After registration, clinics complete Stripe Connect onboarding to receive payouts.
+                There are no setup fees or contracts &mdash; clinics earn a 3% revenue share on
+                every enrollment.
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="data-security">
+              <AccordionTrigger>Is my financial information secure?</AccordionTrigger>
+              <AccordionContent>
+                Yes. FuzzyCat never stores your card numbers, bank account numbers, or routing
+                numbers. All payment processing is handled by Stripe (PCI DSS Level 1 certified) and
+                bank verification is handled by Plaid. Your data is encrypted in transit and at
+                rest.
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="receipt">
+              <AccordionTrigger>How do I get a receipt for my payments?</AccordionTrigger>
+              <AccordionContent>
+                You receive an email confirmation after each successful payment. You can also view
+                your complete payment history and download receipts from your owner portal at any
+                time.
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        </div>
+      </section>
+
+      <Separator className="my-10" />
+
+      {/* Contact Section */}
+      <section>
+        <h2 className="text-2xl font-bold tracking-tight">Contact Us</h2>
+        <p className="mt-3 text-muted-foreground">
+          Can&apos;t find what you&apos;re looking for? Our support team is here to help.
+        </p>
+        <div className="mt-6 grid gap-6 sm:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <Mail className="h-5 w-5" />
+              </div>
+              <CardTitle className="text-lg">Email Support</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Send us an email and we will respond within one business day.
+              </p>
+              <a href="mailto:support@fuzzycatapp.com">
+                <Button variant="outline" className="mt-4 w-full">
+                  support@fuzzycatapp.com
+                </Button>
+              </a>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <MessageCircle className="h-5 w-5" />
+              </div>
+              <CardTitle className="text-lg">Help Center</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Learn more about how FuzzyCat works, including payment details and clinic
+                information.
+              </p>
+              <Link href="/how-it-works">
+                <Button variant="outline" className="mt-4 w-full">
+                  How It Works
+                </Button>
+              </Link>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/(marketing)/terms/page.tsx
+++ b/app/(marketing)/terms/page.tsx
@@ -1,0 +1,233 @@
+import type { Metadata } from 'next';
+import { Separator } from '@/components/ui/separator';
+
+export const metadata: Metadata = {
+  title: 'Terms of Service',
+  description:
+    'FuzzyCat Terms of Service. Read the terms and conditions governing your use of the FuzzyCat payment plan platform.',
+};
+
+export default function TermsOfServicePage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
+      <h1 className="text-4xl font-bold tracking-tight">Terms of Service</h1>
+      <p className="mt-3 text-sm text-muted-foreground">Last updated: February 1, 2026</p>
+
+      <Separator className="my-8" />
+
+      <div className="prose prose-neutral dark:prose-invert max-w-none space-y-8 text-sm leading-relaxed text-muted-foreground">
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">1. Acceptance of Terms</h2>
+          <p className="mt-3">
+            By accessing or using the FuzzyCat platform at fuzzycatapp.com (&quot;Service&quot;),
+            you agree to be bound by these Terms of Service (&quot;Terms&quot;). If you do not agree
+            to these Terms, do not use the Service. These Terms constitute a legally binding
+            agreement between you and FuzzyCat (&quot;we,&quot; &quot;us,&quot; or &quot;our&quot;).
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">2. Service Description</h2>
+          <p className="mt-3">
+            FuzzyCat is a payment facilitation platform that enables pet owners to pay veterinary
+            bills in biweekly installments over 12 weeks. FuzzyCat is not a lender. We do not extend
+            credit, charge interest, or perform credit checks. We facilitate the scheduling and
+            processing of payments between pet owners and veterinary clinics using third-party
+            payment processors.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">3. Eligibility</h2>
+          <p className="mt-3">To use FuzzyCat, you must:</p>
+          <ul className="mt-3 list-disc space-y-2 pl-6">
+            <li>Be at least 18 years of age.</li>
+            <li>
+              Be a resident of the United States (excluding New York, pending regulatory review).
+            </li>
+            <li>Have a valid debit card and a U.S. bank account capable of ACH transactions.</li>
+            <li>Provide accurate and complete information during registration and enrollment.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">4. Payment Plans</h2>
+          <p className="mt-3">
+            When you enroll in a FuzzyCat payment plan, the following terms apply:
+          </p>
+          <ul className="mt-3 list-disc space-y-2 pl-6">
+            <li>
+              <strong className="text-foreground">Bill range:</strong> Payment plans are available
+              for veterinary bills between $500 and $25,000.
+            </li>
+            <li>
+              <strong className="text-foreground">Platform fee:</strong> A flat 6% platform fee is
+              added to your bill amount. This fee is disclosed before you confirm enrollment.
+            </li>
+            <li>
+              <strong className="text-foreground">Deposit:</strong> 25% of the total amount
+              (including the platform fee) is charged immediately to your debit card upon
+              enrollment.
+            </li>
+            <li>
+              <strong className="text-foreground">Installments:</strong> The remaining 75% is
+              divided into 6 equal biweekly payments deducted automatically via ACH from your
+              connected bank account.
+            </li>
+            <li>
+              <strong className="text-foreground">Payment schedule:</strong> Installment dates are
+              set at enrollment and occur every two weeks. You will receive reminders before each
+              scheduled payment.
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">5. Failed Payments and Default</h2>
+          <p className="mt-3">
+            If a scheduled payment fails (for example, due to insufficient funds):
+          </p>
+          <ul className="mt-3 list-disc space-y-2 pl-6">
+            <li>
+              We will automatically retry the payment up to 3 times, with retries aligned to common
+              paydays (the next Friday, 1st, or 15th of the month, at least 2 days out).
+            </li>
+            <li>
+              You will receive email and SMS reminders at day 1, 7, and 14 after the missed payment.
+            </li>
+            <li>There are no late fees or penalty charges.</li>
+            <li>
+              If all retry attempts fail, your plan will be marked as &quot;defaulted.&quot; In this
+              case, the veterinary clinic will be notified and may contact you directly to collect
+              the outstanding balance. FuzzyCat does not guarantee payment to clinics and is not
+              responsible for collection of defaulted plans.
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">6. Veterinary Clinic Terms</h2>
+          <p className="mt-3">If you are a veterinary clinic using FuzzyCat:</p>
+          <ul className="mt-3 list-disc space-y-2 pl-6">
+            <li>
+              You will receive payouts for each successful payment via Stripe Connect to your
+              connected bank account.
+            </li>
+            <li>
+              You will receive a 3% platform administration compensation on each enrollment, paid as
+              part of your payout schedule.
+            </li>
+            <li>
+              You are responsible for collecting any outstanding balance from pet owners whose plans
+              default. FuzzyCat does not guarantee payment from pet owners to clinics.
+            </li>
+            <li>
+              You must maintain an active Stripe Connect account in good standing to receive
+              payouts.
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">7. Account Responsibilities</h2>
+          <p className="mt-3">
+            You are responsible for maintaining the confidentiality of your account credentials and
+            for all activities that occur under your account. You agree to notify us immediately of
+            any unauthorized use of your account. You must provide accurate information and keep it
+            up to date.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">8. Prohibited Uses</h2>
+          <p className="mt-3">You agree not to:</p>
+          <ul className="mt-3 list-disc space-y-2 pl-6">
+            <li>Use the Service for any unlawful purpose or in violation of these Terms.</li>
+            <li>Provide false or misleading information during registration or enrollment.</li>
+            <li>
+              Attempt to interfere with, compromise, or disrupt the Service or its infrastructure.
+            </li>
+            <li>Use the Service on behalf of a third party without proper authorization.</li>
+            <li>Reverse-engineer, decompile, or disassemble any part of the Service.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">9. Intellectual Property</h2>
+          <p className="mt-3">
+            The FuzzyCat name, logo, and all content, features, and functionality of the Service are
+            owned by FuzzyCat and are protected by copyright, trademark, and other intellectual
+            property laws. You may not reproduce, distribute, or create derivative works from any
+            part of the Service without our prior written consent.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">10. Limitation of Liability</h2>
+          <p className="mt-3">
+            To the maximum extent permitted by applicable law, FuzzyCat shall not be liable for any
+            indirect, incidental, special, consequential, or punitive damages, including but not
+            limited to loss of profits, data, or business opportunities, arising from your use of
+            the Service. Our total liability for any claim arising from or related to the Service
+            shall not exceed the total platform fees you have paid to FuzzyCat in the 12 months
+            preceding the claim.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">11. Disclaimer of Warranties</h2>
+          <p className="mt-3">
+            The Service is provided &quot;as is&quot; and &quot;as available&quot; without
+            warranties of any kind, either express or implied. We do not warrant that the Service
+            will be uninterrupted, error-free, or secure. We do not guarantee payment between pet
+            owners and clinics.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">12. Governing Law</h2>
+          <p className="mt-3">
+            These Terms shall be governed by and construed in accordance with the laws of the State
+            of California, without regard to its conflict of law provisions. Any disputes arising
+            from these Terms or your use of the Service shall be resolved in the state or federal
+            courts located in San Francisco County, California.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">13. Changes to These Terms</h2>
+          <p className="mt-3">
+            We reserve the right to modify these Terms at any time. We will notify you of material
+            changes by posting the updated Terms on this page and updating the &quot;Last
+            updated&quot; date. Your continued use of the Service after changes are posted
+            constitutes acceptance of the revised Terms.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">14. Termination</h2>
+          <p className="mt-3">
+            We may suspend or terminate your access to the Service at any time for violation of
+            these Terms or for any other reason at our discretion. Upon termination, any outstanding
+            payment obligations remain in effect. You may close your account at any time by
+            contacting us, though this does not relieve you of any existing payment plan
+            obligations.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">15. Contact Us</h2>
+          <p className="mt-3">If you have questions about these Terms, contact us at:</p>
+          <p className="mt-3">
+            <strong className="text-foreground">FuzzyCat</strong>
+            <br />
+            Email:{' '}
+            <a href="mailto:legal@fuzzycatapp.com" className="text-primary hover:underline">
+              legal@fuzzycatapp.com
+            </a>
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -14,6 +14,10 @@ const AUTH_PAGES = ['/login', '/signup'];
 const STATIC_ROUTES = new Set([
   '/',
   '/how-it-works',
+  '/privacy',
+  '/terms',
+  '/support',
+  '/api-docs',
   '/signup',
   '/signup/owner',
   '/signup/clinic',


### PR DESCRIPTION
## Summary
- Create four new pages under `app/(marketing)/` to resolve 404 errors from footer links: `/privacy`, `/terms`, `/support`, `/api-docs`
- Add all four routes to `STATIC_ROUTES` in `middleware.ts` so they get the relaxed CSP (required for statically generated pages)
- Pages use the existing `(marketing)` layout with header/footer, matching the style of `/how-it-works`

## Details
Every page with the site-wide footer (marketing, owner portal, clinic portal, admin portal) was triggering 4 RSC prefetch 404 errors in the browser console. The `PortalFooter` component links to `/privacy`, `/terms`, `/api-docs`, and `/support`, and the marketing layout footer links to `/privacy` and `/terms`.

**New pages:**
- `/privacy` — Privacy Policy with sections on data collection, usage, sharing, security, cookies, data retention, and user rights. References Stripe, Plaid, Supabase, PostHog, Sentry, Resend, Twilio.
- `/terms` — Terms of Service with sections on service description, eligibility, payment terms (matching business rules), fees, default handling, clinic terms, limitation of liability, governing law (California).
- `/support` — Help & Support page with FAQ accordion and contact section (email: support@fuzzycatapp.com).
- `/api-docs` — API Documentation placeholder with "Coming Soon" card and contact CTA.

Closes #257

## Test plan
- [x] `bun run check` passes (Biome lint + format)
- [x] `bun run typecheck` passes (tsc --noEmit)
- [x] `bun run test` passes (601 tests, 0 failures)
- [ ] Verify each route renders: `/privacy`, `/terms`, `/support`, `/api-docs`
- [ ] Verify footer links navigate correctly from marketing pages
- [ ] Verify portal footer links navigate correctly from authenticated portals
- [ ] Verify no more 404 console errors on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)