### PR TITLE
fix: point How It Works CTAs to role-specific signup pages

### DIFF
--- a/app/(marketing)/how-it-works/page.tsx
+++ b/app/(marketing)/how-it-works/page.tsx
@@ -255,7 +255,7 @@ export default function HowItWorksPage() {
           </div>
 
           <div className="mt-8 text-center">
-            <Link href="/signup">
+            <Link href="/signup/clinic">
               <Button size="lg">
                 Become a Partner Clinic
                 <ArrowRight className="ml-1.5 h-4 w-4" />
@@ -273,13 +273,13 @@ export default function HowItWorksPage() {
             Sign up in minutes. See your full payment schedule before you commit.
           </p>
           <div className="mt-6 flex flex-col items-center justify-center gap-4 sm:flex-row">
-            <Link href="/signup">
+            <Link href="/signup/owner">
               <Button size="lg" className="w-full sm:w-auto">
                 Sign Up as Pet Owner
                 <ArrowRight className="ml-1.5 h-4 w-4" />
               </Button>
             </Link>
-            <Link href="/signup">
+            <Link href="/signup/clinic">
               <Button variant="outline" size="lg" className="w-full sm:w-auto">
                 Register Your Clinic
               </Button>

--- a/e2e/tests/public/how-it-works-interaction.spec.ts
+++ b/e2e/tests/public/how-it-works-interaction.spec.ts
@@ -5,18 +5,18 @@ test.describe('How It Works — Interactions', () => {
     await page.goto('/how-it-works');
   });
 
-  test('"Become a Partner Clinic" CTA navigates to /signup', async ({ page }) => {
+  test('"Become a Partner Clinic" CTA navigates to /signup/clinic', async ({ page }) => {
     const cta = page.getByRole('link', { name: /become a partner clinic/i });
     await expect(cta).toBeVisible();
     await cta.click();
-    await expect(page).toHaveURL(/\/signup/);
+    await expect(page).toHaveURL(/\/signup\/clinic/);
   });
 
-  test('"Sign Up as Pet Owner" CTA navigates to /signup', async ({ page }) => {
+  test('"Sign Up as Pet Owner" CTA navigates to /signup/owner', async ({ page }) => {
     const cta = page.getByRole('link', { name: /sign up as pet owner/i });
     await expect(cta).toBeVisible();
     await cta.click();
-    await expect(page).toHaveURL(/\/signup/);
+    await expect(page).toHaveURL(/\/signup\/owner/);
   });
 
   test('clinic benefits section shows key value props', async ({ page }) => {

--- a/tests/fast/marketing/how-it-works.test.ts
+++ b/tests/fast/marketing/how-it-works.test.ts
@@ -58,7 +58,7 @@ describe('How It Works /how-it-works', () => {
     const { $ } = await fetchPage('/how-it-works');
     const text = $('body').text();
     expect(text).toContain('Ready to get started?');
-    expect($('a:contains("Sign Up as Pet Owner")').attr('href')).toBe('/signup');
-    expect($('a:contains("Register Your Clinic")').attr('href')).toBe('/signup');
+    expect($('a:contains("Sign Up as Pet Owner")').attr('href')).toBe('/signup/owner');
+    expect($('a:contains("Register Your Clinic")').attr('href')).toBe('/signup/clinic');
   });
 });


### PR DESCRIPTION
## Summary
- **"Become a Partner Clinic"** → `/signup/clinic` (was `/signup`)
- **"Sign Up as Pet Owner"** → `/signup/owner` (was `/signup`)
- **"Register Your Clinic"** → `/signup/clinic` (was `/signup`)

Eliminates an unnecessary portal-selection step for users clicking these CTAs.

## Test plan
- [x] Fast test updated: verifies `href` values for both CTA links
- [x] E2E test updated: verifies navigation to role-specific signup pages
- [x] `bun run typecheck && bun run check && bun run test` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)