### PR TITLE
feat: implement clinic payouts dashboard

### DIFF
--- a/app/clinic/payouts/_components/payout-earnings.tsx
+++ b/app/clinic/payouts/_components/payout-earnings.tsx
@@ -10,7 +10,7 @@ import { formatCents } from '@/lib/utils/money';
 export function PayoutEarnings() {
   const trpc = useTRPC();
 
-  const { data: earnings, isLoading, error } = useQuery(trpc.payout.earnings.queryOptions());
+  const { data: earnings, isLoading, error } = useQuery(trpc.clinic.getEarnings.queryOptions());
 
   if (isLoading) {
     return <PayoutEarningsSkeleton />;

--- a/app/clinic/payouts/_components/payout-history.tsx
+++ b/app/clinic/payouts/_components/payout-history.tsx
@@ -29,7 +29,7 @@ export function PayoutHistory() {
     data: historyData,
     isLoading,
     error,
-  } = useQuery(trpc.payout.history.queryOptions({ limit: PAGE_SIZE, offset }));
+  } = useQuery(trpc.clinic.getPayoutHistory.queryOptions({ limit: PAGE_SIZE, offset }));
 
   if (isLoading) {
     return <PayoutHistorySkeleton />;

--- a/app/clinic/payouts/page.tsx
+++ b/app/clinic/payouts/page.tsx
@@ -1,48 +1,34 @@
-import { CalendarDays, Clock, Landmark, TableProperties } from 'lucide-react';
+import { HydrationBoundary } from '@tanstack/react-query';
 import type { Metadata } from 'next';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-
-const PLANNED_FEATURES = [
-  { icon: TableProperties, label: 'View a detailed history of all payouts to your account' },
-  { icon: CalendarDays, label: 'See your upcoming payout schedule and expected amounts' },
-  { icon: Landmark, label: 'Manage your connected bank account for receiving payouts' },
-];
+import { createServerHelpers } from '@/lib/trpc/server';
+import { PayoutEarnings } from './_components/payout-earnings';
+import { PayoutHistory } from './_components/payout-history';
 
 export const metadata: Metadata = {
   title: 'Payouts | FuzzyCat',
 };
 
-export default function ClinicPayoutsPage() {
-  return (
-    <div className="container mx-auto max-w-5xl px-6 py-8 space-y-8">
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight">Payouts</h1>
-        <p className="text-muted-foreground mt-1">
-          Track your payout history and revenue earned through FuzzyCat.
-        </p>
-      </div>
+export default async function ClinicPayoutsPage() {
+  const { trpc, queryClient, dehydrate } = await createServerHelpers();
 
-      <Card>
-        <CardHeader className="text-center pb-2">
-          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-muted">
-            <Clock className="h-6 w-6 text-muted-foreground" />
-          </div>
-          <CardTitle className="mt-4">Coming Soon</CardTitle>
-          <CardDescription>
-            We're building your payout tracking dashboard. These features will be available shortly.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <ul className="space-y-3">
-            {PLANNED_FEATURES.map((feature) => (
-              <li key={feature.label} className="flex items-center gap-3 text-sm">
-                <feature.icon className="h-4 w-4 shrink-0 text-muted-foreground" />
-                <span className="text-muted-foreground">{feature.label}</span>
-              </li>
-            ))}
-          </ul>
-        </CardContent>
-      </Card>
-    </div>
+  await Promise.all([
+    queryClient.prefetchQuery(trpc.clinic.getEarnings.queryOptions()),
+    queryClient.prefetchQuery(trpc.clinic.getPayoutHistory.queryOptions({ limit: 20, offset: 0 })),
+  ]);
+
+  return (
+    <HydrationBoundary state={dehydrate()}>
+      <div className="container mx-auto max-w-5xl px-6 py-8 space-y-8">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Payouts</h1>
+          <p className="text-muted-foreground mt-1">
+            Track your payout history and revenue earned through FuzzyCat.
+          </p>
+        </div>
+
+        <PayoutEarnings />
+        <PayoutHistory />
+      </div>
+    </HydrationBoundary>
   );
 }

--- a/server/routers/clinic.ts
+++ b/server/routers/clinic.ts
@@ -14,6 +14,7 @@ import { clinics, owners, payments, payouts, pets, plans } from '@/server/db/sch
 import { generateApiKey, listApiKeys, revokeApiKey } from '@/server/services/api-key';
 import { logAuditEvent } from '@/server/services/audit';
 import { sendClinicWelcome } from '@/server/services/email';
+import { getClinicEarnings, getClinicPayoutHistory } from '@/server/services/payout';
 import { createConnectAccount, createOnboardingLink } from '@/server/services/stripe/connect';
 import { clinicProcedure, protectedProcedure, router } from '@/server/trpc';
 
@@ -882,6 +883,32 @@ export const clinicRouter = router({
       payoutCount: Number(row.payoutCount),
     }));
   }),
+
+  /**
+   * Get aggregate earnings summary for the clinic payouts page.
+   */
+  getEarnings: clinicProcedure.query(async ({ ctx }) => {
+    return getClinicEarnings(ctx.clinicId);
+  }),
+
+  /**
+   * Get paginated payout history for the clinic.
+   */
+  getPayoutHistory: clinicProcedure
+    .input(
+      z
+        .object({
+          limit: z.number().int().min(1).max(100).default(20),
+          offset: z.number().int().min(0).default(0),
+        })
+        .optional(),
+    )
+    .query(async ({ ctx, input }) => {
+      return getClinicPayoutHistory(ctx.clinicId, {
+        limit: input?.limit ?? 20,
+        offset: input?.offset ?? 0,
+      });
+    }),
 
   // ── Reporting procedures (Issue #36) ─────────────────────────────
 


### PR DESCRIPTION
## Summary
- Replaces the "Coming Soon" placeholder on `/clinic/payouts` with a functional payouts dashboard
- Adds `getEarnings` and `getPayoutHistory` tRPC procedures to the clinic router (delegating to existing service functions)
- Wires up existing `PayoutEarnings` and `PayoutHistory` client components to the correct tRPC endpoints
- Server-side prefetching via `HydrationBoundary` for instant load

## Test plan
- [x] `bun run typecheck` — passes
- [x] `bun run check` — passes  
- [x] `bun run test` — 451 tests pass
- [ ] Verify payouts page renders with data after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)