### PR TITLE
fix: revenue export payoutsCents mapping + silence Sentry ad-blocker errors

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -14,26 +14,30 @@ Sentry.init({
 // ~400ms of CDN fetch + integration init during the interaction window.
 if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
   const loadIntegrations = () => {
-    Sentry.lazyLoadIntegration('replayIntegration').then((replayIntegration) => {
-      Sentry.addIntegration(replayIntegration());
-    });
+    Sentry.lazyLoadIntegration('replayIntegration')
+      .then((replayIntegration) => {
+        Sentry.addIntegration(replayIntegration());
+      })
+      .catch(() => {});
 
-    Sentry.lazyLoadIntegration('feedbackIntegration').then((feedbackIntegration) => {
-      Sentry.addIntegration(
-        feedbackIntegration({
-          colorScheme: 'system',
-          autoInject: true,
-          enableScreenshot: true,
-          showBranding: false,
-          triggerLabel: 'Feedback',
-          formTitle: 'Send us feedback',
-          submitButtonLabel: 'Send feedback',
-          messagePlaceholder: "What's on your mind? Bug reports, suggestions, anything.",
-          isEmailRequired: false,
-          isNameRequired: false,
-        }),
-      );
-    });
+    Sentry.lazyLoadIntegration('feedbackIntegration')
+      .then((feedbackIntegration) => {
+        Sentry.addIntegration(
+          feedbackIntegration({
+            colorScheme: 'system',
+            autoInject: true,
+            enableScreenshot: true,
+            showBranding: false,
+            triggerLabel: 'Feedback',
+            formTitle: 'Send us feedback',
+            submitButtonLabel: 'Send feedback',
+            messagePlaceholder: "What's on your mind? Bug reports, suggestions, anything.",
+            isEmailRequired: false,
+            isNameRequired: false,
+          }),
+        );
+      })
+      .catch(() => {});
   };
 
   if (typeof requestIdleCallback === 'function') {

--- a/server/routers/clinic.ts
+++ b/server/routers/clinic.ts
@@ -910,7 +910,7 @@ export const clinicRouter = router({
         month,
         enrollments: enrollmentMap.get(month) ?? 0,
         revenueCents: revenueMap.get(month)?.revenueCents ?? 0,
-        payoutsCents: revenueMap.get(month)?.revenueCents ?? 0,
+        payoutsCents: revenueMap.get(month)?.clinicShareCents ?? 0,
         clinicShareCents: revenueMap.get(month)?.clinicShareCents ?? 0,
       }));
     }),

--- a/server/services/clinic-queries.ts
+++ b/server/services/clinic-queries.ts
@@ -475,7 +475,7 @@ export async function getRevenueReport(clinicId: string, dateFrom: Date, dateTo:
     month,
     enrollments: enrollmentMap.get(month) ?? 0,
     revenueCents: revenueMap.get(month)?.revenueCents ?? 0,
-    payoutsCents: revenueMap.get(month)?.revenueCents ?? 0,
+    payoutsCents: revenueMap.get(month)?.clinicShareCents ?? 0,
     clinicShareCents: revenueMap.get(month)?.clinicShareCents ?? 0,
   }));
 }


### PR DESCRIPTION
## Summary
- **Revenue export bug**: `payoutsCents` was incorrectly mapped to `revenueCents` instead of `clinicShareCents` in both `server/services/clinic-queries.ts` and `server/routers/clinic.ts`, causing incorrect payout figures in CSV exports
- **Sentry console errors**: Added `.catch(() => {})` to `lazyLoadIntegration` promises in `instrumentation-client.ts` so ad-blockers blocking Sentry CDN no longer produce unhandled rejection errors

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run check` passes (pre-existing `next-env.d.ts` format issue only)
- [x] `bun run test` — 484 tests pass
- [ ] Verify revenue CSV export shows correct clinic share amounts
- [ ] Verify no console errors with ad-blocker enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)