### PR TITLE
fix: resolve React hydration mismatch on owner dashboard (#259)

### DIFF
--- a/app/clinic/dashboard/_components/revenue-table.tsx
+++ b/app/clinic/dashboard/_components/revenue-table.tsx
@@ -18,7 +18,7 @@ import { formatCents } from '@/lib/utils/money';
 function formatMonth(yyyyMm: string): string {
   const [year, month] = yyyyMm.split('-');
   const date = new Date(Number(year), Number(month) - 1, 1);
-  return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+  return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric', timeZone: 'UTC' });
 }
 
 export function RevenueTable() {

--- a/app/owner/__tests__/format-helpers.test.ts
+++ b/app/owner/__tests__/format-helpers.test.ts
@@ -26,34 +26,41 @@ const PAYMENT_STATUS_LABEL: Record<string, string> = {
 describe('formatDate', () => {
   it('formats a Date object', () => {
     const result = formatDate(new Date('2026-02-20T12:00:00Z'));
-    expect(result).toContain('Feb');
-    expect(result).toContain('2026');
-    expect(result).toContain('20');
+    expect(result).toBe('Feb 20, 2026');
   });
 
   it('formats a date string', () => {
     const result = formatDate('2026-12-25');
-    expect(result).toContain('Dec');
-    expect(result).toContain('25');
-    expect(result).toContain('2026');
+    expect(result).toBe('Dec 25, 2026');
   });
 
   it('returns em-dash for null', () => {
     expect(formatDate(null)).toBe('\u2014');
+  });
+
+  it('uses UTC to avoid timezone-dependent hydration mismatches', () => {
+    // A date near midnight UTC — in UTC+5 this would be the next day
+    // without the timeZone: 'UTC' option.
+    const result = formatDate('2026-03-15T23:30:00Z');
+    expect(result).toBe('Mar 15, 2026');
   });
 });
 
 describe('daysUntil', () => {
   it('returns positive number for future dates', () => {
     const futureDate = new Date();
-    futureDate.setDate(futureDate.getDate() + 5);
-    expect(daysUntil(futureDate)).toBeGreaterThan(0);
+    futureDate.setUTCDate(futureDate.getUTCDate() + 5);
+    expect(daysUntil(futureDate)).toBe(5);
   });
 
   it('returns negative number for past dates', () => {
     const pastDate = new Date();
-    pastDate.setDate(pastDate.getDate() - 3);
-    expect(daysUntil(pastDate)).toBeLessThan(0);
+    pastDate.setUTCDate(pastDate.getUTCDate() - 3);
+    expect(daysUntil(pastDate)).toBe(-3);
+  });
+
+  it('returns 0 for today', () => {
+    expect(daysUntil(new Date())).toBe(0);
   });
 });
 

--- a/app/owner/enroll/_components/step-bill-details.tsx
+++ b/app/owner/enroll/_components/step-bill-details.tsx
@@ -37,6 +37,7 @@ function formatDate(date: Date): string {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
+    timeZone: 'UTC',
   });
 }
 

--- a/app/owner/enroll/_components/step-review-confirm.tsx
+++ b/app/owner/enroll/_components/step-review-confirm.tsx
@@ -27,6 +27,7 @@ function formatDate(date: Date): string {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
+    timeZone: 'UTC',
   });
 }
 

--- a/app/owner/enroll/success/page.tsx
+++ b/app/owner/enroll/success/page.tsx
@@ -16,6 +16,7 @@ function formatDate(dateStr: string | Date): string {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
+    timeZone: 'UTC',
   });
 }
 

--- a/lib/utils/date.ts
+++ b/lib/utils/date.ts
@@ -3,6 +3,10 @@
 /**
  * Format a date value for display.
  *
+ * Uses an explicit UTC timezone so the formatted string is identical on
+ * server (typically UTC) and client (user's local timezone), avoiding
+ * React hydration mismatches.
+ *
  * @param date - Date object, ISO string, or null
  * @returns Formatted date string (e.g., "Feb 20, 2026") or an em-dash for null
  */
@@ -12,23 +16,26 @@ export function formatDate(date: Date | string | null): string {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
+    timeZone: 'UTC',
   });
 }
 
 /**
  * Calculate the number of days from today until a target date.
- * Both dates are normalized to midnight before comparison so
- * the result is independent of the current time of day.
+ *
+ * Uses UTC day boundaries so the result is identical on server and
+ * client regardless of local timezone, preventing React hydration
+ * mismatches.
  *
  * @param date - Target date
  * @returns Number of calendar days (positive = future, negative = past)
  */
 export function daysUntil(date: Date | string): number {
   const now = new Date();
-  now.setHours(0, 0, 0, 0);
+  const nowUtcDay = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
   const target = new Date(date);
-  target.setHours(0, 0, 0, 0);
-  return Math.ceil((target.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+  const targetUtcDay = Date.UTC(target.getUTCFullYear(), target.getUTCMonth(), target.getUTCDate());
+  return Math.round((targetUtcDay - nowUtcDay) / (1000 * 60 * 60 * 24));
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Root cause**: `toLocaleDateString()` calls and `daysUntil()` used local timezone, producing different text on server (UTC) vs client (user's timezone) — triggering React error #418 on every owner dashboard visit.
- **Fix**: Added explicit `timeZone: 'UTC'` to all `toLocaleDateString` calls across 6 files, and rewrote `daysUntil()` to use UTC day boundaries (`Date.UTC` + `getUTCFullYear/Month/Date`).
- **Scope**: Core `lib/utils/date.ts` (used by 20+ components) plus 3 local `formatDate` functions in enrollment pages and 1 `formatMonth` in the clinic revenue table.

## Files changed

| File | Change |
|------|--------|
| `lib/utils/date.ts` | Added `timeZone: 'UTC'` to `formatDate`, rewrote `daysUntil` to use UTC boundaries |
| `app/owner/enroll/success/page.tsx` | Added `timeZone: 'UTC'` to local `formatDate` |
| `app/owner/enroll/_components/step-review-confirm.tsx` | Added `timeZone: 'UTC'` to local `formatDate` |
| `app/owner/enroll/_components/step-bill-details.tsx` | Added `timeZone: 'UTC'` to local `formatDate` |
| `app/clinic/dashboard/_components/revenue-table.tsx` | Added `timeZone: 'UTC'` to `formatMonth` |
| `app/owner/__tests__/format-helpers.test.ts` | Tightened assertions to exact match, added UTC edge-case test |

## Test plan

- [x] All 603 unit tests pass (`bun run test`)
- [x] TypeScript compiles clean (`bun run typecheck`)
- [x] Biome lint + format passes (`bun run check`)
- [ ] Verify no hydration warnings in browser console on owner dashboard
- [ ] Verify dates still display correctly across all owner/clinic/admin pages

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)