### PR TITLE
feat: payment method remove, replace, and pre-charge validation

### DIFF
--- a/app/owner/settings/_components/payment-method-section.tsx
+++ b/app/owner/settings/_components/payment-method-section.tsx
@@ -5,6 +5,17 @@ import { AlertCircle, CheckCircle2, CreditCard, Landmark, Loader2 } from 'lucide
 import { usePathname, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -41,31 +52,107 @@ function SavedMethodDetails({
   isLoading,
   card,
   bankAccount,
+  disabled,
+  onReplaceCard,
+  onReplaceBank,
+  onRemoveCard,
+  onRemoveBank,
 }: {
   isLoading: boolean;
   card: { brand: string; last4: string } | null | undefined;
   bankAccount: { bankName: string; last4: string } | null | undefined;
+  disabled: boolean;
+  onReplaceCard: () => void;
+  onReplaceBank: () => void;
+  onRemoveCard: () => void;
+  onRemoveBank: () => void;
 }) {
   if (isLoading) return <Skeleton className="h-5 w-48" />;
 
   if (card || bankAccount) {
     return (
-      <div className="text-sm text-muted-foreground">
+      <div className="space-y-2 text-sm text-muted-foreground">
         {card && (
-          <p>
-            {card.brand.charAt(0).toUpperCase() + card.brand.slice(1)} ending in {card.last4}
-          </p>
+          <div className="flex items-center justify-between">
+            <p>
+              {card.brand.charAt(0).toUpperCase() + card.brand.slice(1)} ending in {card.last4}
+            </p>
+            <div className="flex gap-2">
+              <Button variant="ghost" size="sm" disabled={disabled} onClick={onReplaceCard}>
+                Replace
+              </Button>
+              <RemoveConfirmDialog
+                methodLabel="debit card"
+                disabled={disabled}
+                onConfirm={onRemoveCard}
+              />
+            </div>
+          </div>
         )}
         {bankAccount && (
-          <p>
-            {bankAccount.bankName} ****{bankAccount.last4}
-          </p>
+          <div className="flex items-center justify-between">
+            <p>
+              {bankAccount.bankName} ****{bankAccount.last4}
+            </p>
+            <div className="flex gap-2">
+              <Button variant="ghost" size="sm" disabled={disabled} onClick={onReplaceBank}>
+                Replace
+              </Button>
+              <RemoveConfirmDialog
+                methodLabel="bank account"
+                disabled={disabled}
+                onConfirm={onRemoveBank}
+              />
+            </div>
+          </div>
         )}
       </div>
     );
   }
 
   return <p className="text-sm text-muted-foreground">No payment method on file</p>;
+}
+
+function RemoveConfirmDialog({
+  methodLabel,
+  disabled,
+  onConfirm,
+}: {
+  methodLabel: string;
+  disabled: boolean;
+  onConfirm: () => void;
+}) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={disabled}
+          className="text-destructive hover:text-destructive"
+        >
+          Remove
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Remove payment method?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently remove your {methodLabel}. You cannot undo this action.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            Remove
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
 }
 
 function StatusMessage({
@@ -185,6 +272,17 @@ export function PaymentMethodSection() {
     }),
   );
 
+  const removeMutation = useMutation(
+    trpc.owner.removePaymentMethod.mutationOptions({
+      onSuccess: () => {
+        setSaveStatus('saved');
+        invalidateQueries();
+        setTimeout(() => setSaveStatus('idle'), 2000);
+      },
+      onError: (error) => handleMutationError(error, 'Failed to remove payment method.'),
+    }),
+  );
+
   function handleSelectDebitCard() {
     if (profile?.paymentMethod === 'debit_card') return;
     setErrorMessage(null);
@@ -209,6 +307,31 @@ export function PaymentMethodSection() {
     }
   }
 
+  function handleReplaceCard() {
+    setErrorMessage(null);
+    setSaveStatus('saving');
+    const baseUrl = `${window.location.origin}${pathname}`;
+    setupCard.mutate({ successUrl: baseUrl, cancelUrl: baseUrl });
+  }
+
+  function handleReplaceBank() {
+    setErrorMessage(null);
+    setShowPlaidLink(true);
+    createLinkToken.mutate();
+  }
+
+  function handleRemoveCard() {
+    setErrorMessage(null);
+    setSaveStatus('saving');
+    removeMutation.mutate({ method: 'debit_card' });
+  }
+
+  function handleRemoveBank() {
+    setErrorMessage(null);
+    setSaveStatus('saving');
+    removeMutation.mutate({ method: 'bank_account' });
+  }
+
   if (isLoading) {
     return (
       <Card>
@@ -229,7 +352,8 @@ export function PaymentMethodSection() {
     setupCard.isPending ||
     confirmCard.isPending ||
     createLinkToken.isPending ||
-    exchangeToken.isPending;
+    exchangeToken.isPending ||
+    removeMutation.isPending;
 
   return (
     <Card>
@@ -273,6 +397,11 @@ export function PaymentMethodSection() {
           isLoading={isLoadingDetails}
           card={paymentDetails?.card}
           bankAccount={paymentDetails?.bankAccount}
+          disabled={isBusy}
+          onReplaceCard={handleReplaceCard}
+          onReplaceBank={handleReplaceBank}
+          onRemoveCard={handleRemoveCard}
+          onRemoveBank={handleRemoveBank}
         />
 
         {isBusy && (

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@marsidev/react-turnstile": "^1.4.2",
         "@radix-ui/react-accordion": "^1.2.12",
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
+import * as React from 'react';
+import { buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+const AlertDialog = AlertDialogPrimitive.Root;
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        className,
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
+
+const AlertDialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-2 text-center sm:text-left', className)} {...props} />
+);
+AlertDialogHeader.displayName = 'AlertDialogHeader';
+
+const AlertDialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
+    {...props}
+  />
+);
+AlertDialogFooter.displayName = 'AlertDialogFooter';
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold', className)}
+    {...props}
+  />
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+AlertDialogDescription.displayName = AlertDialogPrimitive.Description.displayName;
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action ref={ref} className={cn(buttonVariants(), className)} {...props} />
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(buttonVariants({ variant: 'outline' }), 'mt-2 sm:mt-0', className)}
+    {...props}
+  />
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@marsidev/react-turnstile": "^1.4.2",
     "@radix-ui/react-accordion": "^1.2.12",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/server/__tests__/services/payment.test.ts
+++ b/server/__tests__/services/payment.test.ts
@@ -22,12 +22,20 @@ const mockTransfersCreate = mock(() => Promise.resolve({ id: 'tr_transfer_789' }
 
 const mockCustomersUpdate = mock(() => Promise.resolve({}));
 
+const mockPaymentMethodsRetrieve = mock((_id: string) =>
+  Promise.resolve({ id: _id, customer: 'cus_test' }),
+);
+const mockCustomersRetrieveSource = mock((_cust: string, _src: string) =>
+  Promise.resolve({ id: _src, status: 'verified' }),
+);
+
 mock.module('@/lib/stripe', () => ({
   stripe: () => ({
     checkout: { sessions: { create: mockCheckoutSessionsCreate } },
     paymentIntents: { create: mockPaymentIntentsCreate },
     transfers: { create: mockTransfersCreate },
-    customers: { update: mockCustomersUpdate },
+    customers: { update: mockCustomersUpdate, retrieveSource: mockCustomersRetrieveSource },
+    paymentMethods: { retrieve: mockPaymentMethodsRetrieve },
   }),
 }));
 
@@ -233,6 +241,8 @@ function clearAllMocks() {
     mockPaymentIntentsCreate,
     mockTransfersCreate,
     mockCustomersUpdate,
+    mockPaymentMethodsRetrieve,
+    mockCustomersRetrieveSource,
   ]) {
     m.mockClear();
   }
@@ -1273,5 +1283,86 @@ describe('processInstallment — no payment method preference', () => {
 
     expect(result.paymentIntentId).toBe('pi_ach_789');
     expect(mockPaymentIntentsCreate).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── Payment method validation in processInstallment ──────────────────
+
+describe('processInstallment — payment method validation', () => {
+  beforeEach(() => {
+    clearAllMocks();
+    setupSelectChain();
+    setupUpdateChain();
+    setupInsertChain();
+  });
+
+  afterEach(clearAllMocks);
+
+  it('proceeds normally when payment method is valid', async () => {
+    mockPaymentMethodsRetrieve.mockImplementation((_id: string) =>
+      Promise.resolve({ id: _id, customer: 'cus_456' }),
+    );
+
+    mockSelectLimit
+      .mockResolvedValueOnce([
+        {
+          id: 'pay-valid-pm',
+          planId: 'plan-valid',
+          amountCents: 10000,
+          status: 'pending',
+          type: 'installment',
+        },
+      ])
+      .mockResolvedValueOnce([{ ownerId: 'owner-1', status: 'active' }])
+      .mockResolvedValueOnce([
+        {
+          stripeCustomerId: 'cus_456',
+          paymentMethod: 'debit_card',
+          stripeCardPaymentMethodId: 'pm_card_valid',
+          stripeAchPaymentMethodId: null,
+        },
+      ]);
+
+    const result = await processInstallment({ paymentId: 'pay-valid-pm' });
+    expect(result.paymentIntentId).toBe('pi_ach_789');
+    expect(mockPaymentMethodsRetrieve).toHaveBeenCalledWith('pm_card_valid');
+    expect(mockPaymentIntentsCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails payment immediately when payment method is invalid', async () => {
+    mockPaymentMethodsRetrieve.mockImplementation(() =>
+      Promise.reject(new Error('No such PaymentMethod')),
+    );
+
+    mockSelectLimit
+      .mockResolvedValueOnce([
+        {
+          id: 'pay-invalid-pm',
+          planId: 'plan-invalid',
+          amountCents: 10000,
+          status: 'pending',
+          type: 'installment',
+        },
+      ])
+      .mockResolvedValueOnce([{ ownerId: 'owner-1', status: 'active' }])
+      .mockResolvedValueOnce([
+        {
+          stripeCustomerId: 'cus_456',
+          paymentMethod: 'debit_card',
+          stripeCardPaymentMethodId: 'pm_card_deleted',
+          stripeAchPaymentMethodId: null,
+        },
+      ]);
+
+    // handlePaymentFailure will use a transaction — mock it
+    mockTxSelectLimit.mockResolvedValueOnce([
+      { id: 'pay-invalid-pm', status: 'pending', retryCount: 0, planId: 'plan-invalid' },
+    ]);
+
+    await expect(processInstallment({ paymentId: 'pay-invalid-pm' })).rejects.toThrow(
+      'no longer valid',
+    );
+    // PaymentIntent should NOT have been created
+    expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
   });
 });

--- a/server/routers/owner.ts
+++ b/server/routers/owner.ts
@@ -1,8 +1,9 @@
 import { TRPCError } from '@trpc/server';
-import { and, desc, eq, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, sql } from 'drizzle-orm';
 import { z } from 'zod';
 import { cachedQuery, revalidateTag } from '@/lib/cache';
 import { logger } from '@/lib/logger';
+import { plaid } from '@/lib/plaid';
 import { stripe } from '@/lib/stripe';
 import { clinics, owners, payments, pets, plans } from '@/server/db/schema';
 import { logAuditEvent } from '@/server/services/audit';
@@ -56,6 +57,78 @@ async function fetchBankAccountDetails(
     });
   }
   return null;
+}
+
+/** Detach a card or bank source from Stripe. Logs errors but does not throw. */
+async function detachStripeInstrument(
+  method: 'debit_card' | 'bank_account',
+  owner: {
+    stripeCustomerId: string | null;
+    stripeCardPaymentMethodId: string | null;
+    stripeAchPaymentMethodId: string | null;
+    plaidAccessToken: string | null;
+  },
+  ownerId: string,
+): Promise<void> {
+  if (method === 'debit_card' && owner.stripeCardPaymentMethodId) {
+    try {
+      await stripe().paymentMethods.detach(owner.stripeCardPaymentMethodId);
+    } catch (err) {
+      logger.error('Failed to detach card payment method from Stripe', {
+        ownerId,
+        paymentMethodId: owner.stripeCardPaymentMethodId,
+        error: err,
+      });
+    }
+    return;
+  }
+
+  if (method === 'bank_account' && owner.stripeAchPaymentMethodId && owner.stripeCustomerId) {
+    try {
+      await stripe().customers.deleteSource(owner.stripeCustomerId, owner.stripeAchPaymentMethodId);
+    } catch (err) {
+      logger.error('Failed to delete ACH source from Stripe', {
+        ownerId,
+        sourceId: owner.stripeAchPaymentMethodId,
+        error: err,
+      });
+    }
+
+    if (owner.plaidAccessToken) {
+      try {
+        await plaid().itemRemove({ access_token: owner.plaidAccessToken });
+      } catch (err) {
+        logger.error('Failed to remove Plaid item', { ownerId, error: err });
+      }
+    }
+  }
+}
+
+/** Build the DB update fields for removing a payment method. */
+function buildRemoveFields(
+  method: 'debit_card' | 'bank_account',
+  currentMethod: string,
+  otherMethodExists: boolean,
+): { updateFields: Record<string, unknown>; switchedTo: string | null } {
+  const updateFields: Record<string, unknown> = {};
+  let switchedTo: string | null = null;
+
+  if (method === 'debit_card') {
+    updateFields.stripeCardPaymentMethodId = null;
+  } else {
+    updateFields.stripeAchPaymentMethodId = null;
+    updateFields.plaidAccessToken = null;
+    updateFields.plaidItemId = null;
+    updateFields.plaidAccountId = null;
+  }
+
+  if (currentMethod === method && otherMethodExists) {
+    const newMethod = method === 'debit_card' ? 'bank_account' : 'debit_card';
+    updateFields.paymentMethod = newMethod;
+    switchedTo = newMethod;
+  }
+
+  return { updateFields, switchedTo };
 }
 
 export const ownerRouter = router({
@@ -219,6 +292,109 @@ export const ownerRouter = router({
     }),
 
   /**
+   * Remove a saved payment method (debit card or bank account).
+   * Detaches the instrument from Stripe, clears DB fields, and auto-switches
+   * the preference if the other method is available.
+   * Blocks removal if it's the owner's only method and they have active plans.
+   */
+  removePaymentMethod: ownerProcedure
+    .input(
+      z.object({
+        method: z.enum(['debit_card', 'bank_account']),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const [owner] = await ctx.db
+        .select({
+          stripeCustomerId: owners.stripeCustomerId,
+          stripeCardPaymentMethodId: owners.stripeCardPaymentMethodId,
+          stripeAchPaymentMethodId: owners.stripeAchPaymentMethodId,
+          plaidAccessToken: owners.plaidAccessToken,
+          paymentMethod: owners.paymentMethod,
+        })
+        .from(owners)
+        .where(eq(owners.id, ctx.ownerId))
+        .limit(1);
+
+      if (!owner) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Owner not found.' });
+      }
+
+      // Validate the requested method has a saved instrument
+      if (input.method === 'debit_card' && !owner.stripeCardPaymentMethodId) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'No debit card on file to remove.',
+        });
+      }
+
+      if (input.method === 'bank_account' && !owner.stripeAchPaymentMethodId) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'No bank account on file to remove.',
+        });
+      }
+
+      // Check if the other method has a saved instrument
+      const otherMethodHasInstrument =
+        input.method === 'debit_card'
+          ? !!owner.stripeAchPaymentMethodId
+          : !!owner.stripeCardPaymentMethodId;
+
+      // Block removal if this is the only method and owner has active plans
+      if (!otherMethodHasInstrument) {
+        const activePlans = await ctx.db
+          .select({ id: plans.id })
+          .from(plans)
+          .where(
+            and(eq(plans.ownerId, ctx.ownerId), inArray(plans.status, ['active', 'deposit_paid'])),
+          )
+          .limit(1);
+
+        if (activePlans.length > 0) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message:
+              'Cannot remove your only payment method while you have active plans. Add an alternative payment method first.',
+          });
+        }
+      }
+
+      // Detach from Stripe (logs errors but does not throw)
+      await detachStripeInstrument(input.method, owner, ctx.ownerId);
+
+      // Clear DB fields and auto-switch if needed
+      const { updateFields, switchedTo } = buildRemoveFields(
+        input.method,
+        owner.paymentMethod,
+        otherMethodHasInstrument,
+      );
+
+      await ctx.db.update(owners).set(updateFields).where(eq(owners.id, ctx.ownerId));
+
+      await logAuditEvent({
+        entityType: 'owner',
+        entityId: ctx.ownerId,
+        action: 'payment_method_removed',
+        oldValue: {
+          method: input.method,
+          paymentMethod: owner.paymentMethod,
+        },
+        newValue: {
+          method: input.method,
+          removed: true,
+          switchedTo,
+        },
+        actorType: 'owner',
+        actorId: ctx.ownerId,
+      });
+
+      revalidateTag(`owner:${ctx.ownerId}:profile`);
+
+      return { success: true as const, switchedTo };
+    }),
+
+  /**
    * Create a Stripe Checkout Session in setup mode for collecting a debit card.
    * Redirects the user to Stripe's hosted page (avoids needing @stripe/react-stripe-js).
    */
@@ -311,6 +487,28 @@ export const ownerRouter = router({
         });
       }
 
+      // Fetch existing card PM to detach if replacing
+      const [existingOwner] = await ctx.db
+        .select({ stripeCardPaymentMethodId: owners.stripeCardPaymentMethodId })
+        .from(owners)
+        .where(eq(owners.id, ctx.ownerId))
+        .limit(1);
+
+      const oldCardPmId = existingOwner?.stripeCardPaymentMethodId;
+
+      // Detach old card from Stripe if replacing with a different one
+      if (oldCardPmId && oldCardPmId !== paymentMethodId) {
+        try {
+          await stripe().paymentMethods.detach(oldCardPmId);
+        } catch (err) {
+          logger.error('Failed to detach old card payment method from Stripe', {
+            ownerId: ctx.ownerId,
+            oldPaymentMethodId: oldCardPmId,
+            error: err,
+          });
+        }
+      }
+
       await ctx.db
         .update(owners)
         .set({
@@ -322,8 +520,11 @@ export const ownerRouter = router({
       await logAuditEvent({
         entityType: 'owner',
         entityId: ctx.ownerId,
-        action: 'status_changed',
-        oldValue: null,
+        action:
+          oldCardPmId && oldCardPmId !== paymentMethodId
+            ? 'payment_method_replaced'
+            : 'status_changed',
+        oldValue: oldCardPmId ? { stripeCardPaymentMethodId: oldCardPmId } : null,
         newValue: { stripeCardPaymentMethodId: paymentMethodId, paymentMethod: 'debit_card' },
         actorType: 'owner',
         actorId: ctx.ownerId,

--- a/server/services/audit.ts
+++ b/server/services/audit.ts
@@ -34,6 +34,8 @@ export const AUDIT_ACTIONS = [
   'payout_initiated',
   'claim_created',
   'payments_written_off',
+  'payment_method_removed',
+  'payment_method_replaced',
 ] as const;
 export type AuditAction = (typeof AUDIT_ACTIONS)[number];
 

--- a/server/services/payment.ts
+++ b/server/services/payment.ts
@@ -97,6 +97,34 @@ export async function processDeposit(params: {
 }
 
 /**
+ * Validate that a Stripe payment method still exists and is usable.
+ * For card PMs uses paymentMethods.retrieve; for ACH sources uses customers.retrieveSource.
+ * Returns true if valid, false if the PM has been deleted or is invalid.
+ */
+async function validatePaymentMethod(params: {
+  paymentMethodId: string;
+  paymentMethodType: 'card' | 'us_bank_account';
+  stripeCustomerId: string;
+}): Promise<boolean> {
+  try {
+    if (params.paymentMethodType === 'card') {
+      const pm = await stripe().paymentMethods.retrieve(params.paymentMethodId);
+      return pm.customer !== null;
+    }
+    // ACH: retrieve the source (legacy Source/BankAccount)
+    await stripe().customers.retrieveSource(params.stripeCustomerId, params.paymentMethodId);
+    return true;
+  } catch (err) {
+    logger.error('Payment method validation failed', {
+      paymentMethodId: params.paymentMethodId,
+      paymentMethodType: params.paymentMethodType,
+      error: err,
+    });
+    return false;
+  }
+}
+
+/**
  * Resolve which Stripe payment method and type to use for an installment charge.
  * An explicit override takes priority; otherwise the owner's saved preference is used.
  */
@@ -217,6 +245,25 @@ export async function processInstallment(params: {
 
   // Resolve the payment method: explicit override takes priority, then owner preference
   const resolved = resolvePaymentMethod(params.paymentId, params.paymentMethodId, owner);
+
+  // Validate the payment method still exists in Stripe before charging
+  if (resolved.paymentMethodId && resolved.paymentMethodType) {
+    const isValid = await validatePaymentMethod({
+      paymentMethodId: resolved.paymentMethodId,
+      paymentMethodType: resolved.paymentMethodType,
+      stripeCustomerId: owner.stripeCustomerId,
+    });
+
+    if (!isValid) {
+      await handlePaymentFailure(
+        params.paymentId,
+        'Payment method is no longer valid. Please update your payment method.',
+      );
+      throw new Error(
+        `Payment method ${resolved.paymentMethodId} is no longer valid for payment ${params.paymentId}`,
+      );
+    }
+  }
 
   return createInstallmentPaymentIntent({
     paymentId: params.paymentId,

--- a/server/services/plaid.ts
+++ b/server/services/plaid.ts
@@ -61,6 +61,46 @@ export async function createLinkToken(userId: string): Promise<string> {
  * @param ownerId - UUID of the pet owner
  * @param accountId - Plaid account ID selected by the user
  */
+
+/** Detach old bank account from Stripe and Plaid if replacing. Returns old ACH ID if replaced. */
+async function detachOldBankAccount(
+  ownerId: string,
+  stripeCustomerId: string,
+  newAchId: string,
+): Promise<string | null> {
+  const [existing] = await db
+    .select({
+      stripeAchPaymentMethodId: owners.stripeAchPaymentMethodId,
+      plaidAccessToken: owners.plaidAccessToken,
+    })
+    .from(owners)
+    .where(eq(owners.id, ownerId))
+    .limit(1);
+
+  const oldAchId = existing?.stripeAchPaymentMethodId;
+  if (!oldAchId || oldAchId === newAchId) return null;
+
+  try {
+    await stripe().customers.deleteSource(stripeCustomerId, oldAchId);
+  } catch (err) {
+    logger.error('Failed to delete old ACH source from Stripe', {
+      ownerId,
+      oldSourceId: oldAchId,
+      error: err,
+    });
+  }
+
+  if (existing?.plaidAccessToken) {
+    try {
+      await plaid().itemRemove({ access_token: existing.plaidAccessToken });
+    } catch (err) {
+      logger.error('Failed to remove old Plaid item', { ownerId, error: err });
+    }
+  }
+
+  return oldAchId;
+}
+
 export async function exchangePublicToken(
   publicToken: string,
   ownerId: string,
@@ -122,6 +162,14 @@ export async function exchangePublicToken(
     throw err;
   }
 
+  // Detach old bank account if replacing with a different one
+  const oldAchId = await detachOldBankAccount(
+    ownerId,
+    owner.stripeCustomerId,
+    stripeAchPaymentMethodId,
+  );
+  const isReplacing = !!oldAchId;
+
   // Store access token, item ID, account ID, and Stripe ACH payment method on owner record
   await db
     .update(owners)
@@ -136,8 +184,8 @@ export async function exchangePublicToken(
   await logAuditEvent({
     entityType: 'owner',
     entityId: ownerId,
-    action: 'status_changed',
-    oldValue: null,
+    action: isReplacing ? 'payment_method_replaced' : 'status_changed',
+    oldValue: isReplacing ? { stripeAchPaymentMethodId: oldAchId } : null,
     newValue: { plaidItemId: itemId, stripeAchPaymentMethodId, bankConnected: true },
     actorType: 'owner',
     actorId: ownerId,

--- a/tests/isolated/owner-router.test.ts
+++ b/tests/isolated/owner-router.test.ts
@@ -67,15 +67,32 @@ const mockSetupIntentsRetrieve = mock((_id: string) =>
     payment_method: 'pm_card_new_456' as string | null,
   }),
 );
+const mockPaymentMethodsDetach = mock((_id: string) => Promise.resolve({ id: _id }));
+const mockCustomersDeleteSource = mock((_cust: string, _src: string) =>
+  Promise.resolve({ id: _src, deleted: true }),
+);
 
 mock.module('@/lib/stripe', () => ({
   stripe: () => ({
-    paymentMethods: { retrieve: mockPaymentMethodsRetrieve },
-    customers: { retrieveSource: mockCustomersRetrieveSource },
+    paymentMethods: { retrieve: mockPaymentMethodsRetrieve, detach: mockPaymentMethodsDetach },
+    customers: {
+      retrieveSource: mockCustomersRetrieveSource,
+      deleteSource: mockCustomersDeleteSource,
+    },
     checkout: {
       sessions: { create: mockCheckoutSessionsCreate, retrieve: mockCheckoutSessionsRetrieve },
     },
     setupIntents: { retrieve: mockSetupIntentsRetrieve },
+  }),
+}));
+
+// ── Plaid mocks ──────────────────────────────────────────────────────
+
+const mockPlaidItemRemove = mock((_params: unknown) => Promise.resolve({ data: {} }));
+
+mock.module('@/lib/plaid', () => ({
+  plaid: () => ({
+    itemRemove: mockPlaidItemRemove,
   }),
 }));
 
@@ -115,6 +132,9 @@ function clearStripeMocks() {
   mockCheckoutSessionsCreate.mockClear();
   mockCheckoutSessionsRetrieve.mockClear();
   mockSetupIntentsRetrieve.mockClear();
+  mockPaymentMethodsDetach.mockClear();
+  mockCustomersDeleteSource.mockClear();
+  mockPlaidItemRemove.mockClear();
 }
 
 // ── healthCheck ───────────────────────────────────────────────────────
@@ -702,5 +722,229 @@ describe('owner.getDashboardSummary', () => {
     expect(result.nextPayment).toBeNull();
     expect(result.totalPaidCents).toBe(127200);
     expect(result.activePlans).toBe(0);
+  });
+});
+
+// ── removePaymentMethod ──────────────────────────────────────────────
+
+describe('owner.removePaymentMethod', () => {
+  beforeEach(() => {
+    resetDbMocks();
+    clearStripeMocks();
+  });
+  afterEach(resetDbMocks);
+
+  it('removes debit card successfully — detaches from Stripe and clears DB', async () => {
+    createMockChain([
+      [{ id: OWNER_ID }], // middleware
+      [
+        {
+          stripeCustomerId: 'cus_test',
+          stripeCardPaymentMethodId: 'pm_card_123',
+          stripeAchPaymentMethodId: null,
+          plaidAccessToken: null,
+          paymentMethod: 'debit_card',
+        },
+      ], // owner fetch
+      [], // no active plans
+      [{ id: OWNER_ID }], // DB update
+    ]);
+
+    const caller = createOwnerCaller(ctx());
+    const result = await caller.removePaymentMethod({ method: 'debit_card' });
+    expect(result.success).toBe(true);
+    expect(mockPaymentMethodsDetach).toHaveBeenCalledWith('pm_card_123');
+  });
+
+  it('removes bank account — deletes Stripe source and Plaid item', async () => {
+    createMockChain([
+      [{ id: OWNER_ID }], // middleware
+      [
+        {
+          stripeCustomerId: 'cus_test',
+          stripeCardPaymentMethodId: null,
+          stripeAchPaymentMethodId: 'ba_ach_123',
+          plaidAccessToken: 'access-sandbox-123',
+          paymentMethod: 'bank_account',
+        },
+      ], // owner fetch
+      [], // no active plans
+      [{ id: OWNER_ID }], // DB update
+    ]);
+
+    const caller = createOwnerCaller(ctx());
+    const result = await caller.removePaymentMethod({ method: 'bank_account' });
+    expect(result.success).toBe(true);
+    expect(mockCustomersDeleteSource).toHaveBeenCalledWith('cus_test', 'ba_ach_123');
+    expect(mockPlaidItemRemove).toHaveBeenCalledWith({ access_token: 'access-sandbox-123' });
+  });
+
+  it('auto-switches to other method when removing active preference', async () => {
+    createMockChain([
+      [{ id: OWNER_ID }], // middleware
+      [
+        {
+          stripeCustomerId: 'cus_test',
+          stripeCardPaymentMethodId: 'pm_card_123',
+          stripeAchPaymentMethodId: 'ba_ach_456',
+          plaidAccessToken: null,
+          paymentMethod: 'debit_card',
+        },
+      ], // owner fetch (card is active, bank also exists)
+      [{ id: OWNER_ID }], // DB update
+    ]);
+
+    const caller = createOwnerCaller(ctx());
+    const result = await caller.removePaymentMethod({ method: 'debit_card' });
+    expect(result.success).toBe(true);
+    expect(result.switchedTo).toBe('bank_account');
+  });
+
+  it('blocks removal when only method and active plans exist', async () => {
+    createMockChain([
+      [{ id: OWNER_ID }], // middleware
+      [
+        {
+          stripeCustomerId: 'cus_test',
+          stripeCardPaymentMethodId: 'pm_card_123',
+          stripeAchPaymentMethodId: null,
+          plaidAccessToken: null,
+          paymentMethod: 'debit_card',
+        },
+      ], // owner fetch (only card, no bank)
+      [{ id: PLAN_ID }], // has active plans
+    ]);
+
+    const caller = createOwnerCaller(ctx());
+    await expect(caller.removePaymentMethod({ method: 'debit_card' })).rejects.toThrow(TRPCError);
+  });
+
+  it('allows removal of non-active method with active plans', async () => {
+    createMockChain([
+      [{ id: OWNER_ID }], // middleware
+      [
+        {
+          stripeCustomerId: 'cus_test',
+          stripeCardPaymentMethodId: 'pm_card_123',
+          stripeAchPaymentMethodId: 'ba_ach_456',
+          plaidAccessToken: null,
+          paymentMethod: 'debit_card',
+        },
+      ], // owner fetch (both methods exist)
+      [{ id: OWNER_ID }], // DB update (no active plan check needed — other method exists)
+    ]);
+
+    const caller = createOwnerCaller(ctx());
+    // Removing bank_account while debit_card is active and has instrument
+    const result = await caller.removePaymentMethod({ method: 'bank_account' });
+    expect(result.success).toBe(true);
+  });
+
+  it('throws when nothing to remove', async () => {
+    createMockChain([
+      [{ id: OWNER_ID }], // middleware
+      [
+        {
+          stripeCustomerId: 'cus_test',
+          stripeCardPaymentMethodId: null,
+          stripeAchPaymentMethodId: null,
+          plaidAccessToken: null,
+          paymentMethod: 'debit_card',
+        },
+      ], // owner fetch (no card on file)
+    ]);
+
+    const caller = createOwnerCaller(ctx());
+    await expect(caller.removePaymentMethod({ method: 'debit_card' })).rejects.toThrow(TRPCError);
+  });
+
+  it('handles Stripe detach error gracefully — still clears DB', async () => {
+    mockPaymentMethodsDetach.mockImplementationOnce(() =>
+      Promise.reject(new Error('Stripe error')),
+    );
+
+    createMockChain([
+      [{ id: OWNER_ID }], // middleware
+      [
+        {
+          stripeCustomerId: 'cus_test',
+          stripeCardPaymentMethodId: 'pm_card_123',
+          stripeAchPaymentMethodId: null,
+          plaidAccessToken: null,
+          paymentMethod: 'debit_card',
+        },
+      ], // owner fetch
+      [], // no active plans
+      [{ id: OWNER_ID }], // DB update (still proceeds)
+    ]);
+
+    const caller = createOwnerCaller(ctx());
+    const result = await caller.removePaymentMethod({ method: 'debit_card' });
+    expect(result.success).toBe(true);
+    expect(mockPaymentMethodsDetach).toHaveBeenCalled();
+  });
+});
+
+// ── confirmCardPaymentMethod — card replacement ──────────────────────
+
+describe('owner.confirmCardPaymentMethod — replacement', () => {
+  beforeEach(() => {
+    resetDbMocks();
+    clearStripeMocks();
+  });
+  afterEach(resetDbMocks);
+
+  it('detaches old card when confirming a new one', async () => {
+    createMockChain([
+      [{ id: OWNER_ID }], // middleware
+      [{ stripeCardPaymentMethodId: 'pm_old_123' }], // existing owner card
+      [{ id: OWNER_ID }], // DB update
+    ]);
+
+    const caller = createOwnerCaller(ctx());
+    const result = await caller.confirmCardPaymentMethod({ sessionId: 'cs_setup_test_123' });
+    expect(result.success).toBe(true);
+    expect(mockPaymentMethodsDetach).toHaveBeenCalledWith('pm_old_123');
+  });
+
+  it('does not detach when first card setup', async () => {
+    createMockChain([
+      [{ id: OWNER_ID }], // middleware
+      [{ stripeCardPaymentMethodId: null }], // no existing card
+      [{ id: OWNER_ID }], // DB update
+    ]);
+
+    const caller = createOwnerCaller(ctx());
+    await caller.confirmCardPaymentMethod({ sessionId: 'cs_setup_test_123' });
+    expect(mockPaymentMethodsDetach).not.toHaveBeenCalled();
+  });
+
+  it('does not detach when same card re-confirmed', async () => {
+    createMockChain([
+      [{ id: OWNER_ID }], // middleware
+      [{ stripeCardPaymentMethodId: 'pm_card_new_456' }], // same as setupIntent returns
+      [{ id: OWNER_ID }], // DB update
+    ]);
+
+    const caller = createOwnerCaller(ctx());
+    await caller.confirmCardPaymentMethod({ sessionId: 'cs_setup_test_123' });
+    expect(mockPaymentMethodsDetach).not.toHaveBeenCalled();
+  });
+
+  it('detach error does not block new card confirmation', async () => {
+    mockPaymentMethodsDetach.mockImplementationOnce(() =>
+      Promise.reject(new Error('Stripe detach failed')),
+    );
+
+    createMockChain([
+      [{ id: OWNER_ID }], // middleware
+      [{ stripeCardPaymentMethodId: 'pm_old_123' }], // existing card
+      [{ id: OWNER_ID }], // DB update (still proceeds)
+    ]);
+
+    const caller = createOwnerCaller(ctx());
+    const result = await caller.confirmCardPaymentMethod({ sessionId: 'cs_setup_test_123' });
+    expect(result.success).toBe(true);
+    expect(result.paymentMethodId).toBe('pm_card_new_456');
   });
 });


### PR DESCRIPTION
## Summary
- **Remove**: Pet owners can now remove a saved debit card or bank account from settings, with confirmation dialog. Removal is blocked if it's the only method and they have active plans. Auto-switches to the other method when applicable.
- **Replace**: When adding a new card (via Stripe Checkout setup) or bank account (via Plaid Link), the old instrument is automatically detached from Stripe and the old Plaid item is removed.
- **Validate**: Before charging an installment, the system now validates the payment method still exists in Stripe. If deleted, the payment immediately fails (triggering retry/soft-collection) instead of creating an orphaned `processing` record.

## Files changed
| File | What |
|------|------|
| `server/services/audit.ts` | Added `payment_method_removed` and `payment_method_replaced` audit actions |
| `server/routers/owner.ts` | New `removePaymentMethod` procedure; updated `confirmCardPaymentMethod` to detach old card |
| `server/services/plaid.ts` | Updated `exchangePublicToken` to detach old bank/Plaid when replacing |
| `server/services/payment.ts` | Added `validatePaymentMethod()` + integrated into `processInstallment()` |
| `components/ui/alert-dialog.tsx` | New shadcn AlertDialog component |
| `app/owner/settings/_components/payment-method-section.tsx` | Remove + Replace buttons with confirmation dialog |
| `tests/isolated/owner-router.test.ts` | 11 new tests (7 remove, 4 replace) |
| `server/__tests__/services/payment.test.ts` | 2 new tests (PM validation) |

## Test plan
- [x] `bun run test` — 499 tests pass
- [x] `bun test tests/isolated/owner-router.test.ts` — 39 tests pass (11 new)
- [x] `bun run typecheck` — clean
- [x] `bun run check` — Biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)