### PR TITLE
chore: update seed script default password to match E2E credentials

### DIFF
--- a/scripts/e2e-reset-and-seed.ts
+++ b/scripts/e2e-reset-and-seed.ts
@@ -43,7 +43,7 @@ type Tx = PgTransaction<
 // ── Config ──────────────────────────────────────────────────────────
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
-const PASSWORD = process.env.E2E_TEST_PASSWORD ?? 'TestPassword123!';
+const PASSWORD = process.env.E2E_TEST_PASSWORD ?? 'TzaZDjm0FZ0x6vTtQ9p5xH1b';
 
 if (!SUPABASE_URL || !SERVICE_KEY) {
   console.error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');


### PR DESCRIPTION
## Summary
- Updates the fallback password in `scripts/e2e-reset-and-seed.ts` from the old default to `TzaZDjm0FZ0x6vTtQ9p5xH1b` to match configured E2E credentials

## Test plan
- [x] Re-seeded dev database with new password — all 3 users login successfully
- [x] Re-seeded production database — all 3 users verified via Supabase REST API
- [x] Playwright login tested for owner, clinic, and admin roles on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)