### PR TITLE
fix: captcha test cross-contamination from missing server env vars

### DIFF
--- a/lib/__tests__/captcha.test.ts
+++ b/lib/__tests__/captcha.test.ts
@@ -3,16 +3,34 @@ import { verifyCaptcha } from '@/lib/captcha';
 import { _resetEnvCache } from '@/lib/env';
 
 describe('verifyCaptcha', () => {
-  const originalEnv = process.env.TURNSTILE_SECRET_KEY;
+  const originalEnv = { ...process.env };
   const originalFetch = globalThis.fetch;
 
   beforeEach(() => {
     _resetEnvCache();
+    // Set all required server env vars to prevent cross-contamination failures
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key';
+    process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+    process.env.STRIPE_SECRET_KEY = 'sk_test_123';
+    process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test_123';
+    process.env.RESEND_API_KEY = 're_test_123';
+    process.env.PLAID_CLIENT_ID = 'test-plaid-client';
+    process.env.PLAID_SECRET = 'test-plaid-secret';
+    process.env.PLAID_ENV = 'sandbox';
+    process.env.TWILIO_ACCOUNT_SID = 'ACtest123';
+    process.env.TWILIO_AUTH_TOKEN = 'test-twilio-token';
+    process.env.TWILIO_PHONE_NUMBER = '+15551234567';
     process.env.TURNSTILE_SECRET_KEY = 'test-secret-key';
   });
 
   afterEach(() => {
-    process.env.TURNSTILE_SECRET_KEY = originalEnv;
+    // Restore original env
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    Object.assign(process.env, originalEnv);
     _resetEnvCache();
     globalThis.fetch = originalFetch;
     mock.restore();


### PR DESCRIPTION
## Summary
- Set all required server env vars in captcha test `beforeEach` to prevent cross-contamination failures when test file ordering changes

## Context
The captcha test calls `verifyCaptcha()` which invokes `serverEnv()`, validating ALL server env vars. The test only set `TURNSTILE_SECRET_KEY`, so when other test files run first and reset the env cache, the captcha test fails with missing env var errors.

This was a pre-existing issue that became more visible after adding new test files in PRs #270-#279.

## Test plan
- [x] `bun run test` — captcha tests now pass regardless of file ordering
- [x] `bun run check` — Biome clean
- [x] `bun run typecheck` — TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)