### PR TITLE
feat: add existing client search to clinic enrollment

### DIFF
--- a/app/clinic/enroll/_components/client-search.tsx
+++ b/app/clinic/enroll/_components/client-search.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { Loader2, Search, X } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useTRPC } from '@/lib/trpc/client';
+
+export interface ClientResult {
+  id: string;
+  name: string;
+  email: string;
+  phone: string;
+  petName: string;
+  pets: { id: string; name: string; species: string; breed: string | null }[];
+}
+
+interface ClientSearchProps {
+  selectedClient: ClientResult | null;
+  onSelect: (client: ClientResult) => void;
+  onClear: () => void;
+}
+
+export function ClientSearch({ selectedClient, onSelect, onClear }: ClientSearchProps) {
+  const trpc = useTRPC();
+  const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [showResults, setShowResults] = useState(false);
+  const searchRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQuery(searchQuery), 300);
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (searchRef.current && !searchRef.current.contains(e.target as Node)) {
+        setShowResults(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
+  const searchResults = useQuery(
+    trpc.clinic.searchClients.queryOptions(
+      { query: debouncedQuery },
+      { enabled: debouncedQuery.length >= 2 && !selectedClient },
+    ),
+  );
+
+  if (selectedClient) {
+    return (
+      <div className="flex items-center justify-between rounded-md border bg-muted/30 px-3 py-2">
+        <div>
+          <p className="text-sm font-medium">{selectedClient.name}</p>
+          <p className="text-xs text-muted-foreground">{selectedClient.email}</p>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            onClear();
+            setSearchQuery('');
+          }}
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={searchRef} className="relative">
+      <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+      <Input
+        placeholder="Search by name or email..."
+        value={searchQuery}
+        onChange={(e) => {
+          setSearchQuery(e.target.value);
+          setShowResults(true);
+        }}
+        onFocus={() => setShowResults(true)}
+        className="pl-9"
+      />
+      {showResults && debouncedQuery.length >= 2 && (
+        <div className="absolute z-10 mt-1 w-full rounded-md border bg-popover shadow-md">
+          {searchResults.isLoading && (
+            <div className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              Searching...
+            </div>
+          )}
+          {searchResults.data?.length === 0 && (
+            <div className="px-3 py-2 text-sm text-muted-foreground">
+              No existing clients found. Fill in the details below for a new client.
+            </div>
+          )}
+          {searchResults.data?.map((client) => (
+            <button
+              key={client.id}
+              type="button"
+              className="flex w-full items-start gap-3 px-3 py-2 text-left text-sm hover:bg-muted"
+              onClick={() => onSelect(client)}
+            >
+              <div className="flex-1">
+                <p className="font-medium">{client.name}</p>
+                <p className="text-xs text-muted-foreground">{client.email}</p>
+              </div>
+              {client.pets.length > 0 && (
+                <span className="text-xs text-muted-foreground">
+                  {client.pets.map((p) => p.name).join(', ')}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/clinic/enroll/page.tsx
+++ b/app/clinic/enroll/page.tsx
@@ -14,6 +14,7 @@ import { MAX_BILL_CENTS, MIN_BILL_CENTS } from '@/lib/constants';
 import { useTRPC } from '@/lib/trpc/client';
 import { formatCents, toCents } from '@/lib/utils/money';
 import { calculatePaymentSchedule } from '@/lib/utils/schedule';
+import { type ClientResult, ClientSearch } from './_components/client-search';
 
 const MIN_BILL_DOLLARS = MIN_BILL_CENTS / 100;
 const MAX_BILL_DOLLARS = MAX_BILL_CENTS / 100;
@@ -21,9 +22,11 @@ const MAX_BILL_DOLLARS = MAX_BILL_CENTS / 100;
 export default function ClinicEnrollPage() {
   const trpc = useTRPC();
 
-  // Fetch the clinic's own ID from their profile
   const profileQuery = useQuery(trpc.clinic.getProfile.queryOptions());
   const clinicId = profileQuery.data?.id;
+
+  // Client search
+  const [selectedClient, setSelectedClient] = useState<ClientResult | null>(null);
 
   // Form state
   const [ownerName, setOwnerName] = useState('');
@@ -34,6 +37,22 @@ export default function ClinicEnrollPage() {
   const [billDollars, setBillDollars] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [successPlanId, setSuccessPlanId] = useState<string | null>(null);
+
+  function handleSelectClient(client: ClientResult) {
+    setSelectedClient(client);
+    setOwnerName(client.name);
+    setOwnerEmail(client.email);
+    setOwnerPhone(client.phone);
+    setPetName(client.pets.length > 0 ? client.pets[0].name : client.petName);
+  }
+
+  function handleClearClient() {
+    setSelectedClient(null);
+    setOwnerName('');
+    setOwnerEmail('');
+    setOwnerPhone('');
+    setPetName('');
+  }
 
   const billAmountCents = useMemo(() => {
     const parsed = Number.parseFloat(billDollars);
@@ -69,7 +88,6 @@ export default function ClinicEnrollPage() {
       setError('Clinic profile not loaded. Please try again.');
       return;
     }
-
     if (!ownerName.trim()) {
       setError('Owner name is required.');
       return;
@@ -104,7 +122,6 @@ export default function ClinicEnrollPage() {
     });
   }
 
-  // Success state
   if (successPlanId) {
     return (
       <div className="container mx-auto max-w-2xl px-6 py-8">
@@ -161,10 +178,7 @@ export default function ClinicEnrollPage() {
           <Button
             onClick={() => {
               setSuccessPlanId(null);
-              setOwnerName('');
-              setOwnerEmail('');
-              setOwnerPhone('');
-              setPetName('');
+              handleClearClient();
               setBillDollars('');
               setPaymentMethod('debit_card');
               setError(null);
@@ -177,7 +191,6 @@ export default function ClinicEnrollPage() {
     );
   }
 
-  // Loading state
   if (profileQuery.isLoading) {
     return (
       <div className="container mx-auto max-w-2xl px-6 py-8">
@@ -188,7 +201,6 @@ export default function ClinicEnrollPage() {
     );
   }
 
-  // Error loading profile
   if (profileQuery.isError || !clinicId) {
     return (
       <div className="container mx-auto max-w-2xl px-6 py-8">
@@ -230,6 +242,21 @@ export default function ClinicEnrollPage() {
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-6">
+            {/* Client Search */}
+            <div className="space-y-3">
+              <h3 className="text-sm font-medium">Find Existing Client</h3>
+              <ClientSearch
+                selectedClient={selectedClient}
+                onSelect={handleSelectClient}
+                onClear={handleClearClient}
+              />
+              <p className="text-xs text-muted-foreground">
+                Search for a returning client or enter new client details below.
+              </p>
+            </div>
+
+            <Separator />
+
             {/* Owner Information */}
             <div className="space-y-4">
               <h3 className="text-sm font-medium">Pet Owner Information</h3>
@@ -243,6 +270,8 @@ export default function ClinicEnrollPage() {
                     onChange={(e) => setOwnerName(e.target.value)}
                     placeholder="Jane Smith"
                     required
+                    readOnly={!!selectedClient}
+                    className={selectedClient ? 'bg-muted' : ''}
                   />
                 </div>
                 <div className="space-y-2">
@@ -254,6 +283,8 @@ export default function ClinicEnrollPage() {
                     onChange={(e) => setOwnerEmail(e.target.value)}
                     placeholder="jane@example.com"
                     required
+                    readOnly={!!selectedClient}
+                    className={selectedClient ? 'bg-muted' : ''}
                   />
                 </div>
               </div>
@@ -272,13 +303,30 @@ export default function ClinicEnrollPage() {
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="pet-name">Pet Name</Label>
-                  <Input
-                    id="pet-name"
-                    value={petName}
-                    onChange={(e) => setPetName(e.target.value)}
-                    placeholder="Whiskers"
-                    required
-                  />
+                  {selectedClient && selectedClient.pets.length > 1 ? (
+                    <select
+                      id="pet-name"
+                      value={petName}
+                      onChange={(e) => setPetName(e.target.value)}
+                      className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                      required
+                    >
+                      {selectedClient.pets.map((pet) => (
+                        <option key={pet.id} value={pet.name}>
+                          {pet.name} ({pet.species})
+                        </option>
+                      ))}
+                      <option value="">New pet...</option>
+                    </select>
+                  ) : (
+                    <Input
+                      id="pet-name"
+                      value={petName}
+                      onChange={(e) => setPetName(e.target.value)}
+                      placeholder="Whiskers"
+                      required
+                    />
+                  )}
                 </div>
               </div>
             </div>
@@ -337,7 +385,7 @@ export default function ClinicEnrollPage() {
 
             {/* Payment Preview */}
             {schedule && (
-              <div className="rounded-md border bg-muted/30 p-4 space-y-2">
+              <div className="space-y-2 rounded-md border bg-muted/30 p-4">
                 <h3 className="text-sm font-medium">Payment Plan Preview</h3>
                 <div className="grid gap-2 text-sm md:grid-cols-2">
                   <div className="flex justify-between md:flex-col">

--- a/server/routers/clinic.ts
+++ b/server/routers/clinic.ts
@@ -10,7 +10,7 @@ import { generateCsv } from '@/lib/utils/csv';
 import { formatCents } from '@/lib/utils/money';
 import { escapeIlike } from '@/lib/utils/sql';
 import { API_PERMISSIONS } from '@/server/api/types';
-import { clinics, owners, payments, payouts, plans } from '@/server/db/schema';
+import { clinics, owners, payments, payouts, pets, plans } from '@/server/db/schema';
 import { generateApiKey, listApiKeys, revokeApiKey } from '@/server/services/api-key';
 import { logAuditEvent } from '@/server/services/audit';
 import { sendClinicWelcome } from '@/server/services/email';
@@ -106,6 +106,58 @@ export const clinicRouter = router({
   healthCheck: clinicProcedure.query(() => {
     return { status: 'ok' as const, router: 'clinic' };
   }),
+
+  /**
+   * Search existing clients (owners) who have plans with this clinic.
+   * Used by the enrollment form to pre-populate returning client info.
+   */
+  searchClients: clinicProcedure
+    .input(z.object({ query: z.string().min(1).max(100) }))
+    .query(async ({ ctx, input }) => {
+      const searchPattern = `%${escapeIlike(input.query)}%`;
+      const searchCondition = or(
+        ilike(owners.name, searchPattern),
+        ilike(owners.email, searchPattern),
+      );
+
+      const clientRows = await ctx.db
+        .select({
+          id: owners.id,
+          name: owners.name,
+          email: owners.email,
+          phone: owners.phone,
+          petName: owners.petName,
+        })
+        .from(owners)
+        .innerJoin(plans, eq(plans.ownerId, owners.id))
+        .where(and(eq(plans.clinicId, ctx.clinicId), searchCondition ?? sql`true`))
+        .groupBy(owners.id)
+        .orderBy(owners.name)
+        .limit(10);
+
+      // Fetch pets for matched owners
+      const ownerIds = clientRows.map((r) => r.id);
+      const petRows =
+        ownerIds.length > 0
+          ? await ctx.db
+              .select({
+                id: pets.id,
+                ownerId: pets.ownerId,
+                name: pets.name,
+                species: pets.species,
+                breed: pets.breed,
+              })
+              .from(pets)
+              .where(
+                sql`${pets.ownerId} = ANY(${sql.raw(`ARRAY[${ownerIds.map((id) => `'${id}'`).join(',')}]::uuid[]`)})`,
+              )
+          : [];
+
+      return clientRows.map((client) => ({
+        ...client,
+        pets: petRows.filter((p) => p.ownerId === client.id),
+      }));
+    }),
 
   /**
    * Search clinics by name or city. Only returns active clinics.


### PR DESCRIPTION
## Summary
- **Client search autocomplete** on clinic enrollment form — search existing clients by name/email, debounced 300ms
- **Pre-fill fields** when existing client selected: name, email, phone, pet name (read-only with clear button)
- **Pet selector** dropdown for clients with multiple pets
- **New tRPC procedure**: `clinic.searchClients` — searches owners with existing plans at the clinic, includes pets

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run check` passes
- [x] `bun run test` — 451 tests pass
- [ ] Search for existing client by name — verify pre-fill
- [ ] Search for existing client by email — verify pre-fill
- [ ] Clear selected client — verify fields reset
- [ ] Create enrollment for new client (no search) — still works
- [ ] Create enrollment for returning client — verify deduplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)