### PR TITLE
fix: security audit hardening — 5 targeted fixes

### DIFF
--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -28,15 +28,11 @@ export default function ForgotPasswordPage() {
       }
 
       const supabase = createClient();
-      const { error: resetError } = await supabase.auth.resetPasswordForEmail(email, {
+      await supabase.auth.resetPasswordForEmail(email, {
         redirectTo: `${window.location.origin}/reset-password`,
       });
 
-      if (resetError) {
-        setError(resetError.message);
-        return;
-      }
-
+      // Always show success to prevent user enumeration
       setSubmitted(true);
     } finally {
       setLoading(false);

--- a/app/(auth)/login/clinic/_components/clinic-login-form.tsx
+++ b/app/(auth)/login/clinic/_components/clinic-login-form.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { getUserRole, ROLE_HOME } from '@/lib/auth';
 import { createClient } from '@/lib/supabase/client';
+import { checkLoginRateLimit } from '../../actions';
 
 export function ClinicLoginForm() {
   const router = useRouter();
@@ -22,6 +23,12 @@ export function ClinicLoginForm() {
     setLoading(true);
 
     try {
+      const { error: rateLimitError } = await checkLoginRateLimit();
+      if (rateLimitError) {
+        setError(rateLimitError);
+        return;
+      }
+
       const supabase = createClient();
       const { data, error: signInError } = await supabase.auth.signInWithPassword({
         email,

--- a/app/(auth)/login/owner/_components/owner-login-form.tsx
+++ b/app/(auth)/login/owner/_components/owner-login-form.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { getUserRole, ROLE_HOME } from '@/lib/auth';
 import { createClient } from '@/lib/supabase/client';
+import { checkLoginRateLimit } from '../../actions';
 
 export function OwnerLoginForm() {
   const router = useRouter();
@@ -22,6 +23,12 @@ export function OwnerLoginForm() {
     setLoading(true);
 
     try {
+      const { error: rateLimitError } = await checkLoginRateLimit();
+      if (rateLimitError) {
+        setError(rateLimitError);
+        return;
+      }
+
       const supabase = createClient();
       const { data, error: signInError } = await supabase.auth.signInWithPassword({
         email,

--- a/middleware.ts
+++ b/middleware.ts
@@ -117,7 +117,10 @@ export async function middleware(request: NextRequest) {
     passThrough.headers.set('Content-Security-Policy', buildCspHeader());
     passThrough.headers.set('X-Content-Type-Options', 'nosniff');
     passThrough.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
-    passThrough.headers.set('Permissions-Policy', 'geolocation=(), microphone=(), camera=()');
+    passThrough.headers.set(
+      'Permissions-Policy',
+      'camera=(), geolocation=(), microphone=(), payment=()',
+    );
     return passThrough;
   }
 
@@ -212,7 +215,10 @@ export async function middleware(request: NextRequest) {
   supabaseResponse.headers.set('Server-Timing', `middleware;dur=${duration.toFixed(1)}`);
   supabaseResponse.headers.set('X-Content-Type-Options', 'nosniff');
   supabaseResponse.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
-  supabaseResponse.headers.set('Permissions-Policy', 'geolocation=(), microphone=(), camera=()');
+  supabaseResponse.headers.set(
+    'Permissions-Policy',
+    'camera=(), geolocation=(), microphone=(), payment=()',
+  );
 
   return supabaseResponse;
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,7 @@ const withBundleAnalyzer = bundleAnalyzer({
 });
 
 const nextConfig: NextConfig = {
+  poweredByHeader: false,
   experimental: {
     clientTraceMetadata: ['sentry-trace', 'baggage'],
     optimizePackageImports: [

--- a/server/routers/payment.ts
+++ b/server/routers/payment.ts
@@ -12,7 +12,7 @@ import { adminProcedure, ownerProcedure, router } from '@/server/trpc';
 /** Validate that a URL belongs to the app domain. */
 function isAppUrl(url: string): boolean {
   const appUrl = publicEnv().NEXT_PUBLIC_APP_URL;
-  if (!appUrl) return true; // Skip validation if app URL not configured
+  if (!appUrl) return false;
   try {
     const parsed = new URL(url);
     const appParsed = new URL(appUrl);

--- a/vercel.json
+++ b/vercel.json
@@ -12,7 +12,7 @@
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         {
           "key": "Permissions-Policy",
-          "value": "camera=(), microphone=(), geolocation=()"
+          "value": "camera=(), geolocation=(), microphone=(), payment=()"
         },
         {
           "key": "Strict-Transport-Security",


### PR DESCRIPTION
## Summary
Comprehensive security audit identified and fixed 5 actionable vulnerabilities:

- **Disable `X-Powered-By` header** — `next.config.ts` now sets `poweredByHeader: false` to stop leaking framework info
- **Fix open redirect in `isAppUrl()`** — Previously returned `true` when `NEXT_PUBLIC_APP_URL` was unset, allowing arbitrary redirect URLs. Now returns `false` (fail-closed)
- **Prevent user enumeration on password reset** — Always shows "check your email" regardless of whether the account exists, preventing attackers from probing valid emails
- **Add rate limiting to owner/clinic login forms** — The generic `/login` form had `checkLoginRateLimit()` but the role-specific forms (`/login/owner`, `/login/clinic`) did not, allowing brute-force bypass
- **Expand `Permissions-Policy`** — Added `payment=()` directive to both middleware and vercel.json headers

### Not fixed (intentional design / false positives):
- Rate limiter fail-open: Deliberate — Supabase Auth has infra-level rate limiting; blocking all users on Redis blip is worse
- Admin undefined ownerId: By design — admin can call owner procedures, empty results are safe
- Protocol-relative redirect: False positive — `//evil.com/clinic`.startsWith(`/clinic`) is `false`

## Test plan
- [x] `bun run typecheck` — zero errors
- [x] `bun run check` — Biome clean
- [x] `bun run test` — 480 tests pass
- [x] Isolated tests — 198 tests pass (12 files)
- [x] Middleware tests — 10 pass
- [x] Authorization matrix — 228 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)