### PR TITLE
fix: use correct Scalar API reference CDN version (1.46.0)

### DIFF
--- a/server/api/app.ts
+++ b/server/api/app.ts
@@ -238,7 +238,7 @@ export function createApiApp() {
 </head>
 <body>
   <script id="api-reference" data-url="/api/v1/openapi.json"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@0.1.5" integrity="sha384-nkaTxTyLh1KRRqMea/fXk3r6dumKhvBIfFtoJk64Lzlsb0p/6MTGvWHTHE03hiPV" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.46.0" integrity="sha384-J8SKUvgS9P4wa0c+HdF7IJMAxLKPA2MTTiMrMHEnBGrImueMygyFW5kWh60jyN1j" crossorigin="anonymous"></script>
 </body>
 </html>`);
   });


### PR DESCRIPTION
## Summary
- Fixed `/api/v1/docs` blank page — previous version (0.1.5) was an early alpha using ES modules
- Updated to Scalar API Reference v1.46.0 (latest stable) which works with plain `<script>` tags
- Updated SRI integrity hash

## Test plan
- [x] `bun run test` — 484 pass
- [x] `bun run typecheck` — clean
- [x] Verified CDN returns 200 for `@scalar/api-reference@1.46.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)