### PR TITLE
chore: remove Plaid refs, overhaul ToS and privacy policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,6 @@ Payment plan platform for veterinary clinics. Pet owners split vet bills into bi
 | ORM | Drizzle ORM (`server/db/schema.ts`) |
 | Database | PostgreSQL via Supabase (separate dev + production instances) |
 | Payments | Stripe Checkout (deposits), Stripe ACH (installments), Stripe Connect (payouts) |
-| Bank Verification | Plaid Link + Balance |
 | Auth | Supabase Auth (role-based: owner, clinic, admin) |
 | Linting | Biome (not ESLint/Prettier) |
 | Testing | Bun test runner (not Jest/Vitest), Playwright E2E |
@@ -57,15 +56,15 @@ bunx drizzle-kit generate        # Generate SQL migrations
 - **ILIKE escaping**: Always use `escapeIlike()` when interpolating user input into SQL ILIKE patterns.
 - **Naming**: `camelCase` variables/functions, `PascalCase` components/types, `SCREAMING_SNAKE` env vars.
 - **Bun test runner**: Always `bun run test` (not bare `bun test`, which picks up `node_modules`).
-- **Error handling**: All Stripe/Plaid calls in try/catch. Never expose internals to users.
+- **Error handling**: All Stripe calls in try/catch. Never expose internals to users.
 - **Audit trail** (NON-NEGOTIABLE): Every payment state change must log to `audit_log` with timestamp, actor, previous state, and new state.
 
 ## Security
 
-- **PCI SAQ A**: Servers never touch card data. Use Stripe Checkout and Plaid Link (both hosted). Never store PAN, CVV, bank account numbers, or routing numbers.
+- **PCI SAQ A**: Servers never touch card data. Use Stripe Checkout (hosted). Never store PAN, CVV, bank account numbers, or routing numbers.
 - **Authorization**: All tRPC procedures guarded by `assertClinicOwnership()` or `assertPlanAccess()`.
 - **CSP**: `'self' 'unsafe-inline' https:` for scripts via middleware. Nonce-based `strict-dynamic` was removed because Next.js SPA navigation injects inline scripts without nonces.
-- **Webhook verification**: Plaid via JWT validation, Stripe via signature verification. Stripe webhooks return 200 even on handler errors (prevents retry storms).
+- **Webhook verification**: Stripe via signature verification. Stripe webhooks return 200 even on handler errors (prevents retry storms).
 - **MFA**: Feature-flagged via `ENABLE_MFA`. Enforced at middleware for clinic/admin routes.
 - **Stripe Connect**: Validate `stripeAccountId` non-null before Connect API calls. Account creation uses `db.transaction()` with conditional UPDATE for race safety.
 
@@ -95,7 +94,7 @@ bunx drizzle-kit generate        # Generate SQL migrations
 ```
 ENROLLMENT:
   1. Owner enters vet bill → system calculates 6% fee, 25% deposit, 6 installments
-  2. Owner connects bank (Plaid) OR enters debit card (Stripe Checkout)
+  2. Owner enters debit card (Stripe Checkout) for deposit, connects bank for ACH installments
   3. Deposit charged immediately → plan becomes "active"
   4. Remaining 75% split into 6 biweekly ACH debits
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Flexible payment plans for veterinary clinics. Pet owners split vet bills into b
 
 1. **Clinic enrolls pet owner** with vet bill amount ($500–$25,000)
 2. **Owner pays 25% deposit** via debit card (Stripe Checkout)
-3. **Remaining 75%** splits into 6 biweekly ACH installments (Plaid-verified bank account)
+3. **Remaining 75%** splits into 6 biweekly ACH installments via Stripe
 4. **Clinics receive payouts** after each successful installment via Stripe Connect
 
 Competitive platform fee for owners. Revenue share for participating clinics.
@@ -17,7 +17,7 @@ FuzzyCat is **not a lender** — no credit checks, no interest, no loan originat
 
 ### For Pet Owners
 - Split vet bills into manageable biweekly payments
-- Secure bank verification via Plaid Link
+- Secure payment processing via Stripe
 - Real-time payment tracking and history
 - Automated email/SMS reminders
 
@@ -42,7 +42,6 @@ FuzzyCat is **not a lender** — no credit checks, no interest, no loan originat
 | ORM | Drizzle ORM (`server/db/schema.ts`) |
 | Database | PostgreSQL via Supabase |
 | Payments | Stripe Checkout (deposits), Stripe ACH (installments), Stripe Connect (payouts) |
-| Bank Verification | Plaid Link + Balance |
 | Auth | Supabase Auth (role-based: owner, clinic, admin) |
 | Linting | Biome |
 | Testing | Bun test runner + Playwright E2E |
@@ -57,7 +56,7 @@ FuzzyCat is **not a lender** — no credit checks, no interest, no loan originat
 - [Bun](https://bun.sh/) v1.1+
 - PostgreSQL database (via [Supabase](https://supabase.com/))
 - [Stripe](https://stripe.com/) account (test mode)
-- [Plaid](https://plaid.com/) account (sandbox)
+
 
 ### Installation
 
@@ -77,7 +76,6 @@ Fill in your credentials — see `.env.example` for all required and optional va
 
 - **Supabase**: Project URL, anon key, service role key, database URL
 - **Stripe**: Secret key, publishable key, webhook secret
-- **Plaid**: Client ID, secret, environment (`sandbox` for development)
 - **Resend**: API key for transactional email
 - **Twilio**: Account SID, auth token, phone number for SMS
 
@@ -104,15 +102,15 @@ app/                     # Next.js App Router
   clinic/                # Clinic portal (dashboard, clients, reports, payouts)
   admin/                 # Admin portal (dashboard, plans, payments, settings)
   api/                   # API routes
-    webhooks/            #   Stripe + Plaid + Sentry webhooks
+    webhooks/            #   Stripe + Sentry webhooks
     cron/                #   Scheduled jobs (collect-payments, process-payouts)
     health/              #   Health check endpoint
     trpc/                #   tRPC handler
 components/              # Shared UI components (shadcn/ui based)
-lib/                     # Shared utilities (env, auth, stripe, plaid, logger)
+lib/                     # Shared utilities (env, auth, stripe, logger)
 server/
   db/                    # Drizzle ORM schema and database connection
-  routers/               # tRPC routers (enrollment, payment, payout, plan, plaid)
+  routers/               # tRPC routers (enrollment, payment, payout, plan)
   services/              # Business logic (enrollment, payment, collection, payout, audit)
   trpc.ts                # tRPC context, procedures, and middleware
 drizzle/                 # Generated SQL migrations
@@ -144,7 +142,7 @@ scripts/                 # Utility scripts (seed, admin creation, QA, E2E setup)
 bun run test             # Run all unit tests
 ```
 
-Tests use Bun's built-in test runner with `mock.module()` for dependency mocking. External services (Stripe, Plaid, Supabase) are fully mocked — no real API calls in tests.
+Tests use Bun's built-in test runner with `mock.module()` for dependency mocking. External services (Stripe, Supabase) are fully mocked — no real API calls in tests.
 
 ### E2E Tests
 
@@ -161,7 +159,7 @@ Deployed on **Vercel** with **Supabase** for database and auth.
 
 1. Connect repository to Vercel
 2. Set all environment variables from `.env.example` in Vercel dashboard
-3. Configure Stripe and Plaid webhooks to point to your Vercel deployment
+3. Configure Stripe webhooks to point to your Vercel deployment
 4. Set up Vercel Cron for scheduled payment collection and payout processing
 
 ## License

--- a/app/(marketing)/privacy/page.tsx
+++ b/app/(marketing)/privacy/page.tsx
@@ -11,83 +11,138 @@ export default function PrivacyPolicyPage() {
   return (
     <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
       <h1 className="text-4xl font-bold tracking-tight">Privacy Policy</h1>
-      <p className="mt-3 text-sm text-muted-foreground">Last updated: February 1, 2026</p>
+      <p className="mt-3 text-sm text-muted-foreground">Last updated: March 3, 2026</p>
 
       <Separator className="my-8" />
 
       <div className="prose prose-neutral dark:prose-invert max-w-none space-y-8 text-sm leading-relaxed text-muted-foreground">
+        {/* 1 */}
         <section>
           <h2 className="text-xl font-semibold text-foreground">1. Introduction</h2>
           <p className="mt-3">
-            FuzzyCat (&quot;we,&quot; &quot;us,&quot; or &quot;our&quot;) operates the FuzzyCat
-            payment facilitation platform at fuzzycatapp.com. This Privacy Policy explains how we
-            collect, use, disclose, and safeguard your personal information when you use our website
-            and services. By using FuzzyCat, you consent to the practices described in this policy.
+            FuzzyCat Inc. (&quot;FuzzyCat,&quot; &quot;we,&quot; &quot;us,&quot; or &quot;our&quot;)
+            operates the FuzzyCat payment facilitation platform at fuzzycatapp.com. This Privacy
+            Policy explains how we collect, use, disclose, and safeguard your personal information
+            when you use our website and services (&quot;Service&quot;). By using FuzzyCat, you
+            consent to the practices described in this policy.
+          </p>
+          <p className="mt-3">
+            This policy applies to all users of the Service, including pet owners, veterinary
+            clinics, and administrators.
           </p>
         </section>
 
+        {/* 2 */}
         <section>
           <h2 className="text-xl font-semibold text-foreground">2. Information We Collect</h2>
           <p className="mt-3">We collect the following categories of information:</p>
-          <ul className="mt-3 list-disc space-y-2 pl-6">
+
+          <h3 className="mt-4 text-base font-semibold text-foreground">
+            2.1 Information You Provide
+          </h3>
+          <ul className="mt-2 list-disc space-y-2 pl-6">
             <li>
               <strong className="text-foreground">Account information:</strong> Name, email address,
               phone number, and role (pet owner or veterinary clinic) provided during registration.
             </li>
             <li>
-              <strong className="text-foreground">Financial information:</strong> We use Stripe to
-              process debit card payments and ACH transfers. FuzzyCat does not store your card
-              numbers, bank account numbers, or routing numbers on our servers. All payment
-              credentials are handled directly by Stripe in compliance with PCI DSS standards.
+              <strong className="text-foreground">Clinic information:</strong> Clinic name, state,
+              ZIP code, and Stripe Connect account details for clinics.
             </li>
             <li>
-              <strong className="text-foreground">Payment plan data:</strong> Bill amounts, payment
-              schedules, payment statuses, and transaction history associated with your plans.
+              <strong className="text-foreground">Pet information:</strong> Pet name provided during
+              registration.
             </li>
             <li>
-              <strong className="text-foreground">Usage data:</strong> Pages visited, features used,
-              browser type, device type, IP address, and referring URLs collected automatically
-              through cookies and analytics tools.
+              <strong className="text-foreground">Payment plan data:</strong> Veterinary bill
+              amounts, payment schedules, payment statuses, and transaction history.
             </li>
             <li>
               <strong className="text-foreground">Communications:</strong> Records of support
-              inquiries, emails, and any other correspondence with us.
+              inquiries, feedback submissions, and any correspondence with us.
+            </li>
+          </ul>
+
+          <h3 className="mt-4 text-base font-semibold text-foreground">
+            2.2 Information Collected Through Payment Processors
+          </h3>
+          <ul className="mt-2 list-disc space-y-2 pl-6">
+            <li>
+              <strong className="text-foreground">Financial information:</strong> We use Stripe to
+              process debit card payments and ACH transfers. FuzzyCat does not store your card
+              numbers, bank account numbers, or routing numbers on our servers. All payment
+              credentials are handled directly by Stripe in compliance with PCI DSS Level 1
+              standards. We receive only tokenized references, transaction statuses, and the last
+              four digits of your payment method for display purposes.
+            </li>
+          </ul>
+
+          <h3 className="mt-4 text-base font-semibold text-foreground">
+            2.3 Information Collected Automatically
+          </h3>
+          <ul className="mt-2 list-disc space-y-2 pl-6">
+            <li>
+              <strong className="text-foreground">Usage data:</strong> Pages visited, features used,
+              clickstream data, browser type, device type, operating system, IP address, and
+              referring URLs.
+            </li>
+            <li>
+              <strong className="text-foreground">Performance data:</strong> Page load times,
+              errors, and application performance metrics.
+            </li>
+            <li>
+              <strong className="text-foreground">Bot detection data:</strong> Browser signals and
+              interaction patterns collected by Cloudflare Turnstile during account registration to
+              prevent automated abuse. This data is processed by Cloudflare and is not stored by
+              FuzzyCat.
             </li>
           </ul>
         </section>
 
+        {/* 3 */}
         <section>
           <h2 className="text-xl font-semibold text-foreground">3. How We Use Your Information</h2>
           <p className="mt-3">We use the information we collect to:</p>
           <ul className="mt-3 list-disc space-y-2 pl-6">
             <li>Create and manage your account and payment plans.</li>
-            <li>Process payments, including deposits and biweekly installments.</li>
-            <li>Verify your bank account to ensure you can make scheduled payments.</li>
+            <li>Process payments, including deposits and biweekly installments via Stripe.</li>
             <li>
-              Send payment confirmations, reminders, and notifications about your plan status.
+              Send payment confirmations, reminders, and notifications about your plan status via
+              email (Resend) and SMS (Twilio).
             </li>
             <li>Facilitate clinic payouts via Stripe Connect.</li>
             <li>Respond to support requests and communicate with you about our services.</li>
-            <li>
-              Improve our platform, analyze usage patterns, and monitor performance using tools such
-              as PostHog and Sentry.
-            </li>
-            <li>Comply with legal obligations and prevent fraud.</li>
+            <li>Improve our platform and analyze usage patterns.</li>
+            <li>Monitor application health, detect errors, and debug issues.</li>
+            <li>Prevent fraud, unauthorized access, and automated abuse.</li>
+            <li>Comply with legal obligations and enforce our Terms of Service.</li>
           </ul>
         </section>
 
+        {/* 4 */}
         <section>
           <h2 className="text-xl font-semibold text-foreground">
             4. How We Share Your Information
           </h2>
           <p className="mt-3">
-            We do not sell your personal information. We share information only in the following
-            circumstances:
+            <strong className="text-foreground">We do not sell your personal information.</strong>{' '}
+            We have not sold personal information in the preceding 12 months and have no plans to do
+            so. We share information only in the following circumstances:
           </p>
           <ul className="mt-3 list-disc space-y-2 pl-6">
             <li>
-              <strong className="text-foreground">Payment processors:</strong> Stripe processes your
-              payments and receives the data necessary to complete transactions.
+              <strong className="text-foreground">Stripe (payment processing):</strong> Stripe
+              processes your debit card deposits, ACH installments, and clinic payouts. Stripe
+              receives the data necessary to complete these transactions. See{' '}
+              <a
+                href="https://stripe.com/privacy"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                Stripe&apos;s Privacy Policy
+              </a>
+              .
             </li>
             <li>
               <strong className="text-foreground">Veterinary clinics:</strong> If you are a pet
@@ -95,64 +150,329 @@ export default function PrivacyPolicyPage() {
               clinic associated with your plan so they can track receivables.
             </li>
             <li>
-              <strong className="text-foreground">Service providers:</strong> We use Supabase for
-              authentication and data storage, Resend for transactional email, Twilio for SMS
-              notifications, and Vercel for hosting. These providers process data on our behalf
-              under contractual obligations.
+              <strong className="text-foreground">Service providers:</strong> We use the following
+              providers who process data on our behalf under contractual obligations:
+              <ul className="mt-2 list-disc space-y-1 pl-6">
+                <li>
+                  <strong className="text-foreground">Supabase</strong> — Authentication and
+                  database hosting (United States)
+                </li>
+                <li>
+                  <strong className="text-foreground">Vercel</strong> — Application hosting, edge
+                  functions, and web analytics (United States)
+                </li>
+                <li>
+                  <strong className="text-foreground">Resend</strong> — Transactional email delivery
+                </li>
+                <li>
+                  <strong className="text-foreground">Twilio</strong> — SMS notifications
+                </li>
+                <li>
+                  <strong className="text-foreground">PostHog</strong> — Product analytics (United
+                  States)
+                </li>
+                <li>
+                  <strong className="text-foreground">Sentry</strong> — Error monitoring and
+                  performance tracking
+                </li>
+                <li>
+                  <strong className="text-foreground">Cloudflare</strong> — Bot detection via
+                  Turnstile during registration
+                </li>
+              </ul>
             </li>
             <li>
               <strong className="text-foreground">Legal requirements:</strong> We may disclose
-              information if required by law, regulation, legal process, or governmental request.
+              information if required by law, regulation, legal process, or governmental request, or
+              to protect the rights, property, or safety of FuzzyCat, our users, or others.
+            </li>
+            <li>
+              <strong className="text-foreground">Business transfers:</strong> In the event of a
+              merger, acquisition, or sale of all or a portion of our assets, your personal
+              information may be transferred as part of that transaction. We will notify you via
+              email and/or a prominent notice on our website before your information becomes subject
+              to a different privacy policy.
             </li>
           </ul>
         </section>
 
+        {/* 5 */}
         <section>
           <h2 className="text-xl font-semibold text-foreground">5. Data Security</h2>
           <p className="mt-3">
-            We implement industry-standard security measures to protect your information. All data
-            transmitted between your browser and our servers is encrypted using TLS. Sensitive
-            financial data is handled exclusively by PCI-compliant third parties (Stripe) and is
-            never stored on our servers. We use Supabase Auth with role-based access controls and
-            enforce Content Security Policy headers to prevent cross-site scripting attacks.
+            We implement industry-standard security measures to protect your information:
+          </p>
+          <ul className="mt-3 list-disc space-y-2 pl-6">
+            <li>
+              All data transmitted between your browser and our servers is encrypted using TLS
+              (HTTPS enforced).
+            </li>
+            <li>
+              Sensitive financial data is handled exclusively by PCI DSS Level 1 compliant
+              processors (Stripe) and is never stored on our servers.
+            </li>
+            <li>
+              Authentication is managed by Supabase Auth with role-based access controls and
+              optional multi-factor authentication (MFA).
+            </li>
+            <li>
+              We enforce Content Security Policy (CSP) headers, HTTP Strict Transport Security
+              (HSTS), and other browser security headers to prevent common web attacks.
+            </li>
+            <li>API access uses SHA-256 hashed keys with granular permission scopes.</li>
+            <li>All payment state changes are recorded in an immutable audit log.</li>
+          </ul>
+          <p className="mt-3">
+            While we strive to protect your personal information, no method of transmission over the
+            Internet or electronic storage is 100% secure. We cannot guarantee absolute security.
           </p>
         </section>
 
+        {/* 6 */}
         <section>
-          <h2 className="text-xl font-semibold text-foreground">6. Cookies and Analytics</h2>
+          <h2 className="text-xl font-semibold text-foreground">
+            6. Cookies, Analytics, and Tracking
+          </h2>
           <p className="mt-3">
             We use cookies and similar technologies to maintain your session, remember your
-            preferences, and analyze how our platform is used. We use PostHog for product analytics
-            and Sentry for error monitoring. You can control cookie settings through your browser
-            preferences, though disabling cookies may affect the functionality of our platform.
+            preferences, and understand how our platform is used. Below is a summary of the tracking
+            technologies we employ:
+          </p>
+
+          <div className="mt-4 overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr className="border-b">
+                  <th className="pb-2 pr-4 font-semibold text-foreground">Technology</th>
+                  <th className="pb-2 pr-4 font-semibold text-foreground">Purpose</th>
+                  <th className="pb-2 font-semibold text-foreground">Type</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                <tr>
+                  <td className="py-2 pr-4">Supabase Auth cookies</td>
+                  <td className="py-2 pr-4">Session management and authentication</td>
+                  <td className="py-2">Essential (session)</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4">Theme preference</td>
+                  <td className="py-2 pr-4">Remembering light/dark mode selection</td>
+                  <td className="py-2">Functional (persistent)</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4">PostHog</td>
+                  <td className="py-2 pr-4">
+                    Product analytics, feature usage, and funnel analysis
+                  </td>
+                  <td className="py-2">Analytics</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4">Sentry</td>
+                  <td className="py-2 pr-4">Error monitoring and performance tracking</td>
+                  <td className="py-2">Analytics</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4">Vercel Analytics</td>
+                  <td className="py-2 pr-4">Page view tracking and audience insights</td>
+                  <td className="py-2">Analytics</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4">Vercel Speed Insights</td>
+                  <td className="py-2 pr-4">Core Web Vitals and page performance</td>
+                  <td className="py-2">Analytics</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <p className="mt-4">
+            You can control cookie settings through your browser preferences, though disabling
+            essential cookies may prevent you from logging in. PostHog respects the{' '}
+            <code className="rounded bg-muted px-1.5 py-0.5">Do Not Track</code> browser signal. To
+            opt out of PostHog analytics specifically, you can enable Do Not Track in your browser
+            settings.
           </p>
         </section>
 
+        {/* 7 */}
         <section>
           <h2 className="text-xl font-semibold text-foreground">7. Data Retention</h2>
           <p className="mt-3">
             We retain your personal information for as long as your account is active or as needed
             to provide services, comply with legal obligations, resolve disputes, and enforce our
-            agreements. Payment plan records and audit logs are retained for a minimum of seven
-            years to comply with financial record-keeping requirements.
+            agreements. Specific retention periods:
+          </p>
+          <ul className="mt-3 list-disc space-y-2 pl-6">
+            <li>
+              <strong className="text-foreground">Payment records and audit logs:</strong> Minimum
+              seven (7) years, in compliance with IRS record-keeping requirements and applicable
+              financial regulations.
+            </li>
+            <li>
+              <strong className="text-foreground">Account information:</strong> Retained while your
+              account is active and for up to two (2) years after account closure.
+            </li>
+            <li>
+              <strong className="text-foreground">Analytics data:</strong> Aggregated and
+              de-identified analytics data may be retained indefinitely.
+            </li>
+          </ul>
+          <p className="mt-3">
+            When data is no longer needed, it is securely deleted or anonymized.
           </p>
         </section>
 
+        {/* 8 */}
         <section>
-          <h2 className="text-xl font-semibold text-foreground">8. Your Rights</h2>
-          <p className="mt-3">Depending on your jurisdiction, you may have the right to:</p>
+          <h2 className="text-xl font-semibold text-foreground">8. Your Privacy Rights</h2>
+          <p className="mt-3">
+            Depending on your jurisdiction, you may have the following rights regarding your
+            personal information:
+          </p>
           <ul className="mt-3 list-disc space-y-2 pl-6">
-            <li>Access the personal information we hold about you.</li>
-            <li>Request correction of inaccurate information.</li>
             <li>
-              Request deletion of your personal information, subject to legal retention
-              requirements.
+              <strong className="text-foreground">Right to know:</strong> Request information about
+              the categories and specific pieces of personal information we have collected about
+              you.
             </li>
-            <li>Opt out of marketing communications at any time.</li>
-            <li>Request a copy of your data in a portable format.</li>
+            <li>
+              <strong className="text-foreground">Right to access:</strong> Obtain a copy of the
+              personal information we hold about you in a portable format.
+            </li>
+            <li>
+              <strong className="text-foreground">Right to correction:</strong> Request correction
+              of inaccurate personal information.
+            </li>
+            <li>
+              <strong className="text-foreground">Right to deletion:</strong> Request deletion of
+              your personal information, subject to legal retention requirements (such as the 7-year
+              financial record retention described in Section 7).
+            </li>
+            <li>
+              <strong className="text-foreground">Right to opt out:</strong> Opt out of marketing
+              communications at any time. Note that transactional communications related to active
+              payment plans cannot be opted out of.
+            </li>
           </ul>
           <p className="mt-3">
             To exercise any of these rights, contact us at{' '}
+            <a href="mailto:privacy@fuzzycatapp.com" className="text-primary hover:underline">
+              privacy@fuzzycatapp.com
+            </a>
+            . We will respond to verifiable requests within 45 days. We will not discriminate
+            against you for exercising your privacy rights.
+          </p>
+        </section>
+
+        {/* 9 */}
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">
+            9. California Privacy Rights (CCPA/CPRA)
+          </h2>
+          <p className="mt-3">
+            If you are a California resident, the California Consumer Privacy Act (CCPA), as amended
+            by the California Privacy Rights Act (CPRA), provides you with additional rights:
+          </p>
+          <ul className="mt-3 list-disc space-y-2 pl-6">
+            <li>
+              <strong className="text-foreground">
+                Categories of personal information collected:
+              </strong>{' '}
+              Identifiers (name, email, phone), financial information (transaction history, payment
+              statuses — not raw account numbers), internet/electronic activity (usage data, IP
+              addresses), and professional information (clinic name, business details for clinic
+              accounts).
+            </li>
+            <li>
+              <strong className="text-foreground">Sale of personal information:</strong> We do not
+              sell your personal information and have not done so in the preceding 12 months.
+            </li>
+            <li>
+              <strong className="text-foreground">
+                Sharing for cross-context behavioral advertising:
+              </strong>{' '}
+              We do not share your personal information for cross-context behavioral advertising
+              purposes.
+            </li>
+            <li>
+              <strong className="text-foreground">
+                Right to limit use of sensitive personal information:
+              </strong>{' '}
+              We only use sensitive personal information (financial data) as necessary to provide
+              the Service, and not for profiling or advertising purposes.
+            </li>
+            <li>
+              <strong className="text-foreground">Non-discrimination:</strong> We will not
+              discriminate against you for exercising any of your CCPA/CPRA rights, including by
+              denying you services, charging different prices, or providing a different quality of
+              service.
+            </li>
+          </ul>
+          <p className="mt-3">
+            To exercise your California privacy rights, contact us at{' '}
+            <a href="mailto:privacy@fuzzycatapp.com" className="text-primary hover:underline">
+              privacy@fuzzycatapp.com
+            </a>{' '}
+            or use the subject line &quot;CCPA Request.&quot;
+          </p>
+        </section>
+
+        {/* 10 */}
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">
+            10. Do Not Sell My Personal Information
+          </h2>
+          <p className="mt-3">
+            FuzzyCat does not sell your personal information to third parties. We do not exchange
+            personal information for monetary or other valuable consideration. If our practices
+            change in the future, we will update this policy, provide notice, and offer you the
+            right to opt out before any sale occurs.
+          </p>
+        </section>
+
+        {/* 11 */}
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">11. Data Breach Notification</h2>
+          <p className="mt-3">
+            In the event of a data breach that compromises your personal information, we will:
+          </p>
+          <ul className="mt-3 list-disc space-y-2 pl-6">
+            <li>
+              Notify affected users via email as soon as reasonably practicable and no later than as
+              required by applicable law (within 72 hours of discovery where required by state law).
+            </li>
+            <li>
+              Provide details about the nature of the breach, the types of information affected, and
+              the steps we are taking to address it.
+            </li>
+            <li>Notify applicable regulatory authorities as required by law.</li>
+            <li>
+              Offer guidance on steps you can take to protect yourself, such as changing passwords
+              or monitoring account activity.
+            </li>
+          </ul>
+        </section>
+
+        {/* 12 */}
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">12. Data Processing Location</h2>
+          <p className="mt-3">
+            All data is processed and stored in the United States. Our primary infrastructure is
+            hosted on Vercel (US regions) with database services provided by Supabase (US data
+            centers). If you access the Service from outside the United States, your information
+            will be transferred to and processed in the United States, which may have different data
+            protection laws than your jurisdiction.
+          </p>
+        </section>
+
+        {/* 13 */}
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">13. Children&apos;s Privacy</h2>
+          <p className="mt-3">
+            FuzzyCat is not intended for use by individuals under the age of 18. We do not knowingly
+            collect personal information from children. If we become aware that we have collected
+            information from a minor, we will take steps to delete it promptly. If you believe a
+            child has provided us with personal information, contact us at{' '}
             <a href="mailto:privacy@fuzzycatapp.com" className="text-primary hover:underline">
               privacy@fuzzycatapp.com
             </a>
@@ -160,37 +480,36 @@ export default function PrivacyPolicyPage() {
           </p>
         </section>
 
+        {/* 14 */}
         <section>
-          <h2 className="text-xl font-semibold text-foreground">9. Children&apos;s Privacy</h2>
-          <p className="mt-3">
-            FuzzyCat is not intended for use by individuals under the age of 18. We do not knowingly
-            collect personal information from children. If we become aware that we have collected
-            information from a minor, we will take steps to delete it promptly.
-          </p>
-        </section>
-
-        <section>
-          <h2 className="text-xl font-semibold text-foreground">10. Changes to This Policy</h2>
+          <h2 className="text-xl font-semibold text-foreground">14. Changes to This Policy</h2>
           <p className="mt-3">
             We may update this Privacy Policy from time to time. We will notify you of material
-            changes by posting the updated policy on this page and updating the &quot;Last
-            updated&quot; date. Your continued use of FuzzyCat after changes are posted constitutes
-            acceptance of the revised policy.
+            changes by posting the updated policy on this page, updating the &quot;Last
+            updated&quot; date, and sending a notification to the email address associated with your
+            account. Your continued use of FuzzyCat after changes are posted constitutes acceptance
+            of the revised policy. We encourage you to review this page periodically.
           </p>
         </section>
 
+        {/* 15 */}
         <section>
-          <h2 className="text-xl font-semibold text-foreground">11. Contact Us</h2>
+          <h2 className="text-xl font-semibold text-foreground">15. Contact Us</h2>
           <p className="mt-3">
-            If you have questions about this Privacy Policy or our data practices, contact us at:
+            If you have questions about this Privacy Policy, wish to exercise your privacy rights,
+            or have concerns about our data practices, contact us at:
           </p>
           <p className="mt-3">
-            <strong className="text-foreground">FuzzyCat</strong>
+            <strong className="text-foreground">FuzzyCat Inc.</strong>
             <br />
             Email:{' '}
             <a href="mailto:privacy@fuzzycatapp.com" className="text-primary hover:underline">
               privacy@fuzzycatapp.com
             </a>
+          </p>
+          <p className="mt-3">
+            For California privacy requests, you may also email us with the subject line &quot;CCPA
+            Request&quot; at the address above.
           </p>
         </section>
       </div>

--- a/app/(marketing)/terms/page.tsx
+++ b/app/(marketing)/terms/page.tsx
@@ -11,21 +11,24 @@ export default function TermsOfServicePage() {
   return (
     <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
       <h1 className="text-4xl font-bold tracking-tight">Terms of Service</h1>
-      <p className="mt-3 text-sm text-muted-foreground">Last updated: February 1, 2026</p>
+      <p className="mt-3 text-sm text-muted-foreground">Last updated: March 3, 2026</p>
 
       <Separator className="my-8" />
 
       <div className="prose prose-neutral dark:prose-invert max-w-none space-y-8 text-sm leading-relaxed text-muted-foreground">
+        {/* 1 */}
         <section>
           <h2 className="text-xl font-semibold text-foreground">1. Acceptance of Terms</h2>
           <p className="mt-3">
             By accessing or using the FuzzyCat platform at fuzzycatapp.com (&quot;Service&quot;),
             you agree to be bound by these Terms of Service (&quot;Terms&quot;). If you do not agree
             to these Terms, do not use the Service. These Terms constitute a legally binding
-            agreement between you and FuzzyCat (&quot;we,&quot; &quot;us,&quot; or &quot;our&quot;).
+            agreement between you and FuzzyCat Inc. (&quot;FuzzyCat,&quot; &quot;we,&quot;
+            &quot;us,&quot; or &quot;our&quot;).
           </p>
         </section>
 
+        {/* 2 */}
         <section>
           <h2 className="text-xl font-semibold text-foreground">2. Service Description</h2>
           <p className="mt-3">
@@ -35,8 +38,17 @@ export default function TermsOfServicePage() {
             processing of payments between pet owners and veterinary clinics using third-party
             payment processors.
           </p>
+          <p className="mt-3">
+            <strong className="text-foreground">Regulatory disclaimer:</strong> The Service is not a
+            loan, credit product, or financing arrangement under the Truth in Lending Act (TILA),
+            the Equal Credit Opportunity Act (ECOA), or equivalent state consumer lending laws. No
+            credit check is performed, no credit is extended, and no interest is charged. The
+            platform fee described in Section 4 is a service fee for payment facilitation, not a
+            finance charge.
+          </p>
         </section>
 
+        {/* 3 */}
         <section>
           <h2 className="text-xl font-semibold text-foreground">3. Eligibility</h2>
           <p className="mt-3">To use FuzzyCat, you must:</p>
@@ -50,6 +62,7 @@ export default function TermsOfServicePage() {
           </ul>
         </section>
 
+        {/* 4 */}
         <section>
           <h2 className="text-xl font-semibold text-foreground">4. Payment Plans</h2>
           <p className="mt-3">
@@ -62,7 +75,9 @@ export default function TermsOfServicePage() {
             </li>
             <li>
               <strong className="text-foreground">Platform fee:</strong> A flat 6% platform fee is
-              added to your bill amount. This fee is disclosed before you confirm enrollment.
+              added to your bill amount. This fee is disclosed before you confirm enrollment and is
+              included in your total payment amount. This is the only cost — there is no interest,
+              no annual percentage rate, and no additional charges.
             </li>
             <li>
               <strong className="text-foreground">Deposit:</strong> 25% of the total amount
@@ -82,8 +97,43 @@ export default function TermsOfServicePage() {
           </ul>
         </section>
 
+        {/* 5 */}
         <section>
-          <h2 className="text-xl font-semibold text-foreground">5. Failed Payments and Default</h2>
+          <h2 className="text-xl font-semibold text-foreground">5. ACH Debit Authorization</h2>
+          <p className="mt-3">
+            By enrolling in a payment plan, you authorize FuzzyCat and its payment processor, Stripe
+            Inc., to initiate recurring Automated Clearing House (ACH) debit entries from the bank
+            account you designate during enrollment. This authorization covers:
+          </p>
+          <ul className="mt-3 list-disc space-y-2 pl-6">
+            <li>
+              Six (6) scheduled biweekly installment payments in the amounts disclosed at
+              enrollment.
+            </li>
+            <li>
+              Up to three (3) retry attempts for any failed installment, as described in Section 6.
+            </li>
+          </ul>
+          <p className="mt-3">
+            This authorization remains in effect until your payment plan is completed, cancelled, or
+            defaulted. You may revoke this authorization at any time by contacting us at{' '}
+            <a href="mailto:support@fuzzycatapp.com" className="text-primary hover:underline">
+              support@fuzzycatapp.com
+            </a>
+            . Revocation must be received at least three (3) business days before the next scheduled
+            debit. Revoking ACH authorization does not cancel your payment plan obligations — see
+            Section 8 for cancellation terms.
+          </p>
+          <p className="mt-3">
+            If you believe an ACH debit was initiated in error, you have the right to dispute the
+            transaction with your bank under NACHA operating rules and Regulation E. You may also
+            contact us directly to resolve the issue.
+          </p>
+        </section>
+
+        {/* 6 */}
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">6. Failed Payments and Default</h2>
           <p className="mt-3">
             If a scheduled payment fails (for example, due to insufficient funds):
           </p>
@@ -105,8 +155,9 @@ export default function TermsOfServicePage() {
           </ul>
         </section>
 
+        {/* 7 */}
         <section>
-          <h2 className="text-xl font-semibold text-foreground">6. Veterinary Clinic Terms</h2>
+          <h2 className="text-xl font-semibold text-foreground">7. Veterinary Clinic Terms</h2>
           <p className="mt-3">If you are a veterinary clinic using FuzzyCat:</p>
           <ul className="mt-3 list-disc space-y-2 pl-6">
             <li>
@@ -125,11 +176,114 @@ export default function TermsOfServicePage() {
               You must maintain an active Stripe Connect account in good standing to receive
               payouts.
             </li>
+            <li>
+              By connecting your Stripe account, you also agree to the{' '}
+              <a
+                href="https://stripe.com/connect-account/legal"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                Stripe Connected Account Agreement
+              </a>
+              , which governs your relationship with Stripe for payment processing and payouts.
+            </li>
           </ul>
         </section>
 
+        {/* 8 */}
         <section>
-          <h2 className="text-xl font-semibold text-foreground">7. Account Responsibilities</h2>
+          <h2 className="text-xl font-semibold text-foreground">
+            8. Cancellation and Refund Policy
+          </h2>
+          <p className="mt-3">
+            <strong className="text-foreground">Before the first installment is processed:</strong>{' '}
+            You may cancel your payment plan by contacting us. Your deposit will be refunded minus
+            any applicable Stripe processing fees.
+          </p>
+          <p className="mt-3">
+            <strong className="text-foreground">After installments have begun:</strong> You may
+            request to cancel your plan. Any payments already made (including the deposit and
+            completed installments) are non-refundable, as those funds have already been transferred
+            to your veterinary clinic. The remaining unpaid balance becomes immediately due to the
+            clinic. FuzzyCat will cease further ACH debits from your account, and the clinic will be
+            notified of the cancellation with the outstanding balance.
+          </p>
+          <p className="mt-3">
+            <strong className="text-foreground">Clinic-initiated cancellation:</strong> If a
+            veterinary clinic cancels a plan (for example, due to a refund, treatment change, or
+            billing error), FuzzyCat will stop future debits and work with the clinic to process any
+            applicable refunds.
+          </p>
+          <p className="mt-3">
+            To request cancellation, contact us at{' '}
+            <a href="mailto:support@fuzzycatapp.com" className="text-primary hover:underline">
+              support@fuzzycatapp.com
+            </a>
+            .
+          </p>
+        </section>
+
+        {/* 9 */}
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">
+            9. Electronic Communications Consent
+          </h2>
+          <p className="mt-3">
+            By creating an account or enrolling in a payment plan, you consent to receive electronic
+            communications from FuzzyCat, including:
+          </p>
+          <ul className="mt-3 list-disc space-y-2 pl-6">
+            <li>Payment confirmations, receipts, and schedule reminders.</li>
+            <li>Failed payment notifications and collection reminders.</li>
+            <li>Account security alerts and password reset emails.</li>
+            <li>Service updates, policy changes, and legal notices.</li>
+          </ul>
+          <p className="mt-3">
+            You agree that these electronic communications satisfy any legal requirement that such
+            communications be in writing, in accordance with the Electronic Signatures in Global and
+            National Commerce Act (E-SIGN Act, 15 U.S.C. 7001 et seq.) and applicable state
+            electronic transaction laws. Communications will be sent via email and/or SMS to the
+            contact information you provide. You may update your contact information in your account
+            settings at any time. You may withdraw consent to non-essential communications by
+            contacting us, but transactional communications related to active payment plans cannot
+            be opted out of while the plan remains active.
+          </p>
+        </section>
+
+        {/* 10 */}
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">
+            10. Third-Party Payment Processing
+          </h2>
+          <p className="mt-3">
+            Payment processing on FuzzyCat is provided by Stripe Inc. By using our Service, you
+            agree to be bound by Stripe&apos;s{' '}
+            <a
+              href="https://stripe.com/legal"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              Terms of Service
+            </a>{' '}
+            and{' '}
+            <a
+              href="https://stripe.com/privacy"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              Privacy Policy
+            </a>{' '}
+            as they apply to the processing of your payments. FuzzyCat is not responsible for
+            Stripe&apos;s actions, errors, or omissions.
+          </p>
+        </section>
+
+        {/* 11 */}
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">11. Account Responsibilities</h2>
           <p className="mt-3">
             You are responsible for maintaining the confidentiality of your account credentials and
             for all activities that occur under your account. You agree to notify us immediately of
@@ -138,8 +292,9 @@ export default function TermsOfServicePage() {
           </p>
         </section>
 
+        {/* 12 */}
         <section>
-          <h2 className="text-xl font-semibold text-foreground">8. Prohibited Uses</h2>
+          <h2 className="text-xl font-semibold text-foreground">12. Prohibited Uses</h2>
           <p className="mt-3">You agree not to:</p>
           <ul className="mt-3 list-disc space-y-2 pl-6">
             <li>Use the Service for any unlawful purpose or in violation of these Terms.</li>
@@ -149,11 +304,45 @@ export default function TermsOfServicePage() {
             </li>
             <li>Use the Service on behalf of a third party without proper authorization.</li>
             <li>Reverse-engineer, decompile, or disassemble any part of the Service.</li>
+            <li>
+              Use any automated system, including bots, scrapers, or scripts, to access the Service
+              in a manner that sends more requests than a human could reasonably produce.
+            </li>
           </ul>
         </section>
 
+        {/* 13 */}
         <section>
-          <h2 className="text-xl font-semibold text-foreground">9. Intellectual Property</h2>
+          <h2 className="text-xl font-semibold text-foreground">13. API Terms of Use</h2>
+          <p className="mt-3">
+            If you access the FuzzyCat REST API (available to registered veterinary clinics), the
+            following additional terms apply:
+          </p>
+          <ul className="mt-3 list-disc space-y-2 pl-6">
+            <li>
+              API access is granted via API keys generated from your clinic dashboard. You are
+              responsible for securing your API keys and must not share them with unauthorized
+              parties.
+            </li>
+            <li>
+              API usage is subject to rate limits as documented in the API reference. Excessive or
+              abusive API usage may result in temporary or permanent suspension of access.
+            </li>
+            <li>
+              Data retrieved via the API remains subject to these Terms and our Privacy Policy. You
+              may not use API data for purposes outside your legitimate clinic operations.
+            </li>
+            <li>
+              FuzzyCat reserves the right to modify, deprecate, or discontinue API endpoints with
+              reasonable notice. We will provide at least 30 days&apos; notice before removing
+              existing endpoints.
+            </li>
+          </ul>
+        </section>
+
+        {/* 14 */}
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">14. Intellectual Property</h2>
           <p className="mt-3">
             The FuzzyCat name, logo, and all content, features, and functionality of the Service are
             owned by FuzzyCat and are protected by copyright, trademark, and other intellectual
@@ -162,8 +351,21 @@ export default function TermsOfServicePage() {
           </p>
         </section>
 
+        {/* 15 */}
         <section>
-          <h2 className="text-xl font-semibold text-foreground">10. Limitation of Liability</h2>
+          <h2 className="text-xl font-semibold text-foreground">15. Indemnification</h2>
+          <p className="mt-3">
+            You agree to indemnify, defend, and hold harmless FuzzyCat, its officers, directors,
+            employees, and agents from and against any claims, liabilities, damages, losses, costs,
+            or expenses (including reasonable attorneys&apos; fees) arising from: (a) your use of
+            the Service; (b) your violation of these Terms; (c) your violation of any rights of a
+            third party; or (d) any content or information you provide through the Service.
+          </p>
+        </section>
+
+        {/* 16 */}
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">16. Limitation of Liability</h2>
           <p className="mt-3">
             To the maximum extent permitted by applicable law, FuzzyCat shall not be liable for any
             indirect, incidental, special, consequential, or punitive damages, including but not
@@ -174,38 +376,81 @@ export default function TermsOfServicePage() {
           </p>
         </section>
 
+        {/* 17 */}
         <section>
-          <h2 className="text-xl font-semibold text-foreground">11. Disclaimer of Warranties</h2>
+          <h2 className="text-xl font-semibold text-foreground">17. Disclaimer of Warranties</h2>
           <p className="mt-3">
             The Service is provided &quot;as is&quot; and &quot;as available&quot; without
-            warranties of any kind, either express or implied. We do not warrant that the Service
-            will be uninterrupted, error-free, or secure. We do not guarantee payment between pet
-            owners and clinics.
+            warranties of any kind, either express or implied, including but not limited to implied
+            warranties of merchantability, fitness for a particular purpose, and non-infringement.
+            We do not warrant that the Service will be uninterrupted, error-free, or secure. We do
+            not guarantee payment between pet owners and clinics.
           </p>
         </section>
 
+        {/* 18 */}
         <section>
-          <h2 className="text-xl font-semibold text-foreground">12. Governing Law</h2>
+          <h2 className="text-xl font-semibold text-foreground">
+            18. Dispute Resolution and Arbitration
+          </h2>
+          <p className="mt-3">
+            <strong className="text-foreground">Informal resolution:</strong> Before filing any
+            formal dispute, you agree to contact us at{' '}
+            <a href="mailto:legal@fuzzycatapp.com" className="text-primary hover:underline">
+              legal@fuzzycatapp.com
+            </a>{' '}
+            and attempt to resolve the dispute informally for at least 30 days.
+          </p>
+          <p className="mt-3">
+            <strong className="text-foreground">Binding arbitration:</strong> If informal resolution
+            fails, any dispute arising from or relating to these Terms or the Service shall be
+            resolved by binding arbitration administered by the American Arbitration Association
+            (AAA) under its Consumer Arbitration Rules. Arbitration will take place in San Francisco
+            County, California, or at another mutually agreed location. The arbitrator&apos;s
+            decision shall be final and binding and may be entered as a judgment in any court of
+            competent jurisdiction.
+          </p>
+          <p className="mt-3">
+            <strong className="text-foreground">Class action waiver:</strong> You agree that any
+            dispute resolution proceedings will be conducted only on an individual basis and not in
+            a class, consolidated, or representative action. If for any reason a claim proceeds in
+            court rather than arbitration, you waive any right to a jury trial.
+          </p>
+          <p className="mt-3">
+            <strong className="text-foreground">Exceptions:</strong> Either party may bring claims
+            in small claims court if eligible. Nothing in this section prevents either party from
+            seeking injunctive or equitable relief in court to prevent the actual or threatened
+            infringement of intellectual property rights.
+          </p>
+        </section>
+
+        {/* 19 */}
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">19. Governing Law</h2>
           <p className="mt-3">
             These Terms shall be governed by and construed in accordance with the laws of the State
-            of California, without regard to its conflict of law provisions. Any disputes arising
-            from these Terms or your use of the Service shall be resolved in the state or federal
-            courts located in San Francisco County, California.
+            of California, without regard to its conflict of law provisions. To the extent any
+            dispute is not subject to arbitration under Section 18, the exclusive venue shall be the
+            state or federal courts located in San Francisco County, California.
           </p>
         </section>
 
+        {/* 20 */}
         <section>
-          <h2 className="text-xl font-semibold text-foreground">13. Changes to These Terms</h2>
+          <h2 className="text-xl font-semibold text-foreground">20. Changes to These Terms</h2>
           <p className="mt-3">
             We reserve the right to modify these Terms at any time. We will notify you of material
-            changes by posting the updated Terms on this page and updating the &quot;Last
-            updated&quot; date. Your continued use of the Service after changes are posted
-            constitutes acceptance of the revised Terms.
+            changes by posting the updated Terms on this page, updating the &quot;Last updated&quot;
+            date, and sending a notification to the email address associated with your account. Your
+            continued use of the Service after changes are posted constitutes acceptance of the
+            revised Terms. If you do not agree to the updated Terms, you must stop using the
+            Service.
           </p>
         </section>
 
+        {/* 21 */}
         <section>
-          <h2 className="text-xl font-semibold text-foreground">14. Termination</h2>
+          <h2 className="text-xl font-semibold text-foreground">21. Termination</h2>
           <p className="mt-3">
             We may suspend or terminate your access to the Service at any time for violation of
             these Terms or for any other reason at our discretion. Upon termination, any outstanding
@@ -215,11 +460,45 @@ export default function TermsOfServicePage() {
           </p>
         </section>
 
+        {/* 22 */}
         <section>
-          <h2 className="text-xl font-semibold text-foreground">15. Contact Us</h2>
+          <h2 className="text-xl font-semibold text-foreground">22. General Provisions</h2>
+          <ul className="mt-3 list-disc space-y-2 pl-6">
+            <li>
+              <strong className="text-foreground">Entire agreement:</strong> These Terms, together
+              with our Privacy Policy, constitute the entire agreement between you and FuzzyCat
+              regarding your use of the Service and supersede any prior agreements.
+            </li>
+            <li>
+              <strong className="text-foreground">Severability:</strong> If any provision of these
+              Terms is found to be unenforceable or invalid by a court of competent jurisdiction,
+              the remaining provisions shall continue in full force and effect.
+            </li>
+            <li>
+              <strong className="text-foreground">Waiver:</strong> Our failure to enforce any right
+              or provision of these Terms shall not constitute a waiver of that right or provision.
+            </li>
+            <li>
+              <strong className="text-foreground">Assignment:</strong> You may not assign or
+              transfer these Terms or your rights under them without our prior written consent. We
+              may assign our rights and obligations under these Terms without restriction, including
+              in connection with a merger, acquisition, or sale of assets.
+            </li>
+            <li>
+              <strong className="text-foreground">Force majeure:</strong> FuzzyCat shall not be
+              liable for any failure or delay in performance resulting from causes beyond our
+              reasonable control, including but not limited to natural disasters, acts of
+              government, internet or power outages, or third-party service provider failures.
+            </li>
+          </ul>
+        </section>
+
+        {/* 23 */}
+        <section>
+          <h2 className="text-xl font-semibold text-foreground">23. Contact Us</h2>
           <p className="mt-3">If you have questions about these Terms, contact us at:</p>
           <p className="mt-3">
-            <strong className="text-foreground">FuzzyCat</strong>
+            <strong className="text-foreground">FuzzyCat Inc.</strong>
             <br />
             Email:{' '}
             <a href="mailto:legal@fuzzycatapp.com" className="text-primary hover:underline">

--- a/vercel.json
+++ b/vercel.json
@@ -20,7 +20,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://js.stripe.com https://challenges.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://*.stripe.com https://*.supabase.co https://us.i.posthog.com https://cdn.plaid.com https://vitals.vercel-insights.com https://va.vercel-scripts.com; frame-src https://js.stripe.com https://cdn.plaid.com https://challenges.cloudflare.com; object-src 'none'; base-uri 'self'; form-action 'self'"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://js.stripe.com https://challenges.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://*.stripe.com https://*.supabase.co https://us.i.posthog.com https://vitals.vercel-insights.com https://va.vercel-scripts.com; frame-src https://js.stripe.com https://challenges.cloudflare.com; object-src 'none'; base-uri 'self'; form-action 'self'"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- **Plaid cleanup**: Removed all stale Plaid references from `vercel.json` (CSP), `CLAUDE.md`, and `README.md`. Plaid was replaced by Stripe in PR #326/#328 but docs were never updated.
- **Terms of Service**: Expanded from 15 to 23 sections. Added ACH debit authorization (NACHA-compliant), cancellation/refund policy, E-SIGN Act consent, Stripe terms reference, API terms of use, indemnification, arbitration with class action waiver, and general provisions (severability, assignment, force majeure). Strengthened regulatory disclaimers (TILA/ECOA).
- **Privacy Policy**: Expanded from 11 to 15 sections. Added CCPA/CPRA disclosures, standalone "Do Not Sell" statement, data breach notification commitment, data processing location, Cloudflare Turnstile disclosure, cookie inventory table, Vercel Analytics/Speed Insights tracking, and expanded service provider list with locations.

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run check` passes (Biome lint + format)
- [x] `bun run test` — 427 tests pass
- [ ] Visual verification of `/terms` and `/privacy` pages after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)