### PR TITLE
feat: API security hardening + OpenAPI response schemas

### DIFF
--- a/server/__tests__/stripe/_mock-schema.ts
+++ b/server/__tests__/stripe/_mock-schema.ts
@@ -69,6 +69,8 @@ export const schemaMock = {
     keyPrefix: 'api_keys.key_prefix',
     permissions: 'api_keys.permissions',
     lastUsedAt: 'api_keys.last_used_at',
+    expiresAt: 'api_keys.expires_at',
+    allowedIps: 'api_keys.allowed_ips',
     createdAt: 'api_keys.created_at',
     revokedAt: 'api_keys.revoked_at',
   },

--- a/server/api/app.ts
+++ b/server/api/app.ts
@@ -2,7 +2,8 @@
 // Creates the OpenAPIHono app with middleware stack and route groups.
 // Both the Next.js catch-all and tests use this factory.
 
-import { OpenAPIHono } from '@hono/zod-openapi';
+import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi';
+import { apiAuditMiddleware } from '@/server/api/middleware/audit';
 import { authMiddleware } from '@/server/api/middleware/auth';
 import { corsMiddleware } from '@/server/api/middleware/cors';
 import { errorHandler } from '@/server/api/middleware/error-handler';
@@ -12,6 +13,115 @@ import { clinicRoutes } from '@/server/api/routes/clinic';
 import { enrollmentRoutes } from '@/server/api/routes/enrollments';
 import { payoutRoutes } from '@/server/api/routes/payouts';
 import type { ApiVariables } from '@/server/api/types';
+
+const API_DESCRIPTION = `
+# FuzzyCat External REST API
+
+REST API for veterinary clinic POS integrations. Manage payment plan enrollments,
+view clinic data, track payouts, and export reports programmatically.
+
+## Authentication
+
+All endpoints (except \`/health\` and \`/openapi.json\`) require a Bearer token.
+
+\`\`\`
+Authorization: Bearer fc_live_<32-hex-chars>
+\`\`\`
+
+### Obtaining an API Key
+
+1. Log in to the **Clinic Portal** at [fuzzycatapp.com](https://www.fuzzycatapp.com)
+2. Navigate to **Settings → API Keys**
+3. Click **Create Key**, name it, and select the permission scopes you need
+4. Copy the key immediately — it is shown only once and cannot be retrieved later
+
+### Revoking a Key
+
+Revoke keys from the same Settings page. Revocation is immediate and permanent.
+
+## Permission Scopes
+
+Each API key is granted specific scopes at creation:
+
+| Scope | Access |
+|-------|--------|
+| \`enrollments:read\` | View enrollment details |
+| \`enrollments:write\` | Create and cancel enrollments |
+| \`clinic:read\` | View clinic profile, stats, and revenue |
+| \`clinic:write\` | Update clinic profile |
+| \`clients:read\` | View client and plan details |
+| \`export:read\` | Download CSV exports |
+| \`payouts:read\` | View payout history and earnings |
+
+A request to an endpoint without the required scope returns \`403 Forbidden\`.
+
+## Rate Limiting
+
+When rate limiting is active, each clinic is allowed **100 requests per 60-second
+sliding window**. Responses include these headers:
+
+| Header | Description |
+|--------|-------------|
+| \`X-RateLimit-Limit\` | Maximum requests per window (100) |
+| \`X-RateLimit-Remaining\` | Requests remaining in the current window |
+| \`X-RateLimit-Reset\` | Unix timestamp when the window resets |
+
+Exceeding the limit returns \`429 Too Many Requests\`.
+
+## Error Format
+
+All errors follow a consistent structure:
+
+\`\`\`json
+{
+  "error": {
+    "code": "ERROR_CODE",
+    "message": "Human-readable description",
+    "details": {}
+  }
+}
+\`\`\`
+
+| Code | HTTP Status | Meaning |
+|------|-------------|---------|
+| \`VALIDATION_ERROR\` | 400 / 422 | Invalid request body or parameters |
+| \`UNAUTHORIZED\` | 401 | Missing or invalid API key |
+| \`FORBIDDEN\` | 403 | Valid key but insufficient permissions |
+| \`NOT_FOUND\` | 404 | Resource does not exist or not owned by your clinic |
+| \`RATE_LIMITED\` | 429 | Too many requests |
+| \`INTERNAL_ERROR\` | 500 | Unexpected server error |
+
+## Monetary Values
+
+All monetary amounts are in **integer cents** (USD). For example, \`150000\` = $1,500.00.
+
+## Request Tracing
+
+Every response includes an \`X-Request-Id\` header (UUID). Include this when
+contacting support for request-level debugging.
+`.trim();
+
+const healthRoute = createRoute({
+  method: 'get',
+  path: '/health',
+  tags: ['System'],
+  summary: 'Health check',
+  description: 'Returns API health status. No authentication required.',
+  security: [],
+  responses: {
+    200: {
+      description: 'API is healthy',
+      content: {
+        'application/json': {
+          schema: z.object({
+            status: z.literal('ok'),
+            api: z.literal('v1'),
+          }),
+        },
+      },
+    },
+  },
+});
 
 export function createApiApp() {
   const app = new OpenAPIHono<{ Variables: ApiVariables }>({
@@ -36,12 +146,13 @@ export function createApiApp() {
   app.use('*', corsMiddleware);
   app.use('*', createRateLimitMiddleware());
   app.use('*', authMiddleware);
+  app.use('*', apiAuditMiddleware);
 
   // ── Global error handler ────────────────────────────────────────
   app.onError(errorHandler);
 
   // ── Health check ────────────────────────────────────────────────
-  app.get('/health', (c) => c.json({ status: 'ok', api: 'v1' }));
+  app.openapi(healthRoute, (c) => c.json({ status: 'ok' as const, api: 'v1' as const }, 200));
 
   // ── Route groups ────────────────────────────────────────────────
   app.route('/enrollments', enrollmentRoutes);
@@ -54,10 +165,32 @@ export function createApiApp() {
     info: {
       title: 'FuzzyCat API',
       version: '1.0.0',
-      description: 'External REST API for veterinary clinic POS integrations',
+      description: API_DESCRIPTION,
     },
     servers: [{ url: '/api/v1', description: 'API v1' }],
     security: [{ bearerAuth: [] }],
+    'x-tagGroups': [
+      { name: 'System', tags: ['System'] },
+      { name: 'Enrollments', tags: ['Enrollments'] },
+      { name: 'Clinic', tags: ['Clinic'] },
+      { name: 'Payouts', tags: ['Payouts'] },
+    ],
+  });
+
+  // ── Scalar API docs UI ──────────────────────────────────────────
+  app.get('/docs', (c) => {
+    return c.html(`<!doctype html>
+<html>
+<head>
+  <title>FuzzyCat API Reference</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+<body>
+  <script id="api-reference" data-url="/api/v1/openapi.json"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+</body>
+</html>`);
   });
 
   return app;

--- a/server/api/middleware/audit.ts
+++ b/server/api/middleware/audit.ts
@@ -1,0 +1,64 @@
+// ── API request audit logging middleware ──────────────────────────────
+// Logs write operations (POST, PATCH, DELETE) to the audit trail for
+// compliance. Read operations (GET) are logged to application logger
+// only (structured JSON) to avoid excessive DB writes.
+
+import type { MiddlewareHandler } from 'hono';
+import { logger } from '@/lib/logger';
+import type { ApiVariables } from '@/server/api/types';
+import { logAuditEvent } from '@/server/services/audit';
+
+const WRITE_METHODS = new Set(['POST', 'PATCH', 'PUT', 'DELETE']);
+const SKIP_PATHS = ['/openapi.json', '/health', '/docs'];
+
+/**
+ * Audit middleware that runs AFTER the route handler.
+ * - All requests: structured log to application logger
+ * - Write requests (POST/PATCH/DELETE): audit log to database
+ */
+export const apiAuditMiddleware: MiddlewareHandler<{ Variables: ApiVariables }> = async (
+  c,
+  next,
+) => {
+  const startTime = Date.now();
+
+  await next();
+
+  // Skip audit for non-authenticated endpoints
+  if (SKIP_PATHS.some((p) => c.req.path.endsWith(p))) {
+    return;
+  }
+
+  const durationMs = Date.now() - startTime;
+  const clinicId = c.get('clinicId');
+  const method = c.req.method;
+  const path = c.req.path;
+  const status = c.res.status;
+  const ipAddress =
+    c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ?? c.req.header('x-real-ip') ?? null;
+  const requestId = c.get('requestId');
+
+  // Structured application log for ALL requests
+  logger.info('API request', {
+    method,
+    path,
+    status,
+    durationMs,
+    clinicId,
+    requestId,
+    ip: ipAddress,
+  });
+
+  // Audit log to database for write operations only (compliance trail)
+  if (clinicId && WRITE_METHODS.has(method)) {
+    logAuditEvent({
+      entityType: 'api_key',
+      entityId: clinicId,
+      action: 'api_request',
+      newValue: { method, path, status, durationMs, requestId },
+      actorType: 'clinic',
+      actorId: clinicId,
+      ipAddress,
+    });
+  }
+};

--- a/server/api/middleware/auth.ts
+++ b/server/api/middleware/auth.ts
@@ -11,12 +11,13 @@ import { validateApiKey } from '@/server/services/api-key';
  * Authentication middleware for external API routes.
  * Expects: `Authorization: Bearer fc_live_...`
  *
- * Skips auth for the OpenAPI spec endpoint.
+ * Skips auth for the OpenAPI spec and health check endpoints.
+ * Passes client IP for allowlist checking.
  */
 export const authMiddleware: MiddlewareHandler<{ Variables: ApiVariables }> = async (c, next) => {
-  // Skip auth for OpenAPI spec and health check
+  // Skip auth for OpenAPI spec, health check, and docs
   const path = c.req.path;
-  if (path.endsWith('/openapi.json') || path.endsWith('/health')) {
+  if (path.endsWith('/openapi.json') || path.endsWith('/health') || path.endsWith('/docs')) {
     await next();
     return;
   }
@@ -32,7 +33,14 @@ export const authMiddleware: MiddlewareHandler<{ Variables: ApiVariables }> = as
   }
 
   const token = match[1];
-  const result = await validateApiKey(token);
+
+  // Extract client IP for allowlist validation
+  const ipAddress =
+    c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ??
+    c.req.header('x-real-ip') ??
+    undefined;
+
+  const result = await validateApiKey(token, { ipAddress });
 
   if (!result) {
     throw new ApiError(401, ErrorCodes.UNAUTHORIZED, 'Invalid or revoked API key');

--- a/server/api/middleware/rate-limit.ts
+++ b/server/api/middleware/rate-limit.ts
@@ -1,9 +1,10 @@
 // ── Rate limiting middleware (optional, env-gated) ───────────────────
 // Uses @upstash/ratelimit when UPSTASH_REDIS_REST_URL is configured.
-// When not configured, this middleware is a no-op passthrough.
+// Falls back to an in-memory fixed-window limiter when Redis is unavailable.
 
 import type { MiddlewareHandler } from 'hono';
 import { serverEnv } from '@/lib/env';
+import { logger } from '@/lib/logger';
 import { ApiError, ErrorCodes } from '@/server/api/middleware/error-handler';
 import type { ApiVariables } from '@/server/api/types';
 
@@ -13,13 +14,67 @@ type RateLimiter = {
   ) => Promise<{ success: boolean; limit: number; remaining: number; reset: number }>;
 };
 
+/** Simple in-memory fixed-window rate limiter (fallback when Redis unavailable). */
+class InMemoryRateLimiter implements RateLimiter {
+  private windows = new Map<string, { count: number; resetAt: number }>();
+  private maxRequests: number;
+  private windowMs: number;
+  // Periodic cleanup to prevent memory leaks
+  private cleanupInterval: ReturnType<typeof setInterval>;
+
+  constructor(maxRequests: number, windowMs: number) {
+    this.maxRequests = maxRequests;
+    this.windowMs = windowMs;
+    // Clean up expired entries every 5 minutes
+    this.cleanupInterval = setInterval(() => this.cleanup(), 5 * 60 * 1000);
+    // Don't keep the process alive just for cleanup
+    if (this.cleanupInterval.unref) this.cleanupInterval.unref();
+  }
+
+  private cleanup() {
+    const now = Date.now();
+    for (const [key, entry] of this.windows) {
+      if (now >= entry.resetAt) this.windows.delete(key);
+    }
+  }
+
+  async limit(
+    id: string,
+  ): Promise<{ success: boolean; limit: number; remaining: number; reset: number }> {
+    const now = Date.now();
+    const entry = this.windows.get(id);
+
+    if (!entry || now >= entry.resetAt) {
+      this.windows.set(id, { count: 1, resetAt: now + this.windowMs });
+      return {
+        success: true,
+        limit: this.maxRequests,
+        remaining: this.maxRequests - 1,
+        reset: Math.ceil((now + this.windowMs) / 1000),
+      };
+    }
+
+    entry.count++;
+    const remaining = Math.max(0, this.maxRequests - entry.count);
+    return {
+      success: entry.count <= this.maxRequests,
+      limit: this.maxRequests,
+      remaining,
+      reset: Math.ceil(entry.resetAt / 1000),
+    };
+  }
+}
+
 /** Attempt to create an Upstash-backed rate limiter from env vars. */
-async function initLimiter(): Promise<RateLimiter | null> {
+async function initLimiter(): Promise<RateLimiter> {
   try {
     const env = serverEnv();
     const url = env.UPSTASH_REDIS_REST_URL;
     const token = env.UPSTASH_REDIS_REST_TOKEN;
-    if (!url || !token) return null;
+    if (!url || !token) {
+      logger.info('Rate limiter: using in-memory fallback (Redis not configured)');
+      return new InMemoryRateLimiter(100, 60_000);
+    }
 
     const { Ratelimit } = await import('@upstash/ratelimit');
     const { Redis } = await import('@upstash/redis');
@@ -30,7 +85,8 @@ async function initLimiter(): Promise<RateLimiter | null> {
       prefix: 'api_v1',
     });
   } catch {
-    return null;
+    logger.info('Rate limiter: using in-memory fallback (Redis not configured)');
+    return new InMemoryRateLimiter(100, 60_000);
   }
 }
 
@@ -56,13 +112,10 @@ export function createRateLimitMiddleware(): MiddlewareHandler<{ Variables: ApiV
       limiter = await initLimiter();
     }
 
-    if (!limiter) {
-      await next();
-      return;
-    }
-
+    // limiter is always non-null after initLimiter (falls back to in-memory)
+    const activeLimiter = limiter as RateLimiter;
     const identifier = c.get('clinicId') ?? c.req.header('x-forwarded-for') ?? 'anonymous';
-    const result = await limiter.limit(identifier);
+    const result = await activeLimiter.limit(identifier);
 
     c.header('X-RateLimit-Limit', String(result.limit));
     c.header('X-RateLimit-Remaining', String(result.remaining));

--- a/server/api/routes/clinic.ts
+++ b/server/api/routes/clinic.ts
@@ -33,6 +33,182 @@ const errorResponseSchema = z.object({
   }),
 });
 
+// ── Response schemas ─────────────────────────────────────────────────
+
+const clinicProfileSchema = z.object({
+  id: z.string().uuid().openapi({ example: '550e8400-e29b-41d4-a716-446655440000' }),
+  name: z.string().openapi({ example: 'Happy Paws Veterinary' }),
+  email: z.string().email().openapi({ example: 'clinic@happypaws.com' }),
+  phone: z.string().nullable().openapi({ example: '+15551234567' }),
+  addressLine1: z.string().nullable().openapi({ example: '123 Main St' }),
+  addressCity: z.string().nullable().openapi({ example: 'Austin' }),
+  addressState: z.string().nullable().openapi({ example: 'TX' }),
+  addressZip: z.string().nullable().openapi({ example: '78701' }),
+  stripeAccountId: z.string().nullable().openapi({ example: 'acct_1234567890' }),
+  status: z.string().openapi({ example: 'active' }),
+});
+
+const recentEnrollmentSchema = z.object({
+  id: z.string().uuid(),
+  ownerName: z.string().nullable(),
+  petName: z.string().nullable(),
+  totalBillCents: z.number().openapi({ example: 150000 }),
+  status: z.string().openapi({ example: 'active' }),
+  createdAt: z.string().nullable().openapi({ example: '2026-01-15T12:00:00.000Z' }),
+});
+
+/** Dashboard stats — has Date fields in recentEnrollments, needs .passthrough() */
+const dashboardStatsSchema = z
+  .object({
+    activePlans: z.number().openapi({ example: 12 }),
+    completedPlans: z.number().openapi({ example: 45 }),
+    defaultedPlans: z.number().openapi({ example: 2 }),
+    totalPlans: z.number().openapi({ example: 59 }),
+    totalRevenueCents: z.number().openapi({ example: 850000 }),
+    totalPayoutCents: z.number().openapi({ example: 7500000 }),
+    pendingPayoutsCount: z.number().openapi({ example: 3 }),
+    pendingPayoutsCents: z.number().openapi({ example: 450000 }),
+    recentEnrollments: z.array(recentEnrollmentSchema),
+  })
+  .passthrough();
+
+const clientStatsSchema = z.object({
+  activePlans: z.number().openapi({ example: 5 }),
+  totalOutstandingCents: z.number().openapi({ example: 250000 }),
+  defaultRate: z.number().openapi({ example: 2.5 }),
+});
+
+const defaultRateSchema = z.object({
+  totalPlans: z.number().openapi({ example: 50 }),
+  defaultedPlans: z.number().openapi({ example: 2 }),
+  defaultRate: z.number().openapi({ example: 4.0 }),
+});
+
+const enrollmentTrendSchema = z.object({
+  month: z.string().openapi({ example: '2026-01' }),
+  enrollments: z.number().openapi({ example: 8 }),
+});
+
+const clientRowSchema = z.object({
+  planId: z.string().uuid(),
+  ownerName: z.string().nullable(),
+  ownerEmail: z.string().nullable(),
+  ownerPhone: z.string().nullable(),
+  petName: z.string().nullable(),
+  totalBillCents: z.number().openapi({ example: 150000 }),
+  totalWithFeeCents: z.number().openapi({ example: 159000 }),
+  planStatus: z.string().openapi({ example: 'active' }),
+  nextPaymentAt: z.string().nullable().openapi({ example: '2026-02-01T00:00:00.000Z' }),
+  createdAt: z.string().nullable().openapi({ example: '2026-01-15T12:00:00.000Z' }),
+  totalPaidCents: z.number().openapi({ example: 39750 }),
+});
+
+/** Clients list — has Date fields (nextPaymentAt, createdAt), needs .passthrough() */
+const clientsResponseSchema = z
+  .object({
+    clients: z.array(clientRowSchema),
+    pagination: z.object({
+      page: z.number().openapi({ example: 1 }),
+      pageSize: z.number().openapi({ example: 20 }),
+      totalCount: z.number().openapi({ example: 42 }),
+      totalPages: z.number().openapi({ example: 3 }),
+    }),
+  })
+  .passthrough();
+
+const clientPlanSchema = z.object({
+  id: z.string().uuid(),
+  totalBillCents: z.number(),
+  totalWithFeeCents: z.number(),
+  depositCents: z.number(),
+  installmentCents: z.number(),
+  numInstallments: z.number(),
+  status: z.string(),
+  createdAt: z.string().nullable(),
+  petName: z.string().nullable(),
+  totalPaidCents: z.number(),
+});
+
+/** Client details — has Date fields (plans[].createdAt, clientSince), needs .passthrough() */
+const clientDetailsSchema = z
+  .object({
+    owner: z.object({
+      name: z.string().nullable(),
+      email: z.string().nullable(),
+      phone: z.string().nullable(),
+      petName: z.string().nullable(),
+    }),
+    plans: z.array(clientPlanSchema),
+    clientSince: z.string().nullable().openapi({ example: '2026-01-15T12:00:00.000Z' }),
+  })
+  .passthrough();
+
+const planDetailSchema = z.object({
+  id: z.string().uuid(),
+  clinicId: z.string().uuid().nullable(),
+  totalBillCents: z.number(),
+  feeCents: z.number(),
+  totalWithFeeCents: z.number(),
+  depositCents: z.number(),
+  remainingCents: z.number(),
+  installmentCents: z.number(),
+  numInstallments: z.number(),
+  status: z.string(),
+  depositPaidAt: z.string().nullable(),
+  nextPaymentAt: z.string().nullable(),
+  completedAt: z.string().nullable(),
+  createdAt: z.string().nullable(),
+  ownerName: z.string().nullable(),
+  ownerEmail: z.string().nullable(),
+  ownerPhone: z.string().nullable(),
+  petName: z.string().nullable(),
+});
+
+const paymentDetailSchema = z.object({
+  id: z.string().uuid(),
+  type: z.string().openapi({ example: 'installment' }),
+  sequenceNum: z.number().nullable().openapi({ example: 1 }),
+  amountCents: z.number().openapi({ example: 19875 }),
+  status: z.string().openapi({ example: 'succeeded' }),
+  scheduledAt: z.string().openapi({ example: '2026-02-01T00:00:00.000Z' }),
+  processedAt: z.string().nullable().openapi({ example: '2026-02-01T12:30:00.000Z' }),
+  failureReason: z.string().nullable(),
+  retryCount: z.number().nullable().openapi({ example: 0 }),
+});
+
+const payoutDetailSchema = z.object({
+  id: z.string().uuid(),
+  amountCents: z.number().openapi({ example: 19000 }),
+  clinicShareCents: z.number().openapi({ example: 570 }),
+  stripeTransferId: z.string().nullable().openapi({ example: 'tr_1234567890' }),
+  status: z.string().openapi({ example: 'succeeded' }),
+  createdAt: z.string().nullable().openapi({ example: '2026-02-01T12:30:00.000Z' }),
+});
+
+/** Plan details — has many Date fields, needs .passthrough() */
+const planDetailsResponseSchema = z
+  .object({
+    plan: planDetailSchema,
+    payments: z.array(paymentDetailSchema),
+    payouts: z.array(payoutDetailSchema),
+  })
+  .passthrough();
+
+const monthlyRevenueSchema = z.object({
+  month: z.string().openapi({ example: '2026-01' }),
+  totalPayoutCents: z.number().openapi({ example: 500000 }),
+  totalShareCents: z.number().openapi({ example: 15000 }),
+  payoutCount: z.number().openapi({ example: 10 }),
+});
+
+const revenueReportSchema = z.object({
+  month: z.string().openapi({ example: '2026-01' }),
+  enrollments: z.number().openapi({ example: 8 }),
+  revenueCents: z.number().openapi({ example: 500000 }),
+  payoutsCents: z.number().openapi({ example: 500000 }),
+  clinicShareCents: z.number().openapi({ example: 15000 }),
+});
+
 // ── Route definitions ────────────────────────────────────────────────
 
 const getProfileRoute = createRoute({
@@ -44,7 +220,7 @@ const getProfileRoute = createRoute({
   responses: {
     200: {
       description: 'Clinic profile',
-      content: { 'application/json': { schema: z.object({}).passthrough() } },
+      content: { 'application/json': { schema: clinicProfileSchema } },
     },
     404: {
       description: 'Not found',
@@ -81,7 +257,7 @@ const updateProfileRoute = createRoute({
   responses: {
     200: {
       description: 'Updated profile',
-      content: { 'application/json': { schema: z.object({}).passthrough() } },
+      content: { 'application/json': { schema: clinicProfileSchema } },
     },
     400: {
       description: 'Bad request',
@@ -99,7 +275,7 @@ const getStatsRoute = createRoute({
   responses: {
     200: {
       description: 'Dashboard stats',
-      content: { 'application/json': { schema: z.object({}).passthrough() } },
+      content: { 'application/json': { schema: dashboardStatsSchema } },
     },
   },
 });
@@ -113,7 +289,7 @@ const getClientStatsRoute = createRoute({
   responses: {
     200: {
       description: 'Client stats',
-      content: { 'application/json': { schema: z.object({}).passthrough() } },
+      content: { 'application/json': { schema: clientStatsSchema } },
     },
   },
 });
@@ -127,7 +303,7 @@ const getDefaultsRoute = createRoute({
   responses: {
     200: {
       description: 'Default rate',
-      content: { 'application/json': { schema: z.object({}).passthrough() } },
+      content: { 'application/json': { schema: defaultRateSchema } },
     },
   },
 });
@@ -146,7 +322,7 @@ const getTrendsRoute = createRoute({
   responses: {
     200: {
       description: 'Enrollment trends',
-      content: { 'application/json': { schema: z.array(z.object({}).passthrough()) } },
+      content: { 'application/json': { schema: z.array(enrollmentTrendSchema) } },
     },
   },
 });
@@ -170,7 +346,7 @@ const getClientsRoute = createRoute({
   responses: {
     200: {
       description: 'Client list with pagination',
-      content: { 'application/json': { schema: z.object({}).passthrough() } },
+      content: { 'application/json': { schema: clientsResponseSchema } },
     },
   },
 });
@@ -187,7 +363,7 @@ const getClientDetailsRoute = createRoute({
   responses: {
     200: {
       description: 'Client details',
-      content: { 'application/json': { schema: z.object({}).passthrough() } },
+      content: { 'application/json': { schema: clientDetailsSchema } },
     },
     404: {
       description: 'Not found',
@@ -208,7 +384,7 @@ const getPlanDetailsRoute = createRoute({
   responses: {
     200: {
       description: 'Plan details',
-      content: { 'application/json': { schema: z.object({}).passthrough() } },
+      content: { 'application/json': { schema: planDetailsResponseSchema } },
     },
     404: {
       description: 'Not found',
@@ -226,7 +402,7 @@ const getRevenueRoute = createRoute({
   responses: {
     200: {
       description: 'Monthly revenue data',
-      content: { 'application/json': { schema: z.array(z.object({}).passthrough()) } },
+      content: { 'application/json': { schema: z.array(monthlyRevenueSchema) } },
     },
   },
 });
@@ -246,7 +422,7 @@ const getRevenueReportRoute = createRoute({
   responses: {
     200: {
       description: 'Revenue report',
-      content: { 'application/json': { schema: z.array(z.object({}).passthrough()) } },
+      content: { 'application/json': { schema: z.array(revenueReportSchema) } },
     },
   },
 });

--- a/server/api/routes/enrollments.ts
+++ b/server/api/routes/enrollments.ts
@@ -16,6 +16,28 @@ import {
   getEnrollmentSummary,
 } from '@/server/services/enrollment';
 
+// ── Enrollment velocity limiter ──────────────────────────────────────
+// Prevents rapid-fire enrollment creation. Max 10 enrollments per clinic
+// per hour via the API. This is an in-memory check (resets on restart).
+
+const ENROLLMENT_RATE_LIMIT = 10;
+const ENROLLMENT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+
+const enrollmentWindows = new Map<string, { count: number; resetAt: number }>();
+
+function checkEnrollmentVelocity(clinicId: string): boolean {
+  const now = Date.now();
+  const entry = enrollmentWindows.get(clinicId);
+
+  if (!entry || now >= entry.resetAt) {
+    enrollmentWindows.set(clinicId, { count: 1, resetAt: now + ENROLLMENT_WINDOW_MS });
+    return true;
+  }
+
+  entry.count++;
+  return entry.count <= ENROLLMENT_RATE_LIMIT;
+}
+
 // ── Schemas ──────────────────────────────────────────────────────────
 
 const ownerDataSchema = z.object({
@@ -119,6 +141,10 @@ const createEnrollmentRoute = createRoute({
       description: 'Unauthorized',
       content: { 'application/json': { schema: errorResponseSchema } },
     },
+    429: {
+      description: 'Enrollment rate limit exceeded',
+      content: { 'application/json': { schema: errorResponseSchema } },
+    },
     422: {
       description: 'Validation failed',
       content: { 'application/json': { schema: errorResponseSchema } },
@@ -199,6 +225,15 @@ enrollmentRoutes.openapi(createEnrollmentRoute, async (c) => {
       400,
       ErrorCodes.VALIDATION_ERROR,
       'Payment plans are not currently available in New York state.',
+    );
+  }
+
+  // Velocity check — prevent rapid-fire enrollment creation
+  if (!checkEnrollmentVelocity(clinicId)) {
+    throw new ApiError(
+      429,
+      ErrorCodes.RATE_LIMITED,
+      'Enrollment rate limit exceeded. Maximum 10 enrollments per hour.',
     );
   }
 

--- a/server/api/routes/payouts.ts
+++ b/server/api/routes/payouts.ts
@@ -7,6 +7,27 @@ import { requirePermission } from '@/server/api/middleware/permissions';
 import type { ApiVariables } from '@/server/api/types';
 import { getClinicEarnings, getClinicPayoutHistory } from '@/server/services/payout';
 
+// ── Response schemas ─────────────────────────────────────────────────
+
+const payoutSummarySchema = z.object({
+  id: z.string().uuid(),
+  planId: z.string().uuid().nullable(),
+  paymentId: z.string().uuid().nullable(),
+  amountCents: z.number().openapi({ example: 19000 }),
+  clinicShareCents: z.number().openapi({ example: 570 }),
+  stripeTransferId: z.string().nullable().openapi({ example: 'tr_1234567890' }),
+  status: z.enum(['pending', 'succeeded', 'failed']).openapi({ example: 'succeeded' }),
+  createdAt: z.string().nullable().openapi({ example: '2026-01-15T12:00:00.000Z' }),
+});
+
+/** Payout list — has Date fields (createdAt), needs .passthrough() */
+const payoutListResponseSchema = z
+  .object({
+    payouts: z.array(payoutSummarySchema),
+    total: z.number().openapi({ example: 42 }),
+  })
+  .passthrough();
+
 // ── Route definitions ────────────────────────────────────────────────
 
 const listPayoutsRoute = createRoute({
@@ -25,7 +46,7 @@ const listPayoutsRoute = createRoute({
   responses: {
     200: {
       description: 'Payout list',
-      content: { 'application/json': { schema: z.object({}).passthrough() } },
+      content: { 'application/json': { schema: payoutListResponseSchema } },
     },
   },
 });

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -274,6 +274,8 @@ export const apiKeys = pgTable(
     keyPrefix: text('key_prefix').notNull(),
     permissions: text('permissions').array().notNull(),
     lastUsedAt: timestamp('last_used_at', { withTimezone: true }),
+    expiresAt: timestamp('expires_at', { withTimezone: true }),
+    allowedIps: text('allowed_ips').array(),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
     revokedAt: timestamp('revoked_at', { withTimezone: true }),
   },

--- a/server/services/api-key.ts
+++ b/server/services/api-key.ts
@@ -19,6 +19,14 @@ const DISPLAY_PREFIX_LENGTH = 12; // e.g. "fc_live_a1b2"
 
 // ── Types ────────────────────────────────────────────────────────────
 
+export interface CreateApiKeyOptions {
+  actorId?: string;
+  /** Optional expiration date. After this time, the key is rejected. */
+  expiresAt?: Date;
+  /** Optional IP allowlist. If set, requests from other IPs are rejected. */
+  allowedIps?: string[];
+}
+
 export interface CreateApiKeyResult {
   /** The API key ID (database UUID). */
   id: string;
@@ -34,6 +42,8 @@ export interface ApiKeyInfo {
   keyPrefix: string;
   permissions: string[];
   lastUsedAt: Date | null;
+  expiresAt: Date | null;
+  allowedIps: string[] | null;
   createdAt: Date | null;
   revokedAt: Date | null;
 }
@@ -73,8 +83,12 @@ export async function generateApiKey(
   clinicId: string,
   name: string,
   permissions: string[],
-  actorId?: string,
+  options?: CreateApiKeyOptions | string,
 ): Promise<CreateApiKeyResult> {
+  // Backwards-compat: old signature passed actorId as 4th arg
+  const opts: CreateApiKeyOptions =
+    typeof options === 'string' ? { actorId: options } : (options ?? {});
+
   const validPermissions = validatePermissions(permissions);
   const plaintextKey = generatePlaintextKey();
   const keyHash = hashKey(plaintextKey);
@@ -88,17 +102,25 @@ export async function generateApiKey(
       keyHash,
       keyPrefix,
       permissions: validPermissions,
+      ...(opts.expiresAt && { expiresAt: opts.expiresAt }),
+      ...(opts.allowedIps && { allowedIps: opts.allowedIps }),
     })
     .returning({ id: apiKeys.id });
 
   await logAuditEvent({
-    entityType: 'clinic',
-    entityId: clinicId,
+    entityType: 'api_key',
+    entityId: inserted.id,
     action: 'created',
     oldValue: null,
-    newValue: { apiKeyId: inserted.id, name, permissions: validPermissions },
-    actorType: actorId ? 'clinic' : 'system',
-    actorId: actorId ?? null,
+    newValue: {
+      clinicId,
+      name,
+      permissions: validPermissions,
+      ...(opts.expiresAt && { expiresAt: opts.expiresAt.toISOString() }),
+      ...(opts.allowedIps && { allowedIps: opts.allowedIps }),
+    },
+    actorType: opts.actorId ? 'clinic' : 'system',
+    actorId: opts.actorId ?? null,
   });
 
   logger.info('API key created', { clinicId, apiKeyId: inserted.id, name });
@@ -112,10 +134,13 @@ export async function generateApiKey(
 
 /**
  * Validate an API key and return the associated clinic + permissions.
- * Returns null if the key is invalid, revoked, or not found.
+ * Returns null if the key is invalid, revoked, expired, or IP-rejected.
  * Updates `lastUsedAt` on successful validation.
  */
-export async function validateApiKey(plaintextKey: string): Promise<ValidatedApiKey | null> {
+export async function validateApiKey(
+  plaintextKey: string,
+  options?: { ipAddress?: string },
+): Promise<ValidatedApiKey | null> {
   if (!plaintextKey.startsWith(KEY_PREFIX)) {
     return null;
   }
@@ -128,6 +153,8 @@ export async function validateApiKey(plaintextKey: string): Promise<ValidatedApi
       clinicId: apiKeys.clinicId,
       permissions: apiKeys.permissions,
       revokedAt: apiKeys.revokedAt,
+      expiresAt: apiKeys.expiresAt,
+      allowedIps: apiKeys.allowedIps,
     })
     .from(apiKeys)
     .where(and(eq(apiKeys.keyHash, keyHash), isNull(apiKeys.revokedAt)))
@@ -135,6 +162,38 @@ export async function validateApiKey(plaintextKey: string): Promise<ValidatedApi
 
   if (!row) {
     return null;
+  }
+
+  // Check expiration
+  if (row.expiresAt && new Date() > row.expiresAt) {
+    logger.warn('API key expired', { apiKeyId: row.id, clinicId: row.clinicId });
+    logAuditEvent({
+      entityType: 'api_key',
+      entityId: row.id,
+      action: 'api_key_expired',
+      newValue: { clinicId: row.clinicId, expiresAt: row.expiresAt.toISOString() },
+      actorType: 'system',
+    });
+    return null;
+  }
+
+  // Check IP allowlist
+  if (row.allowedIps && row.allowedIps.length > 0 && options?.ipAddress) {
+    if (!row.allowedIps.includes(options.ipAddress)) {
+      logger.warn('API key IP not allowed', {
+        apiKeyId: row.id,
+        clinicId: row.clinicId,
+        ip: options.ipAddress,
+      });
+      logAuditEvent({
+        entityType: 'api_key',
+        entityId: row.id,
+        action: 'api_key_ip_rejected',
+        newValue: { clinicId: row.clinicId, ip: options.ipAddress },
+        actorType: 'system',
+      });
+      return null;
+    }
   }
 
   // Fire-and-forget lastUsedAt update (non-blocking)
@@ -175,11 +234,11 @@ export async function revokeApiKey(
   }
 
   await logAuditEvent({
-    entityType: 'clinic',
-    entityId: clinicId,
+    entityType: 'api_key',
+    entityId: apiKeyId,
     action: 'status_changed',
-    oldValue: { apiKeyId, revokedAt: null },
-    newValue: { apiKeyId, revokedAt: new Date().toISOString() },
+    oldValue: { clinicId, revokedAt: null },
+    newValue: { clinicId, revokedAt: new Date().toISOString() },
     actorType: actorId ? 'clinic' : 'system',
     actorId: actorId ?? null,
   });
@@ -200,6 +259,8 @@ export async function listApiKeys(clinicId: string): Promise<ApiKeyInfo[]> {
       keyPrefix: apiKeys.keyPrefix,
       permissions: apiKeys.permissions,
       lastUsedAt: apiKeys.lastUsedAt,
+      expiresAt: apiKeys.expiresAt,
+      allowedIps: apiKeys.allowedIps,
       createdAt: apiKeys.createdAt,
       revokedAt: apiKeys.revokedAt,
     })

--- a/server/services/audit.ts
+++ b/server/services/audit.ts
@@ -19,6 +19,7 @@ export const AUDIT_ENTITY_TYPES = [
   'risk_pool',
   'clinic',
   'owner',
+  'api_key',
 ] as const;
 export type EntityType = (typeof AUDIT_ENTITY_TYPES)[number];
 
@@ -36,6 +37,9 @@ export const AUDIT_ACTIONS = [
   'payments_written_off',
   'payment_method_removed',
   'payment_method_replaced',
+  'api_request',
+  'api_key_expired',
+  'api_key_ip_rejected',
 ] as const;
 export type AuditAction = (typeof AUDIT_ACTIONS)[number];
 

--- a/tests/isolated/api-key.test.ts
+++ b/tests/isolated/api-key.test.ts
@@ -33,6 +33,8 @@ mock.module('@/server/db/schema', () => ({
     keyPrefix: 'api_keys.key_prefix',
     permissions: 'api_keys.permissions',
     lastUsedAt: 'api_keys.last_used_at',
+    expiresAt: 'api_keys.expires_at',
+    allowedIps: 'api_keys.allowed_ips',
     createdAt: 'api_keys.created_at',
     revokedAt: 'api_keys.revoked_at',
   },
@@ -178,6 +180,8 @@ describe('validateApiKey', () => {
         clinicId: CLINIC_ID,
         permissions: ['enrollments:read', 'clinic:read'],
         revokedAt: null,
+        expiresAt: null,
+        allowedIps: null,
       },
     ]);
 


### PR DESCRIPTION
## Summary
- **API key expiration**: New `expiresAt` column on `api_keys` — expired keys are rejected with audit logging
- **IP allowlisting**: New `allowedIps` column on `api_keys` — requests from non-allowed IPs are rejected with audit logging
- **API audit middleware**: Write operations (POST/PATCH/DELETE) logged to `audit_log` table; all requests logged to structured application logger with method, path, status, duration, clinic, IP
- **In-memory rate limit fallback**: When Redis is unavailable, a fixed-window in-memory limiter (100 req/60s) kicks in instead of silently disabling rate limiting
- **Enrollment velocity checks**: Max 10 enrollments per clinic per hour via API to prevent abuse/fraud
- **Explicit OpenAPI response schemas**: All 12 `.passthrough()` schemas in clinic and payout routes replaced with documented Zod schemas with `.openapi()` examples
- **Comprehensive API documentation**: Full API description in OpenAPI spec covering auth, permissions, rate limiting, error format, monetary values, and request tracing
- **Scalar docs UI**: Interactive API reference at `/api/v1/docs`
- **SecuritySchemes**: Bearer auth properly declared in OpenAPI spec

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run check` passes (Biome lint + format)
- [x] `bun run test` passes (484 tests, 0 failures)
- [x] All 51 isolated API tests pass individually
- [ ] CI checks pass
- [ ] Verify `/api/v1/openapi.json` serves valid spec with securitySchemes
- [ ] Verify `/api/v1/docs` renders Scalar API reference
- [ ] Verify expired key returns 401
- [ ] Verify IP-restricted key rejects non-allowed IPs

🤖 Generated with [Claude Code](https://claude.com/claude-code)