### PR TITLE
fix: add ignoreCommand to stop Vercel preview deployments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -48,6 +48,7 @@
       "schedule": "0 7 * * *"
     }
   ],
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ]",
   "git": {
     "deploymentEnabled": {
       "main": true


### PR DESCRIPTION
## Summary
- Add `ignoreCommand` to `vercel.json` that exits 0 (skip) for non-main branches
- The existing `git.deploymentEnabled.main: true` wasn't fully preventing preview deploys — Vercel was still building feature branches (5+ preview deploys/hour visible in `vercel ls`)
- `ignoreCommand` is belt-and-suspenders: Vercel checks this command before starting any build. If it exits 0, the entire deployment is skipped
- Saves deployment quota (free tier: 100/day)

## How it works
```json
"ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ]"
```
- Branch is `main` → `[ "main" != "main" ]` → false → exit 1 → **build proceeds**
- Branch is anything else → `[ "feature" != "main" ]` → true → exit 0 → **build skipped**

## Test plan
- [x] Valid JSON (verified via `JSON.parse`)
- [x] `bun run check` — clean
- [ ] After merge, verify `vercel ls` shows no new Preview deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)