### PR TITLE
feat: expand support page with comprehensive FAQ

### DIFF
--- a/app/(marketing)/support/page.tsx
+++ b/app/(marketing)/support/page.tsx
@@ -1,4 +1,4 @@
-import { Mail, MessageCircle } from 'lucide-react';
+import { HelpCircle, MessageCircle, PawPrint, Stethoscope } from 'lucide-react';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import {
@@ -14,7 +14,7 @@ import { Separator } from '@/components/ui/separator';
 export const metadata: Metadata = {
   title: 'Support',
   description:
-    'Get help with your FuzzyCat payment plan. Find answers to common questions or contact our support team.',
+    'Get help with your FuzzyCat payment plan. Find answers to common questions about payments, enrollment, clinic setup, and more.',
 };
 
 export default function SupportPage() {
@@ -23,97 +23,131 @@ export default function SupportPage() {
       <div className="text-center">
         <h1 className="text-4xl font-bold tracking-tight">Help &amp; Support</h1>
         <p className="mt-3 text-lg text-muted-foreground">
-          Find answers to common questions or get in touch with our support team.
+          Find answers to common questions below. If you need further help, use the feedback button
+          in the bottom-right corner of any page.
         </p>
       </div>
 
       <Separator className="my-10" />
 
-      {/* FAQ Section */}
+      {/* Pet Owner FAQ */}
       <section>
-        <h2 className="text-2xl font-bold tracking-tight">Frequently Asked Questions</h2>
+        <div className="flex items-center gap-2">
+          <PawPrint className="h-5 w-5 text-primary" />
+          <h2 className="text-2xl font-bold tracking-tight">For Pet Owners</h2>
+        </div>
         <div className="mt-6">
           <Accordion type="single" collapsible className="w-full">
             <AccordionItem value="how-payments-work">
               <AccordionTrigger>How do payment plans work?</AccordionTrigger>
               <AccordionContent>
-                When you enroll in a FuzzyCat payment plan, you pay a 25% deposit upfront via debit
-                card. The remaining 75% is divided into 6 equal biweekly payments that are
-                automatically deducted from your bank account via ACH. Your plan is completed in 12
-                weeks. A flat 6% platform fee is added to your bill &mdash; there is no interest and
-                no credit check.
+                <p>
+                  Your veterinary clinic enrolls you in a FuzzyCat payment plan. You pay a 25%
+                  deposit upfront, and the remaining 75% is divided into 6 equal biweekly payments
+                  over 12 weeks. A flat 6% platform fee is included in your total &mdash; there is
+                  no interest and no credit check required.
+                </p>
               </AccordionContent>
             </AccordionItem>
 
-            <AccordionItem value="missed-payment">
-              <AccordionTrigger>What happens if I miss a payment?</AccordionTrigger>
+            <AccordionItem value="deposit">
+              <AccordionTrigger>How does the deposit work?</AccordionTrigger>
               <AccordionContent>
-                If a payment fails, we automatically retry up to 3 times with retries aligned to
-                common paydays. You will receive reminders via email and SMS at day 1, 7, and 14.
-                There are no late fees. If all retries fail, the plan is marked as defaulted and the
-                clinic is notified.
+                <p>
+                  The deposit is 25% of your total amount (bill + 6% fee). It is charged to your
+                  debit card at the time of enrollment. Once the deposit is processed, your payment
+                  plan becomes active and your clinic is notified.
+                </p>
               </AccordionContent>
             </AccordionItem>
 
-            <AccordionItem value="change-bank">
-              <AccordionTrigger>Can I change my bank account after enrolling?</AccordionTrigger>
+            <AccordionItem value="payment-methods">
+              <AccordionTrigger>What payment methods are accepted?</AccordionTrigger>
               <AccordionContent>
-                If you need to update your bank account, please contact our support team at{' '}
-                <a href="mailto:support@fuzzycatapp.com" className="text-primary hover:underline">
-                  support@fuzzycatapp.com
-                </a>{' '}
-                and we will help you through the process. For security, bank account changes require
-                verification.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="cancel-plan">
-              <AccordionTrigger>Can I cancel my payment plan?</AccordionTrigger>
-              <AccordionContent>
-                Payment plans cannot be cancelled once the deposit has been processed, as the funds
-                have already been forwarded to the veterinary clinic. If you are experiencing
-                financial difficulty, please contact us and we will work with you to find a
-                solution.
+                <p>
+                  Deposits are charged to your debit card. Installment payments are collected via
+                  ACH direct debit from your bank account or charged to your debit card, depending
+                  on your preference. Credit cards are not accepted. You can manage your payment
+                  method from the Settings page in your owner portal.
+                </p>
               </AccordionContent>
             </AccordionItem>
 
             <AccordionItem value="payment-schedule">
               <AccordionTrigger>When are my payments due?</AccordionTrigger>
               <AccordionContent>
-                Your payment dates are set when you enroll and occur every two weeks. You can view
-                your full payment schedule in your owner portal under the plan details page. You
-                will also receive email reminders before each payment.
+                <p>
+                  Payments are collected every two weeks starting after your deposit. Your full
+                  payment schedule with exact dates is visible in your owner portal under each plan.
+                  You will also receive email reminders before each payment.
+                </p>
               </AccordionContent>
             </AccordionItem>
 
-            <AccordionItem value="clinic-signup">
-              <AccordionTrigger>How does my clinic sign up for FuzzyCat?</AccordionTrigger>
+            <AccordionItem value="missed-payment">
+              <AccordionTrigger>What happens if a payment fails?</AccordionTrigger>
               <AccordionContent>
-                Veterinary clinics can register at{' '}
-                <Link href="/signup/clinic" className="text-primary hover:underline">
-                  fuzzycatapp.com/signup/clinic
-                </Link>
-                . After registration, clinics complete Stripe Connect onboarding to receive payouts.
-                There are no setup fees or contracts &mdash; clinics earn a 3% revenue share on
-                every enrollment.
+                <p>
+                  If a payment fails, we automatically retry up to 3 times, with retries aligned to
+                  common paydays (the next Friday, 1st, or 15th that is at least 2 days out). You
+                  will receive reminders via email at day 1, 7, and 14 after a missed payment. There
+                  are no late fees. If all 3 retries fail, the plan is marked as defaulted and the
+                  clinic is notified.
+                </p>
               </AccordionContent>
             </AccordionItem>
 
-            <AccordionItem value="data-security">
-              <AccordionTrigger>Is my financial information secure?</AccordionTrigger>
+            <AccordionItem value="cancel-plan">
+              <AccordionTrigger>Can I cancel my payment plan?</AccordionTrigger>
               <AccordionContent>
-                Yes. FuzzyCat never stores your card numbers, bank account numbers, or routing
-                numbers. All payment processing is handled by Stripe (PCI DSS Level 1 certified).
-                Your data is encrypted in transit and at rest.
+                <p>
+                  Payment plans cannot be cancelled once the deposit has been processed, as the
+                  funds are forwarded to the veterinary clinic. If you are experiencing financial
+                  difficulty, please reach out using the feedback button and we will work with you
+                  to find a solution.
+                </p>
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="change-payment-method">
+              <AccordionTrigger>Can I change my payment method?</AccordionTrigger>
+              <AccordionContent>
+                <p>
+                  Yes. You can update your debit card or bank account at any time from the Settings
+                  page in your owner portal. Your new payment method will be used for all future
+                  installments.
+                </p>
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="bill-range">
+              <AccordionTrigger>Is there a minimum or maximum bill amount?</AccordionTrigger>
+              <AccordionContent>
+                <p>
+                  FuzzyCat payment plans are available for veterinary bills between $500 and
+                  $25,000. Bills outside this range are not eligible for enrollment.
+                </p>
               </AccordionContent>
             </AccordionItem>
 
             <AccordionItem value="receipt">
-              <AccordionTrigger>How do I get a receipt for my payments?</AccordionTrigger>
+              <AccordionTrigger>How do I get receipts for my payments?</AccordionTrigger>
               <AccordionContent>
-                You receive an email confirmation after each successful payment. You can also view
-                your complete payment history and download receipts from your owner portal at any
-                time.
+                <p>
+                  You receive an email confirmation after each successful payment. You can also view
+                  your complete payment history from your owner portal at any time.
+                </p>
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="multiple-plans">
+              <AccordionTrigger>Can I have more than one payment plan?</AccordionTrigger>
+              <AccordionContent>
+                <p>
+                  Yes. You can have multiple active payment plans at the same time if your clinic
+                  enrolls you for additional treatments. Each plan has its own payment schedule and
+                  is tracked independently.
+                </p>
               </AccordionContent>
             </AccordionItem>
           </Accordion>
@@ -122,42 +156,224 @@ export default function SupportPage() {
 
       <Separator className="my-10" />
 
-      {/* Contact Section */}
+      {/* Clinic FAQ */}
       <section>
-        <h2 className="text-2xl font-bold tracking-tight">Contact Us</h2>
+        <div className="flex items-center gap-2">
+          <Stethoscope className="h-5 w-5 text-primary" />
+          <h2 className="text-2xl font-bold tracking-tight">For Veterinary Clinics</h2>
+        </div>
+        <div className="mt-6">
+          <Accordion type="single" collapsible className="w-full">
+            <AccordionItem value="clinic-signup">
+              <AccordionTrigger>How does my clinic get started?</AccordionTrigger>
+              <AccordionContent>
+                <p>
+                  Register at{' '}
+                  <Link href="/signup/clinic" className="text-primary hover:underline">
+                    fuzzycatapp.com/signup
+                  </Link>{' '}
+                  and complete Stripe Connect onboarding to receive payouts. There are no setup
+                  fees, monthly fees, or contracts. You can start enrolling clients immediately.
+                </p>
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="clinic-cost">
+              <AccordionTrigger>What does FuzzyCat cost for clinics?</AccordionTrigger>
+              <AccordionContent>
+                <p>
+                  Nothing. FuzzyCat is free for veterinary clinics. The 6% platform fee is paid
+                  entirely by the pet owner. Clinics earn a 3% revenue share on every enrollment as
+                  platform administration compensation.
+                </p>
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="clinic-revenue-share">
+              <AccordionTrigger>How does the 3% revenue share work?</AccordionTrigger>
+              <AccordionContent>
+                <p>
+                  For each enrollment, the clinic receives a 3% share of the total bill as platform
+                  administration compensation. This is paid out via Stripe Connect along with
+                  regular payment transfers. You can track your revenue share in the Payouts section
+                  of your clinic portal.
+                </p>
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="clinic-payouts">
+              <AccordionTrigger>When and how are clinics paid?</AccordionTrigger>
+              <AccordionContent>
+                <p>
+                  After each successful installment payment from a pet owner, the corresponding
+                  amount (minus the FuzzyCat share) is transferred to your Stripe Connect account.
+                  Payouts are automatic and you can track every transfer in the Payouts section of
+                  your clinic portal.
+                </p>
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="clinic-enrollment">
+              <AccordionTrigger>How do I enroll a client?</AccordionTrigger>
+              <AccordionContent>
+                <p>
+                  From your clinic portal, click &ldquo;Initiate Enrollment&rdquo; and fill in the
+                  client and treatment details. You can search for existing clients to auto-fill
+                  their information. The pet owner will then receive instructions to complete their
+                  deposit and activate the plan.
+                </p>
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="clinic-default">
+              <AccordionTrigger>What happens if a pet owner defaults?</AccordionTrigger>
+              <AccordionContent>
+                <p>
+                  FuzzyCat uses an automated soft collection process with escalating reminders. If
+                  all payment retries fail, the plan is marked as defaulted and the clinic is
+                  notified with the owner&apos;s contact information for direct follow-up. FuzzyCat
+                  does not guarantee payment &mdash; clinics retain responsibility for collecting
+                  from defaulting owners.
+                </p>
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="clinic-api">
+              <AccordionTrigger>
+                Can I integrate FuzzyCat with my practice management software?
+              </AccordionTrigger>
+              <AccordionContent>
+                <p>
+                  Yes. FuzzyCat provides a REST API that your practice management software can
+                  integrate with. You can generate API keys from the Settings page in your clinic
+                  portal. Full API documentation is available at{' '}
+                  <Link href="/api-docs" className="text-primary hover:underline">
+                    fuzzycatapp.com/api-docs
+                  </Link>
+                  .
+                </p>
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="clinic-reports">
+              <AccordionTrigger>What reporting is available?</AccordionTrigger>
+              <AccordionContent>
+                <p>
+                  Your clinic portal includes a Reports section with monthly revenue breakdowns,
+                  enrollment trends, and the ability to export data as CSV for your accounting
+                  software. The Payouts section shows a complete record of every transfer to your
+                  bank account.
+                </p>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        </div>
+      </section>
+
+      <Separator className="my-10" />
+
+      {/* General FAQ */}
+      <section>
+        <div className="flex items-center gap-2">
+          <HelpCircle className="h-5 w-5 text-primary" />
+          <h2 className="text-2xl font-bold tracking-tight">General</h2>
+        </div>
+        <div className="mt-6">
+          <Accordion type="single" collapsible className="w-full">
+            <AccordionItem value="what-is-fuzzycat">
+              <AccordionTrigger>What is FuzzyCat?</AccordionTrigger>
+              <AccordionContent>
+                <p>
+                  FuzzyCat is a payment plan platform for veterinary clinics. Pet owners split their
+                  vet bill into a 25% deposit and 6 biweekly installments over 12 weeks. There is no
+                  interest, no credit check, and no loan. Clinics earn a 3% revenue share on every
+                  enrollment at zero cost.
+                </p>
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="is-it-a-loan">
+              <AccordionTrigger>Is FuzzyCat a loan?</AccordionTrigger>
+              <AccordionContent>
+                <p>
+                  No. FuzzyCat is a payment facilitation platform, not a lender. There are no credit
+                  checks, no interest charges, and no loan origination. The 6% fee is a flat
+                  platform fee, not interest.
+                </p>
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="data-security">
+              <AccordionTrigger>Is my financial information secure?</AccordionTrigger>
+              <AccordionContent>
+                <p>
+                  Yes. FuzzyCat never stores card numbers, bank account numbers, or routing numbers.
+                  All payment processing is handled by Stripe, which is PCI DSS Level 1 certified.
+                  Bank account connections are secured through Stripe Financial Connections. Your
+                  data is encrypted in transit and at rest.
+                </p>
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="availability">
+              <AccordionTrigger>Where is FuzzyCat available?</AccordionTrigger>
+              <AccordionContent>
+                <p>
+                  FuzzyCat is currently available to veterinary clinics and pet owners in the United
+                  States, with the exception of New York where we are awaiting regulatory
+                  finalization. We plan to expand availability as regulations are confirmed.
+                </p>
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="accessibility">
+              <AccordionTrigger>Is FuzzyCat accessible?</AccordionTrigger>
+              <AccordionContent>
+                <p>
+                  Yes. FuzzyCat is built with accessibility in mind, including proper semantic HTML,
+                  ARIA labels, keyboard navigation, and screen reader support. The platform also
+                  supports light and dark mode based on your system preferences or manual toggle.
+                </p>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        </div>
+      </section>
+
+      <Separator className="my-10" />
+
+      {/* Need More Help */}
+      <section>
+        <h2 className="text-2xl font-bold tracking-tight">Need More Help?</h2>
         <p className="mt-3 text-muted-foreground">
-          Can&apos;t find what you&apos;re looking for? Our support team is here to help.
+          Can&apos;t find what you&apos;re looking for? We&apos;re here to help.
         </p>
         <div className="mt-6 grid gap-6 sm:grid-cols-2">
           <Card>
             <CardHeader>
               <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
-                <Mail className="h-5 w-5" />
+                <MessageCircle className="h-5 w-5" />
               </div>
-              <CardTitle className="text-lg">Email Support</CardTitle>
+              <CardTitle className="text-lg">Send Feedback</CardTitle>
             </CardHeader>
             <CardContent>
               <p className="text-sm text-muted-foreground">
-                Send us an email and we will respond within one business day.
+                Use the feedback button in the bottom-right corner of any page to report a problem,
+                ask a question, or suggest an improvement. Our team reviews every submission.
               </p>
-              <a href="mailto:support@fuzzycatapp.com">
-                <Button variant="outline" className="mt-4 w-full">
-                  support@fuzzycatapp.com
-                </Button>
-              </a>
             </CardContent>
           </Card>
           <Card>
             <CardHeader>
               <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
-                <MessageCircle className="h-5 w-5" />
+                <PawPrint className="h-5 w-5" />
               </div>
-              <CardTitle className="text-lg">Help Center</CardTitle>
+              <CardTitle className="text-lg">Learn More</CardTitle>
             </CardHeader>
             <CardContent>
               <p className="text-sm text-muted-foreground">
-                Learn more about how FuzzyCat works, including payment details and clinic
-                information.
+                See detailed breakdowns of how payments work, fee calculations, and what clinics
+                earn.
               </p>
               <Link href="/how-it-works">
                 <Button variant="outline" className="mt-4 w-full">


### PR DESCRIPTION
## Summary
- Expanded FAQ from 8 questions to 23 questions across 3 organized sections
- **Pet Owners** (10): payments, deposits, methods, schedule, failures, cancellation, bill range, receipts, multiple plans
- **Veterinary Clinics** (8): signup, cost, revenue share, payouts, enrollment, defaults, API integration, reporting
- **General** (5): what is FuzzyCat, is it a loan, security, availability, accessibility
- Removed email contact section — all support via Sentry feedback button
- "Need More Help" section points to feedback button and How It Works page

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run check` passes
- [x] 451 tests pass
- [ ] Verify `/support` renders all 3 accordion sections on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)