### PR TITLE
fix: add coming soon placeholders to stub settings and payouts pages

### DIFF
--- a/app/clinic/payouts/page.tsx
+++ b/app/clinic/payouts/page.tsx
@@ -1,6 +1,12 @@
+import { CalendarDays, Clock, Landmark, TableProperties } from 'lucide-react';
 import type { Metadata } from 'next';
-import { PayoutEarnings } from './_components/payout-earnings';
-import { PayoutHistory } from './_components/payout-history';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+const PLANNED_FEATURES = [
+  { icon: TableProperties, label: 'View a detailed history of all payouts to your account' },
+  { icon: CalendarDays, label: 'See your upcoming payout schedule and expected amounts' },
+  { icon: Landmark, label: 'Manage your connected bank account for receiving payouts' },
+];
 
 export const metadata: Metadata = {
   title: 'Payouts | FuzzyCat',
@@ -16,8 +22,27 @@ export default function ClinicPayoutsPage() {
         </p>
       </div>
 
-      <PayoutEarnings />
-      <PayoutHistory />
+      <Card>
+        <CardHeader className="text-center pb-2">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+            <Clock className="h-6 w-6 text-muted-foreground" />
+          </div>
+          <CardTitle className="mt-4">Coming Soon</CardTitle>
+          <CardDescription>
+            We're building your payout tracking dashboard. These features will be available shortly.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ul className="space-y-3">
+            {PLANNED_FEATURES.map((feature) => (
+              <li key={feature.label} className="flex items-center gap-3 text-sm">
+                <feature.icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <span className="text-muted-foreground">{feature.label}</span>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/app/clinic/settings/page.tsx
+++ b/app/clinic/settings/page.tsx
@@ -1,8 +1,13 @@
+import { Building2, Clock, CreditCard, Shield, Users } from 'lucide-react';
 import type { Metadata } from 'next';
-import { isMfaEnabled } from '@/lib/supabase/mfa';
-import { ClinicProfileForm } from './_components/clinic-profile-form';
-import { MfaSettingsSection } from './_components/mfa-settings-section';
-import { StripeConnectSection } from './_components/stripe-connect-section';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+const PLANNED_FEATURES = [
+  { icon: Building2, label: 'Edit clinic name, address, and contact information' },
+  { icon: CreditCard, label: 'Manage your Stripe Connect payout account' },
+  { icon: Users, label: 'Add and manage staff accounts' },
+  { icon: Shield, label: 'Configure security and authentication settings' },
+];
 
 export const metadata: Metadata = {
   title: 'Clinic Settings | FuzzyCat',
@@ -18,10 +23,29 @@ export default function ClinicSettingsPage() {
         </p>
       </div>
 
-      <div className="mt-8 space-y-8">
-        <ClinicProfileForm />
-        <StripeConnectSection />
-        {isMfaEnabled() && <MfaSettingsSection />}
+      <div className="mt-8">
+        <Card>
+          <CardHeader className="text-center pb-2">
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+              <Clock className="h-6 w-6 text-muted-foreground" />
+            </div>
+            <CardTitle className="mt-4">Coming Soon</CardTitle>
+            <CardDescription>
+              We're building your clinic settings dashboard. These features will be available
+              shortly.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-3">
+              {PLANNED_FEATURES.map((feature) => (
+                <li key={feature.label} className="flex items-center gap-3 text-sm">
+                  <feature.icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <span className="text-muted-foreground">{feature.label}</span>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
       </div>
     </div>
   );

--- a/app/owner/settings/page.tsx
+++ b/app/owner/settings/page.tsx
@@ -1,7 +1,12 @@
+import { Bell, Clock, CreditCard, UserPen } from 'lucide-react';
 import type { Metadata } from 'next';
-import { ActivePlansSection } from './_components/active-plans-section';
-import { PaymentMethodSection } from './_components/payment-method-section';
-import { ProfileForm } from './_components/profile-form';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+const PLANNED_FEATURES = [
+  { icon: UserPen, label: 'Edit your name, email, and phone number' },
+  { icon: CreditCard, label: 'Manage your payment method (debit card or bank account)' },
+  { icon: Bell, label: 'Set notification preferences for payment reminders' },
+];
 
 export const metadata: Metadata = {
   title: 'Settings | FuzzyCat',
@@ -17,9 +22,28 @@ export default function OwnerSettingsPage() {
         </p>
       </div>
 
-      <ProfileForm />
-      <PaymentMethodSection />
-      <ActivePlansSection />
+      <Card>
+        <CardHeader className="text-center pb-2">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+            <Clock className="h-6 w-6 text-muted-foreground" />
+          </div>
+          <CardTitle className="mt-4">Coming Soon</CardTitle>
+          <CardDescription>
+            We're building your account settings experience. These features will be available
+            shortly.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ul className="space-y-3">
+            {PLANNED_FEATURES.map((feature) => (
+              <li key={feature.label} className="flex items-center gap-3 text-sm">
+                <feature.icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <span className="text-muted-foreground">{feature.label}</span>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Replaces non-functional component imports on three portal pages (`/owner/settings`, `/clinic/settings`, `/clinic/payouts`) with "Coming Soon" placeholder cards
- Each card shows a clock icon, "Coming Soon" heading, a brief description, and a list of planned features with contextual icons
- Pages now appear intentionally incomplete rather than broken

Closes #261

## Test plan

- [ ] Visit `/owner/settings` — should show "Coming Soon" card with profile editing, payment method management, and notification preferences listed
- [ ] Visit `/clinic/settings` — should show "Coming Soon" card with clinic info editing, Stripe Connect management, staff accounts, and security settings listed
- [ ] Visit `/clinic/payouts` — should show "Coming Soon" card with payout history, payout schedule, and bank account management listed
- [ ] `bun run check` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run test` passes (601 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)