### PR TITLE
fix: Plaid link token + CSP nonce propagation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
+import { headers } from 'next/headers';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Providers } from '@/lib/trpc/provider';
 import './globals.css';
@@ -27,15 +28,17 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const nonce = (await headers()).get('x-nonce') ?? undefined;
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <ThemeProvider>
+        <ThemeProvider nonce={nonce}>
           <Providers>{children}</Providers>
         </ThemeProvider>
         <Analytics />

--- a/server/services/plaid.ts
+++ b/server/services/plaid.ts
@@ -35,7 +35,7 @@ export async function createLinkToken(userId: string): Promise<string> {
   const response = await plaid().linkTokenCreate({
     user: { client_user_id: userId },
     client_name: 'FuzzyCat',
-    products: [Products.Auth, Products.Balance],
+    products: [Products.Auth],
     country_codes: [CountryCode.Us],
     language: 'en',
   });


### PR DESCRIPTION
## Summary
- **Plaid fix**: Remove `Products.Balance` from `linkTokenCreate` — Plaid API now auto-includes Balance when Auth is requested. The explicit inclusion was causing `INVALID_PRODUCT` error, breaking bank account setup on `/owner/settings`.
- **CSP fix**: Pass middleware nonce to ThemeProvider via `headers()` in root layout. This fixes the next-themes inline script CSP violation on dynamic routes.

## Test plan
- [ ] `bun run test` — 494 pass (8 pre-existing `next/headers` teardown failures)
- [ ] `bun run typecheck` — clean
- [ ] `bun run check` — clean
- [ ] Verify Plaid `createLinkToken` no longer returns 500 on `/owner/settings`
- [ ] Verify Bank Account option opens Plaid Link flow
- [ ] Verify CSP inline script violations reduced on navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)