### PR TITLE
feat: replace favicon with lucide-cat icon

### DIFF
--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -7,19 +7,34 @@ export default function AppleIcon() {
   return new ImageResponse(
     <div
       style={{
-        fontSize: 120,
         background: '#0f172a',
         width: '100%',
         height: '100%',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        color: '#38bdf8',
         borderRadius: '32px',
-        fontWeight: 700,
+        padding: '24px',
       }}
     >
-      F
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="#38bdf8"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        width="132"
+        height="132"
+        role="img"
+        aria-label="FuzzyCat"
+      >
+        <path d="M12 5c.67 0 1.35.09 2 .26 1.78-2 5.03-2.84 6.42-2.26 1.4.58-.42 7-.42 7 .57 1.07 1 2.24 1 3.44C21 17.9 16.97 21 12 21s-9-3-9-7.56c0-1.25.5-2.4 1-3.44 0 0-1.89-6.42-.5-7 1.39-.58 4.72.23 6.5 2.23A9.04 9.04 0 0 1 12 5Z" />
+        <path d="M8 14v.5" />
+        <path d="M16 14v.5" />
+        <path d="M11.25 16.25h1.5L12 17l-.75-.75Z" />
+      </svg>
     </div>,
     { ...size },
   );

--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -7,19 +7,34 @@ export default function Icon() {
   return new ImageResponse(
     <div
       style={{
-        fontSize: 24,
         background: '#0f172a',
         width: '100%',
         height: '100%',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        color: '#38bdf8',
         borderRadius: '6px',
-        fontWeight: 700,
+        padding: '4px',
       }}
     >
-      F
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="#38bdf8"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        width="24"
+        height="24"
+        role="img"
+        aria-label="FuzzyCat"
+      >
+        <path d="M12 5c.67 0 1.35.09 2 .26 1.78-2 5.03-2.84 6.42-2.26 1.4.58-.42 7-.42 7 .57 1.07 1 2.24 1 3.44C21 17.9 16.97 21 12 21s-9-3-9-7.56c0-1.25.5-2.4 1-3.44 0 0-1.89-6.42-.5-7 1.39-.58 4.72.23 6.5 2.23A9.04 9.04 0 0 1 12 5Z" />
+        <path d="M8 14v.5" />
+        <path d="M16 14v.5" />
+        <path d="M11.25 16.25h1.5L12 17l-.75-.75Z" />
+      </svg>
     </div>,
     { ...size },
   );


### PR DESCRIPTION
## Summary
- Replace the generic "F" letter favicon with the lucide-cat SVG icon
- Both 32x32 (browser tab) and 180x180 (Apple touch icon) variants updated
- Sky blue (#38bdf8) cat on dark slate (#0f172a) background, matching brand colors

## Test plan
- [x] `bun run typecheck` — zero errors
- [x] `bun run check` — Biome clean
- [x] `bun run test` — 480 tests pass
- [x] Visual QA: verified `/icon` (32x32) and `/apple-icon` (180x180) render correctly via Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)