### PR TITLE
chore: DRY up duplicate formatDate, addDays, and VALID_ROLES

### DIFF
--- a/lib/auth-from-middleware.ts
+++ b/lib/auth-from-middleware.ts
@@ -1,7 +1,5 @@
 import { headers } from 'next/headers';
-import type { UserRole } from '@/lib/auth';
-
-const VALID_ROLES = new Set<string>(['owner', 'clinic', 'admin']);
+import { type UserRole, VALID_ROLES } from '@/lib/auth';
 
 /**
  * Reads auth information injected by middleware via request headers.

--- a/lib/utils/date.ts
+++ b/lib/utils/date.ts
@@ -51,3 +51,12 @@ export function formatCountdown(date: Date | string): string {
   if (days === 1) return 'Tomorrow';
   return `In ${days} days`;
 }
+
+/**
+ * Add a number of days to a date and return a new Date.
+ */
+export function addDays(date: Date, days: number): Date {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+}

--- a/server/services/sms.ts
+++ b/server/services/sms.ts
@@ -14,6 +14,7 @@
 import { serverEnv } from '@/lib/env';
 import { logger } from '@/lib/logger';
 import { twilio } from '@/lib/twilio';
+import { formatDate } from '@/lib/utils/date';
 import { formatCents } from '@/lib/utils/money';
 import { isValidUSPhone } from '@/lib/utils/phone';
 import type { UrgencyLevel } from '@/server/services/collection';
@@ -144,16 +145,6 @@ function recordSend(phone: string): void {
 function maskPhone(phone: string): string {
   if (phone.length <= 4) return '****';
   return `****${phone.slice(-4)}`;
-}
-
-/** Format a Date as a short human-readable string (e.g., "Feb 20, 2026"). */
-function formatDate(date: Date): string {
-  return date.toLocaleDateString('en-US', {
-    timeZone: 'UTC',
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
 }
 
 /** Append TCPA opt-out instructions to the first message sent to a number. */

--- a/server/services/soft-collection.ts
+++ b/server/services/soft-collection.ts
@@ -10,6 +10,7 @@
 import { and, eq, inArray, lte } from 'drizzle-orm';
 import { publicEnv } from '@/lib/env';
 import { logger } from '@/lib/logger';
+import { addDays } from '@/lib/utils/date';
 import { db } from '@/server/db';
 import { owners, plans, softCollections } from '@/server/db/schema';
 import { logAuditEvent } from '@/server/services/audit';
@@ -52,13 +53,6 @@ interface PlanOwnerInfo {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────
-
-/** Add days to a date and return a new Date. */
-function addDays(date: Date, days: number): Date {
-  const result = new Date(date);
-  result.setDate(result.getDate() + days);
-  return result;
-}
 
 /** Get the next stage in the escalation sequence. */
 function getNextStage(currentStage: SoftCollectionStage): SoftCollectionStage | null {


### PR DESCRIPTION
## Summary
- **`sms.ts`**: Delete local `formatDate()`, import from `@/lib/utils/date`
- **`soft-collection.ts`**: Delete local `addDays()`, import from `@/lib/utils/date`
- **`auth-from-middleware.ts`**: Delete local `VALID_ROLES`, import from `@/lib/auth`
- **`date.ts`**: Add shared `addDays()` utility

Net result: -8 lines, 3 fewer duplicate definitions.

## Test plan
- [x] `bun run typecheck` — pass
- [x] `bun run check` — pass
- [x] `bun run test` — 451 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)