### PR TITLE
fix: add ACH authorization and NY state restriction

### DIFF
--- a/app/owner/enroll/_components/step-review-confirm.tsx
+++ b/app/owner/enroll/_components/step-review-confirm.tsx
@@ -51,8 +51,11 @@ export function StepReviewConfirm({ data, updateData, onNext, onBack }: StepRevi
     updateData({ captchaToken: null });
   }, [updateData]);
 
+  const needsAchAuth = data.paymentMethod === 'bank_account';
+
   const canContinue =
     data.disclaimersAccepted &&
+    (!needsAchAuth || data.achAuthorizationAccepted) &&
     data.captchaVerified &&
     (process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ? !!data.captchaToken : true);
 
@@ -206,6 +209,23 @@ export function StepReviewConfirm({ data, updateData, onNext, onBack }: StepRevi
             </ul>
           </Label>
         </div>
+
+        {needsAchAuth && (
+          <div className="flex items-start gap-3">
+            <Checkbox
+              id="ach-authorization"
+              checked={data.achAuthorizationAccepted}
+              onCheckedChange={(checked) => {
+                updateData({ achAuthorizationAccepted: checked === true });
+              }}
+            />
+            <Label htmlFor="ach-authorization" className="text-sm leading-relaxed font-normal">
+              I authorize FuzzyCat to initiate ACH Direct Debit entries from my bank account for the
+              installment payments described above. I understand that this authorization will remain
+              in effect until all installment payments are completed or I cancel my payment plan.
+            </Label>
+          </div>
+        )}
       </div>
 
       {/* CAPTCHA */}

--- a/app/owner/enroll/_components/types.ts
+++ b/app/owner/enroll/_components/types.ts
@@ -10,6 +10,7 @@ export interface EnrollmentData {
   plaidPublicToken: string | null;
   plaidAccountId: string | null;
   disclaimersAccepted: boolean;
+  achAuthorizationAccepted: boolean;
   captchaVerified: boolean;
   captchaToken: string | null;
   planId: string | null;
@@ -27,6 +28,7 @@ export const INITIAL_ENROLLMENT_DATA: EnrollmentData = {
   plaidPublicToken: null,
   plaidAccountId: null,
   disclaimersAccepted: false,
+  achAuthorizationAccepted: false,
   captchaVerified: false,
   captchaToken: null,
   planId: null,

--- a/server/routers/enrollment.ts
+++ b/server/routers/enrollment.ts
@@ -47,6 +47,14 @@ export const enrollmentRouter = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
+      // Reject enrollments from New York state (pending DFS BNPL Act regulations)
+      if (input.ownerData.addressState?.toUpperCase() === 'NY') {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Payment plans are not currently available in New York state.',
+        });
+      }
+
       // Admin users bypass clinic ownership check
       if (ctx.session.role !== 'admin') {
         await assertClinicOwnership(ctx.session.userId, input.clinicId);


### PR DESCRIPTION
## Summary
- Add NACHA-compliant ACH Direct Debit authorization checkbox to enrollment review step
- Checkbox appears when payment method is bank account and must be checked to proceed
- Add server-side validation rejecting enrollments for New York state residents
- NY restriction per CLAUDE.md: "No NY launch until DFS finalizes BNPL Act regulations"

Closes #307

## Test plan
- [ ] Run `bun run typecheck` — zero errors
- [ ] Run `bun run check` — Biome clean
- [ ] Run `bun run test` — all pass
- [ ] Verify ACH checkbox appears only for bank account payment method
- [ ] Verify submit disabled until ACH checkbox checked
- [ ] Verify NY state enrollment rejected with appropriate message

🤖 Generated with [Claude Code](https://claude.com/claude-code)