### PR TITLE
fix: wire up missing clinic settings sections

### DIFF
--- a/app/clinic/settings/page.tsx
+++ b/app/clinic/settings/page.tsx
@@ -1,23 +1,37 @@
+import { HydrationBoundary } from '@tanstack/react-query';
 import type { Metadata } from 'next';
+import { createServerHelpers } from '@/lib/trpc/server';
 import { ApiKeysSection } from './_components/api-keys-section';
+import { ClinicProfileForm } from './_components/clinic-profile-form';
+import { MfaSettingsSection } from './_components/mfa-settings-section';
+import { StripeConnectSection } from './_components/stripe-connect-section';
 
 export const metadata: Metadata = {
   title: 'Clinic Settings | FuzzyCat',
 };
 
-export default function ClinicSettingsPage() {
-  return (
-    <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight">Clinic Settings</h1>
-        <p className="mt-1 text-muted-foreground">
-          Manage your clinic information, payment account, and API integrations.
-        </p>
-      </div>
+export default async function ClinicSettingsPage() {
+  const { trpc, queryClient, dehydrate } = await createServerHelpers();
 
-      <div className="mt-8 space-y-6">
-        <ApiKeysSection />
+  await queryClient.prefetchQuery(trpc.clinic.getProfile.queryOptions());
+
+  return (
+    <HydrationBoundary state={dehydrate()}>
+      <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Clinic Settings</h1>
+          <p className="mt-1 text-muted-foreground">
+            Manage your clinic information, payment account, and API integrations.
+          </p>
+        </div>
+
+        <div className="mt-8 space-y-6">
+          <ClinicProfileForm />
+          <StripeConnectSection />
+          <ApiKeysSection />
+          <MfaSettingsSection />
+        </div>
       </div>
-    </div>
+    </HydrationBoundary>
   );
 }


### PR DESCRIPTION
## Summary
- Clinic settings page (`/clinic/settings`) only rendered the API Keys section
- Three existing components were built but never imported into the page
- Added `ClinicProfileForm`, `StripeConnectSection`, and `MfaSettingsSection`
- Added server-side `HydrationBoundary` with `getProfile` prefetch for instant load

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run check` passes  
- [x] 451 tests pass
- [ ] Verify `/clinic/settings` shows all 4 sections on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)