### PR TITLE
fix: add OG image, Twitter cards, and JSON-LD for SEO

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,7 +26,27 @@ export const metadata: Metadata = {
     siteName: 'FuzzyCat',
     type: 'website',
   },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'FuzzyCat — Split Your Vet Bills Into Easy Payments',
+    description:
+      'Pay your vet bills over 12 weeks with no credit check and no interest. 25% deposit, then 6 biweekly installments.',
+  },
 };
+
+const jsonLdData = JSON.stringify({
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: 'FuzzyCat',
+  url: 'https://www.fuzzycatapp.com',
+  description:
+    'Payment plan platform for veterinary clinics. Split vet bills into easy biweekly installments.',
+});
+
+function JsonLd() {
+  // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD structured data requires innerHTML; content is a static schema with no user input
+  return <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: jsonLdData }} />;
+}
 
 export default async function RootLayout({
   children,
@@ -38,6 +58,7 @@ export default async function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <JsonLd />
         <ThemeProvider nonce={nonce}>
           <Providers>{children}</Providers>
         </ThemeProvider>

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,37 @@
+import { ImageResponse } from 'next/og';
+
+export const runtime = 'edge';
+export const alt = 'FuzzyCat — Split Your Vet Bills Into Easy Payments';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default function OgImage() {
+  return new ImageResponse(
+    <div
+      style={{
+        fontSize: 60,
+        background: 'linear-gradient(135deg, #1e293b 0%, #0f172a 100%)',
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: 'white',
+        padding: '40px 80px',
+        textAlign: 'center',
+      }}
+    >
+      <div style={{ fontSize: 80, fontWeight: 700, marginBottom: 20, display: 'flex' }}>
+        FuzzyCat
+      </div>
+      <div style={{ fontSize: 36, opacity: 0.9, display: 'flex' }}>
+        Split Your Vet Bills Into Easy Payments
+      </div>
+      <div style={{ fontSize: 24, opacity: 0.7, marginTop: 20, display: 'flex' }}>
+        No credit check · No interest · 12-week plans
+      </div>
+    </div>,
+    { ...size },
+  );
+}


### PR DESCRIPTION
## Summary
- Create dynamic OG image (`app/opengraph-image.tsx`) using Next.js `ImageResponse`
- Add Twitter card metadata (`summary_large_image`) to root layout
- Add JSON-LD Organization schema to root layout for search engine rich results

Closes #310

## Test plan
- [ ] Run `bun run typecheck` — zero errors
- [ ] Run `bun run check` — Biome clean
- [ ] Run `bun run test` — all pass
- [ ] Verify OG image renders at `/opengraph-image`
- [ ] Validate JSON-LD with Google Rich Results Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)