### PR TITLE
fix: mount Hono API app under /api/v1 prefix

### DIFF
--- a/app/api/v1/[...route]/route.ts
+++ b/app/api/v1/[...route]/route.ts
@@ -1,10 +1,16 @@
 // ── Next.js catch-all route for external REST API ────────────────────
 // Forwards all /api/v1/* requests to the Hono app via the Vercel adapter.
+// The basePath must match the Next.js route prefix so Hono can match
+// paths like /api/v1/health → /health on the app router.
 
+import { Hono } from 'hono';
 import { handle } from 'hono/vercel';
 import { createApiApp } from '@/server/api/app';
 
-const app = createApiApp();
+const apiApp = createApiApp();
+
+// Mount the API app under /api/v1 so the full path matches
+const app = new Hono().route('/api/v1', apiApp);
 
 export const GET = handle(app);
 export const POST = handle(app);


### PR DESCRIPTION
## Summary
- Fixed all `/api/v1/*` endpoints returning 404 in production and locally
- Root cause: Hono app registered routes at `/health`, `/enrollments`, etc. but the Next.js catch-all passes the full path `/api/v1/health` to Hono's fetch handler — no route match
- Fix: mount the API app under a `/api/v1` prefix using `new Hono().route('/api/v1', apiApp)` so full paths correctly map to handlers

## Test plan
- [x] `bun run test` — 484 pass
- [x] `bun run typecheck` — clean
- [x] Isolated tests — 242 pass (15 files)
- [x] Local verification: `/api/v1/health` → 200, `/api/v1/openapi.json` → 21 paths, `/api/v1/enrollments` → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)