### PR TITLE
fix: remove solid background from apple-touch-icon

### DIFF
--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -7,13 +7,12 @@ export default function AppleIcon() {
   return new ImageResponse(
     <div
       style={{
-        background: '#0f172a',
+        background: 'transparent',
         width: '100%',
         height: '100%',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        borderRadius: '32px',
         padding: '24px',
       }}
     >
@@ -21,7 +20,7 @@ export default function AppleIcon() {
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"
         fill="none"
-        stroke="#38bdf8"
+        stroke="#0d9488"
         stroke-width="2"
         stroke-linecap="round"
         stroke-linejoin="round"


### PR DESCRIPTION
## Summary
- Removed dark navy background (`#0f172a`) from apple-touch-icon
- Changed stroke color from sky blue (`#38bdf8`) to teal (`#0d9488`) to match the favicon and site brand

## Test plan
- [x] Builds cleanly
- [x] Consistent with favicon SVG styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)