### PR TITLE
fix: default to dark theme, decouple from system preference

### DIFF
--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -6,8 +6,9 @@ export function ThemeProvider({ children, nonce }: { children: React.ReactNode; 
   return (
     <NextThemesProvider
       attribute="class"
-      defaultTheme="system"
+      defaultTheme="dark"
       enableSystem
+      enableColorScheme={false}
       disableTransitionOnChange
       nonce={nonce}
     >


### PR DESCRIPTION
## Summary
- Change `defaultTheme` from `"system"` to `"dark"` — FuzzyCat's brand identity is dark/teal
- Add `enableColorScheme={false}` — prevents the browser from applying OS-level `color-scheme` rendering that can override the app's theme toggle
- Keep `enableSystem` so users can explicitly opt into system-following via a future settings option
- The toggle still works and persists the user's choice in localStorage

## Root Cause
With `defaultTheme="system"`, first-time visitors (no localStorage) always get whatever their OS preference is. On the client's light-mode MacBook, the app rendered in light mode across all three browsers — because all three read the same OS `prefers-color-scheme: light` preference.

Additionally, `enableColorScheme` (default `true`) was setting `document.documentElement.style.colorScheme` to the resolved theme, which tells the browser to apply OS-level rendering for form controls, scrollbars, and system colors — reinforcing the system preference.

## Test plan
- [ ] `bun run test` — all 497 tests pass
- [ ] `bun run check` — Biome clean
- [ ] Fresh visit (clear localStorage) → site loads in dark mode
- [ ] Toggle to light → persists on refresh
- [ ] Toggle back to dark → persists on refresh
- [ ] Works regardless of OS dark/light mode setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)