### PR TITLE
chore: restrict Vercel deployments to main branch only

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -48,6 +48,11 @@
       "schedule": "0 7 * * *"
     }
   ],
+  "git": {
+    "deploymentEnabled": {
+      "main": true
+    }
+  },
   "github": {
     "silent": true
   }


### PR DESCRIPTION
## Summary

- Added `git.deploymentEnabled` to `vercel.json` to only deploy on pushes to `main`
- Disables all preview deployments for feature branches

## Why

We hit the Vercel free tier limit of 100 deployments/day. Root cause: ~30 PRs merged yesterday, each generating 2+ Vercel builds (1 preview + 1 production). GitHub Actions CI already validates builds, types, lint, tests, and E2E — preview deploys are redundant.

This cuts deployment volume by ~60%, leaving headroom for the parallel agent workflow.

## Test plan

- [x] `vercel.json` is valid JSON
- [ ] Verify next feature branch push does NOT trigger a Vercel preview deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)