### PR TITLE
fix: migrate middleware to proxy, harden Sentry CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,8 +131,8 @@ jobs:
           else
             echo "No test files found, skipping."
           fi
-      - name: Run middleware tests (isolated — mock.module leaks)
-        run: bun test middleware.test.ts --coverage --coverage-reporter=lcov --coverage-dir=coverage-middleware
+      - name: Run proxy tests (isolated — mock.module leaks)
+        run: bun test proxy.test.ts --coverage --coverage-reporter=lcov --coverage-dir=coverage-proxy
       - name: Run authorization matrix tests (isolated — mock.module leaks)
         run: bun test authorization-matrix.test.ts --coverage --coverage-reporter=lcov --coverage-dir=coverage-authz
       - name: Run isolated tests (one-per-process — mock.module leaks)
@@ -144,7 +144,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         if: hashFiles('coverage/lcov.info') != ''
         with:
-          files: coverage/lcov.info,coverage-middleware/lcov.info,coverage-authz/lcov.info
+          files: coverage/lcov.info,coverage-proxy/lcov.info,coverage-authz/lcov.info
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/next.config.ts
+++ b/next.config.ts
@@ -29,11 +29,17 @@ export default withSentryConfig(withBundleAnalyzer(nextConfig), {
   // Proxy Sentry requests through the Next.js server to avoid ad-blockers
   tunnelRoute: '/monitoring',
 
-  // Suppress build noise locally; only log in CI
-  silent: !process.env.CI,
+  // Always silence sentry-cli to avoid EAGAIN crashes from non-blocking stdout
+  // in Vercel's build environment (Rust CLI panics on pipe buffer overflow)
+  silent: true,
 
   // Source maps uploaded then deleted to keep bundle clean
   sourcemaps: {
     deleteSourcemapsAfterUpload: true,
+  },
+
+  // Allow builds to succeed even if source map upload fails (transient Sentry CLI crashes)
+  errorHandler: (err) => {
+    console.warn('[sentry] Source map upload failed (non-fatal):', err.message);
   },
 });

--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -54,9 +54,9 @@ mock.module('@/lib/env', () => ({
   _resetEnvCache: () => {},
 }));
 
-const { middleware } = await import('./middleware');
+const { proxy } = await import('./proxy');
 
-describe('middleware', () => {
+describe('proxy', () => {
   let consoleSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
@@ -74,7 +74,7 @@ describe('middleware', () => {
 
     const { NextRequest } = await import('next/server');
     const req = new NextRequest('http://localhost:3000/clinic/dashboard');
-    const response = await middleware(req);
+    const response = await proxy(req);
 
     // Should pass through (200) rather than crash
     expect(response.status).toBe(200);
@@ -85,7 +85,7 @@ describe('middleware', () => {
 
     const { NextRequest } = await import('next/server');
     const req = new NextRequest('http://localhost:3000/clinic/dashboard');
-    const response = await middleware(req);
+    const response = await proxy(req);
 
     expect(response.status).toBe(307);
     const location = response.headers.get('location');
@@ -108,7 +108,7 @@ describe('middleware', () => {
 
     const { NextRequest } = await import('next/server');
     const req = new NextRequest('http://localhost:3000/login');
-    const response = await middleware(req);
+    const response = await proxy(req);
 
     expect(response.status).toBe(307);
     const location = response.headers.get('location');
@@ -126,7 +126,7 @@ describe('middleware', () => {
         error: null,
       }),
     );
-    const dynamicResp = await middleware(dynamicReq);
+    const dynamicResp = await proxy(dynamicReq);
     const dynamicCsp = dynamicResp.headers.get('Content-Security-Policy');
     expect(dynamicCsp).toBeTruthy();
     expect(dynamicCsp).toContain("default-src 'self'");
@@ -145,7 +145,7 @@ describe('middleware', () => {
     // Test a static route — same CSP
     mockGetUser.mockImplementation(() => Promise.resolve({ data: { user: null }, error: null }));
     const staticReq = new NextRequest('http://localhost:3000/');
-    const staticResp = await middleware(staticReq);
+    const staticResp = await proxy(staticReq);
     const staticCsp = staticResp.headers.get('Content-Security-Policy');
     expect(staticCsp).toEqual(dynamicCsp);
   });
@@ -155,7 +155,7 @@ describe('middleware', () => {
 
     const { NextRequest } = await import('next/server');
     const req = new NextRequest('http://localhost:3000/');
-    const response = await middleware(req);
+    const response = await proxy(req);
 
     const csp = response.headers.get('Content-Security-Policy');
     expect(csp).toBeTruthy();
@@ -171,7 +171,7 @@ describe('middleware', () => {
 
     const { NextRequest } = await import('next/server');
     const req = new NextRequest('http://localhost:3000/owner/payments');
-    const response = await middleware(req);
+    const response = await proxy(req);
 
     // Should redirect to login (unauthenticated)
     expect(response.status).toBe(307);
@@ -211,7 +211,7 @@ describe('middleware', () => {
 
     const { NextRequest } = await import('next/server');
     const req = new NextRequest(`http://localhost:3000${path}`);
-    const response = await middleware(req);
+    const response = await proxy(req);
 
     expect(response.status).toBe(status);
     if (redirect) {

--- a/proxy.ts
+++ b/proxy.ts
@@ -92,8 +92,8 @@ function buildRoleRedirect(
   return null;
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: middleware is inherently sequential — auth routing requires nested conditionals
-export async function middleware(request: NextRequest) {
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: proxy is inherently sequential — auth routing requires nested conditionals
+export async function proxy(request: NextRequest) {
   const startTime = performance.now();
   const nonce = crypto.randomUUID();
   const { pathname } = request.nextUrl;


### PR DESCRIPTION
## Summary
- Migrate `middleware.ts` → `proxy.ts` per Next.js 16 deprecation (eliminates the warning)
- Harden Sentry source map upload: `silent: true` + `errorHandler` to prevent EAGAIN crashes from non-blocking stdout in Vercel's build environment

## Details

### Middleware → Proxy
Next.js 16 renamed the middleware file convention to "proxy". The migration is a rename — all functionality is identical. Updated the exported function name, test file, and CI workflow references.

### Sentry CLI Fix
The Sentry CLI (Rust binary) panics when Node.js sets stdout to non-blocking mode and the pipe buffer fills during source map upload. Fix:
- `silent: true` reduces stdout volume
- `errorHandler` catches failures gracefully so builds succeed even if source map upload fails

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 484 pass
- [x] `bun test proxy.test.ts` — 10 pass
- [x] Biome clean (except auto-generated next-env.d.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)