### PR TITLE
fix: add ARIA attributes for WCAG 2.1 AA compliance

### DIFF
--- a/app/owner/enroll/_components/math-captcha.tsx
+++ b/app/owner/enroll/_components/math-captcha.tsx
@@ -88,7 +88,11 @@ export function MathCaptcha({ onVerified }: MathCaptchaProps) {
           <RefreshCw className="h-4 w-4" />
         </Button>
       </div>
-      {error && <p className="text-xs text-destructive">Incorrect answer. Please try again.</p>}
+      {error && (
+        <p role="alert" aria-live="polite" className="text-xs text-destructive">
+          Incorrect answer. Please try again.
+        </p>
+      )}
     </div>
   );
 }

--- a/app/owner/enroll/page.tsx
+++ b/app/owner/enroll/page.tsx
@@ -56,6 +56,9 @@ export default function OwnerEnrollPage() {
             {STEPS.map((step) => (
               <div key={step.number} className="flex flex-col items-center gap-1">
                 <div
+                  role="img"
+                  aria-label={`Step ${step.number}: ${step.label}`}
+                  aria-current={currentStep === step.number ? 'step' : undefined}
                   className={cn(
                     'flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium transition-colors',
                     currentStep === step.number
@@ -80,7 +83,11 @@ export default function OwnerEnrollPage() {
               </div>
             ))}
           </div>
-          <Progress value={progressPercent} className="h-2" />
+          <Progress
+            value={progressPercent}
+            className="h-2"
+            aria-label={`Enrollment progress: step ${currentStep} of ${STEPS.length}`}
+          />
           <p className="mt-2 text-center text-sm text-muted-foreground">
             Step {currentStep} of {STEPS.length}
           </p>

--- a/components/shared/numbered-pagination.tsx
+++ b/components/shared/numbered-pagination.tsx
@@ -69,6 +69,7 @@ export function NumberedPagination({
         className="h-8 w-8"
         onClick={() => onPageChange(currentPage - 1)}
         disabled={currentPage <= 1}
+        aria-label="Previous page"
       >
         <ChevronLeft className="h-4 w-4" />
       </Button>
@@ -84,6 +85,8 @@ export function NumberedPagination({
             size="icon"
             className="h-8 w-8"
             onClick={() => onPageChange(item.page)}
+            aria-label={`Page ${item.page}`}
+            aria-current={item.page === currentPage ? 'page' : undefined}
           >
             {item.page}
           </Button>
@@ -95,6 +98,7 @@ export function NumberedPagination({
         className="h-8 w-8"
         onClick={() => onPageChange(currentPage + 1)}
         disabled={currentPage >= totalPages}
+        aria-label="Next page"
       >
         <ChevronRight className="h-4 w-4" />
       </Button>

--- a/components/shared/status-badge.tsx
+++ b/components/shared/status-badge.tsx
@@ -48,7 +48,12 @@ export function StatusBadge({ status, size = 'md', className }: StatusBadgeProps
   const sizeClass = sizeStyles[size];
 
   return (
-    <Badge variant="outline" className={cn(colorClass, sizeClass, className)}>
+    <Badge
+      variant="outline"
+      role="status"
+      aria-label={formatStatus(status)}
+      className={cn(colorClass, sizeClass, className)}
+    >
       {formatStatus(status)}
     </Badge>
   );


### PR DESCRIPTION
## Summary
- Add `role="status"` and `aria-label` to StatusBadge component
- Add `aria-current="step"` and descriptive `aria-label` to enrollment step indicator circles
- Add `aria-label` to pagination prev/next buttons and `aria-current="page"` to active page
- Add `role="alert"` and `aria-live="polite"` to math captcha error messages

Closes #309

## Test plan
- [ ] Run `bun run typecheck` — zero errors
- [ ] Run `bun run check` — Biome clean
- [ ] Run `bun run test` — all pass
- [ ] Screen reader test: enrollment wizard announces current step
- [ ] Screen reader test: status badges announce their state

🤖 Generated with [Claude Code](https://claude.com/claude-code)