### PR TITLE
fix: correct Tailwind v4 dark mode selector

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,7 +2,7 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 
-@custom-variant dark (&:is(.dark *));
+@custom-variant dark (&:where(.dark, .dark *));
 
 @theme inline {
   --color-background: var(--background);


### PR DESCRIPTION
## Summary
- Fix `@custom-variant dark` selector in `globals.css` from `(&:is(.dark *))` to `(&:where(.dark, .dark *))`
- The old selector only matched descendants of `.dark` but not the `.dark` element itself, causing all `dark:` utility classes to silently fail
- This is the correct syntax per [Tailwind CSS v4 docs](https://tailwindcss.com/docs/dark-mode)

## Root Cause
`next-themes` adds the `.dark` class to the `<html>` element. The old `&:is(.dark *)` selector generated CSS like `.dark\:bg-black:is(.dark *)` which requires the element to be a **descendant** of `.dark` AND match the utility class — but the utility class is on a descendant, not the `.dark` element itself. The `:where(.dark, .dark *)` selector correctly matches both cases.

## Test plan
- [ ] `bun run build` — production build succeeds
- [ ] `bun run test` — all 497 tests pass
- [ ] `bun run check` — Biome clean
- [ ] Toggle dark mode on landing page — background/text colors change
- [ ] Toggle dark mode on login pages — form styling updates
- [ ] Toggle dark mode on how-it-works — all sections render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)