### PR TITLE
chore: remove stale Plaid env vars from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,9 +197,6 @@ jobs:
           STRIPE_SECRET_KEY: sk_test_placeholder
           STRIPE_WEBHOOK_SECRET: whsec_placeholder
           RESEND_API_KEY: re_placeholder
-          PLAID_CLIENT_ID: placeholder
-          PLAID_SECRET: placeholder
-          PLAID_ENV: sandbox
           TWILIO_ACCOUNT_SID: ACplaceholder
           TWILIO_AUTH_TOKEN: placeholder
           TWILIO_PHONE_NUMBER: '+10000000000'
@@ -230,9 +227,6 @@ jobs:
           STRIPE_SECRET_KEY: sk_test_placeholder
           STRIPE_WEBHOOK_SECRET: whsec_placeholder
           RESEND_API_KEY: re_placeholder
-          PLAID_CLIENT_ID: placeholder
-          PLAID_SECRET: placeholder
-          PLAID_ENV: sandbox
           TWILIO_ACCOUNT_SID: ACplaceholder
           TWILIO_AUTH_TOKEN: placeholder
           TWILIO_PHONE_NUMBER: '+10000000000'


### PR DESCRIPTION
## Summary
- Remove `PLAID_CLIENT_ID`, `PLAID_SECRET`, `PLAID_ENV` placeholder env vars from fast-tests and e2e CI jobs
- Plaid integration was removed in PR #328; these are leftover

🤖 Generated with [Claude Code](https://claude.com/claude-code)