### PR TITLE
fix: security headers, stale docs, console.error cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ bunx drizzle-kit generate        # Generate SQL migrations
 ## Security
 
 - **PCI SAQ A**: Servers never touch card data. Use Stripe Checkout and Plaid Link (both hosted). Never store PAN, CVV, bank account numbers, or routing numbers.
-- **Authorization**: All tRPC procedures guarded by `assertClinicOwnership()`, `assertPlanAccess()`, or `assertPlanOwnership()`.
+- **Authorization**: All tRPC procedures guarded by `assertClinicOwnership()` or `assertPlanAccess()`.
 - **CSP**: `'self' 'unsafe-inline' https:` for scripts via middleware. Nonce-based `strict-dynamic` was removed because Next.js SPA navigation injects inline scripts without nonces.
 - **Webhook verification**: Plaid via JWT validation, Stripe via signature verification. Stripe webhooks return 200 even on handler errors (prevents retry storms).
 - **MFA**: Feature-flagged via `ENABLE_MFA`. Enforced at middleware for clinic/admin routes.

--- a/app/(auth)/login/login-form.tsx
+++ b/app/(auth)/login/login-form.tsx
@@ -46,8 +46,7 @@ export function LoginForm({ redirectTo }: { redirectTo?: string }) {
       const destination = isSafeRedirect ? redirectTo : ROLE_HOME[role];
       router.push(destination);
       router.refresh();
-    } catch (error) {
-      console.error('Login form submission error:', error);
+    } catch {
       setError('Something went wrong. Please try again.');
     } finally {
       setLoading(false);

--- a/app/(auth)/signup/signup-form.tsx
+++ b/app/(auth)/signup/signup-form.tsx
@@ -47,8 +47,7 @@ export function SignupForm() {
 
       router.push(tab === 'owner' ? '/owner/payments' : '/clinic/dashboard');
       router.refresh();
-    } catch (error) {
-      console.error('Signup form submission error:', error);
+    } catch {
       setError('Something went wrong. Please try again.');
     } finally {
       setLoading(false);

--- a/authorization-matrix.test.ts
+++ b/authorization-matrix.test.ts
@@ -155,7 +155,6 @@ mock.module('@/lib/stripe', () => ({
 mock.module('@/server/services/authorization', () => ({
   assertClinicOwnership: mock(),
   assertPlanAccess: mock(() => Promise.resolve({ clinicId: 'c1', ownerId: 'o1' })),
-  assertPlanOwnership: mock(),
 }));
 mock.module('@/server/services/enrollment', () => ({
   createEnrollment: mock(),

--- a/middleware.ts
+++ b/middleware.ts
@@ -115,6 +115,9 @@ export async function middleware(request: NextRequest) {
       request: { headers: requestHeaders },
     });
     passThrough.headers.set('Content-Security-Policy', buildCspHeader());
+    passThrough.headers.set('X-Content-Type-Options', 'nosniff');
+    passThrough.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+    passThrough.headers.set('Permissions-Policy', 'geolocation=(), microphone=(), camera=()');
     return passThrough;
   }
 
@@ -207,6 +210,9 @@ export async function middleware(request: NextRequest) {
 
   const duration = performance.now() - startTime;
   supabaseResponse.headers.set('Server-Timing', `middleware;dur=${duration.toFixed(1)}`);
+  supabaseResponse.headers.set('X-Content-Type-Options', 'nosniff');
+  supabaseResponse.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+  supabaseResponse.headers.set('Permissions-Policy', 'geolocation=(), microphone=(), camera=()');
 
   return supabaseResponse;
 }


### PR DESCRIPTION
## Summary
- Add defense-in-depth security headers (`X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`) to middleware
- Fix CLAUDE.md referencing nonexistent `assertPlanOwnership()` — only `assertClinicOwnership()` and `assertPlanAccess()` exist
- Remove stale `assertPlanOwnership` mock from authorization-matrix test
- Remove `console.error()` in login/signup forms — errors are already shown to the user via state
- Delete stale `.env.local.tmp` leftover file

## Test plan
- [x] `bun run check` — Biome clean
- [x] `bun run typecheck` — zero errors
- [x] `bun run test` — 480 pass, 0 fail
- [x] `bun test middleware.test.ts` — 17 pass
- [x] `bun test authorization-matrix.test.ts` — 228 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)