### PR TITLE
feat: feature-flag Founding Clinic program, reduce duration to 3 months

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,7 @@ CRON_SECRET=                     # Secret for Vercel Cron job authentication
 
 # ── Feature Flags (optional) ─────────────────────────────────────
 ENABLE_MFA=                      # Set to "true" to enforce MFA for clinic/admin roles
+ENABLE_FOUNDING_CLINIC=          # Set to "true" to enable the Founding Clinic enrollment program
 DISABLE_CAPTCHA=                 # Set to "true" to bypass CAPTCHA verification
 
 # ── Sentry → GitHub Pipeline (optional) ──────────────────────────

--- a/app/clinic/dashboard/_components/founding-clinic-banner.tsx
+++ b/app/clinic/dashboard/_components/founding-clinic-banner.tsx
@@ -24,7 +24,7 @@ export function FoundingClinicBanner() {
 
   if (isLoading || !status) return null;
 
-  // Already enrolled — show badge
+  // Already enrolled — show badge regardless of feature flag
   if (status.isFoundingClinic) {
     return (
       <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-950/30">
@@ -42,8 +42,8 @@ export function FoundingClinicBanner() {
     );
   }
 
-  // No spots left
-  if (status.spotsRemaining <= 0) return null;
+  // Feature disabled or no spots left — don't show promotional banner
+  if (!status.enabled || status.spotsRemaining <= 0) return null;
 
   // Promotional banner
   return (
@@ -54,7 +54,7 @@ export function FoundingClinicBanner() {
           <div>
             <p className="font-semibold">Become a Founding Clinic</p>
             <p className="text-sm text-muted-foreground">
-              Earn 5% revenue share (vs. standard 3%) for 12 months. Only {status.spotsRemaining}{' '}
+              Earn 5% revenue share (vs. standard 3%) for 3 months. Only {status.spotsRemaining}{' '}
               spots remaining.
             </p>
           </div>

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -31,7 +31,7 @@ export const FOUNDING_CLINIC_LIMIT = 50;
 export const FOUNDING_CLINIC_SHARE_BPS = 500;
 
 /** Duration of enhanced revenue share for founding clinics (months). */
-export const FOUNDING_CLINIC_DURATION_MONTHS = 12;
+export const FOUNDING_CLINIC_DURATION_MONTHS = 3;
 
 /** Default clinic revenue share in basis points (3%). */
 export const DEFAULT_CLINIC_SHARE_BPS = 300;

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -26,6 +26,7 @@ const serverSchema = z.object({
   SENTRY_PROJECT: z.string().optional(),
   CRON_SECRET: z.string().optional(),
   ENABLE_MFA: z.string().optional(),
+  ENABLE_FOUNDING_CLINIC: z.string().optional(),
   DISABLE_CAPTCHA: z.string().optional(),
   SENTRY_WEBHOOK_SECRET: z.string().optional(),
   GITHUB_TOKEN: z.string().optional(),

--- a/server/__tests__/services/founding-clinic.test.ts
+++ b/server/__tests__/services/founding-clinic.test.ts
@@ -12,6 +12,13 @@ mock.module('@/lib/logger', () => ({
   },
 }));
 
+// Feature flag mock — default to enabled so existing tests pass
+const mockServerEnv = mock(() => ({ ENABLE_FOUNDING_CLINIC: 'true' }) as Record<string, string>);
+mock.module('@/lib/env', () => ({
+  serverEnv: mockServerEnv,
+  _resetEnvCache: () => {},
+}));
+
 // DB mock chain (for non-transaction queries)
 const mockSelectLimit = mock();
 const mockSelectWhere = mock();
@@ -178,6 +185,7 @@ describe('founding-clinic service', () => {
       mockSelect.mockReturnValue({ from: mockSelectFrom });
 
       const status = await getFoundingClinicStatus('clinic-1');
+      expect(status.enabled).toBe(true);
       expect(status.isFoundingClinic).toBe(true);
       expect(status.expiresAt).toEqual(expiresAt);
       expect(status.spotsRemaining).toBe(FOUNDING_CLINIC_LIMIT - 10);
@@ -196,9 +204,42 @@ describe('founding-clinic service', () => {
       mockSelect.mockReturnValue({ from: mockSelectFrom });
 
       const status = await getFoundingClinicStatus('clinic-unknown');
+      expect(status.enabled).toBe(true);
       expect(status.isFoundingClinic).toBe(false);
       expect(status.expiresAt).toBeNull();
       expect(status.spotsRemaining).toBe(FOUNDING_CLINIC_LIMIT - 5);
+    });
+
+    it('returns disabled status when feature flag is off', async () => {
+      mockServerEnv.mockReturnValue({ ENABLE_FOUNDING_CLINIC: '' });
+      mockSelectWhere.mockReturnValue({
+        limit: () => [{ foundingClinic: false, foundingExpiresAt: null }],
+      });
+      mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
+      mockSelect.mockReturnValue({ from: mockSelectFrom });
+
+      const status = await getFoundingClinicStatus('clinic-1');
+      expect(status.enabled).toBe(false);
+      expect(status.spotsRemaining).toBe(0);
+      // Restore default
+      mockServerEnv.mockReturnValue({ ENABLE_FOUNDING_CLINIC: 'true' });
+    });
+
+    it('still shows founding badge when disabled but clinic was already enrolled', async () => {
+      mockServerEnv.mockReturnValue({ ENABLE_FOUNDING_CLINIC: '' });
+      const expiresAt = new Date('2027-01-01');
+      mockSelectWhere.mockReturnValue({
+        limit: () => [{ foundingClinic: true, foundingExpiresAt: expiresAt }],
+      });
+      mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
+      mockSelect.mockReturnValue({ from: mockSelectFrom });
+
+      const status = await getFoundingClinicStatus('clinic-1');
+      expect(status.enabled).toBe(false);
+      expect(status.isFoundingClinic).toBe(true);
+      expect(status.expiresAt).toEqual(expiresAt);
+      // Restore default
+      mockServerEnv.mockReturnValue({ ENABLE_FOUNDING_CLINIC: 'true' });
     });
   });
 
@@ -259,6 +300,17 @@ describe('founding-clinic service', () => {
       const result = await enrollAsFoundingClinic('clinic-1');
       expect(result.success).toBe(false);
       expect(result.error).toBe('Founding Clinic program is full');
+    });
+
+    it('rejects enrollment when feature flag is off', async () => {
+      mockServerEnv.mockReturnValue({ ENABLE_FOUNDING_CLINIC: '' });
+
+      const result = await enrollAsFoundingClinic('clinic-1');
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Founding Clinic program is not currently available');
+      expect(mockTransaction).not.toHaveBeenCalled();
+      // Restore default
+      mockServerEnv.mockReturnValue({ ENABLE_FOUNDING_CLINIC: 'true' });
     });
 
     it('updates clinic with founding status on success', async () => {

--- a/server/services/founding-clinic.ts
+++ b/server/services/founding-clinic.ts
@@ -4,14 +4,23 @@ import {
   FOUNDING_CLINIC_LIMIT,
   FOUNDING_CLINIC_SHARE_BPS,
 } from '@/lib/constants';
+import { serverEnv } from '@/lib/env';
 import { logger } from '@/lib/logger';
 import { addMonths } from '@/lib/utils/date';
 import { db } from '@/server/db';
 import { clinics } from '@/server/db/schema';
 
+// ── Feature flag ─────────────────────────────────────────────────────
+
+/** Returns true if the Founding Clinic program is enabled via ENABLE_FOUNDING_CLINIC env var. */
+export function isFoundingClinicEnabled(): boolean {
+  return serverEnv().ENABLE_FOUNDING_CLINIC === 'true';
+}
+
 // ── Types ────────────────────────────────────────────────────────────
 
 export interface FoundingClinicStatus {
+  enabled: boolean;
   isFoundingClinic: boolean;
   expiresAt: Date | null;
   spotsRemaining: number;
@@ -33,6 +42,25 @@ export async function isFoundingClinicAvailable(): Promise<boolean> {
 }
 
 export async function getFoundingClinicStatus(clinicId: string): Promise<FoundingClinicStatus> {
+  if (!isFoundingClinicEnabled()) {
+    // Still show badge for clinics already enrolled, even when program is disabled
+    const [clinic] = await db
+      .select({
+        foundingClinic: clinics.foundingClinic,
+        foundingExpiresAt: clinics.foundingExpiresAt,
+      })
+      .from(clinics)
+      .where(eq(clinics.id, clinicId))
+      .limit(1);
+
+    return {
+      enabled: false,
+      isFoundingClinic: clinic?.foundingClinic ?? false,
+      expiresAt: clinic?.foundingExpiresAt ?? null,
+      spotsRemaining: 0,
+    };
+  }
+
   const [clinic] = await db
     .select({
       foundingClinic: clinics.foundingClinic,
@@ -46,6 +74,7 @@ export async function getFoundingClinicStatus(clinicId: string): Promise<Foundin
   const spotsRemaining = Math.max(0, FOUNDING_CLINIC_LIMIT - count);
 
   return {
+    enabled: true,
     isFoundingClinic: clinic?.foundingClinic ?? false,
     expiresAt: clinic?.foundingExpiresAt ?? null,
     spotsRemaining,
@@ -57,6 +86,10 @@ export async function getFoundingClinicStatus(clinicId: string): Promise<Foundin
 export async function enrollAsFoundingClinic(
   clinicId: string,
 ): Promise<{ success: boolean; error?: string }> {
+  if (!isFoundingClinicEnabled()) {
+    return { success: false, error: 'Founding Clinic program is not currently available' };
+  }
+
   return await db.transaction(async (tx) => {
     // Lock and check current state
     const [clinic] = await tx


### PR DESCRIPTION
## Summary

- Adds `ENABLE_FOUNDING_CLINIC` env var (disabled by default, same pattern as `ENABLE_MFA`)
- When disabled: hides promotional banner, rejects enrollment mutations, returns `enabled: false` from status query
- Already-enrolled founding clinics still see their badge regardless of flag state
- Reduces `FOUNDING_CLINIC_DURATION_MONTHS` from 12 → 3

## Test plan
- [x] 473 tests pass (3 new feature flag tests)
- [x] TypeScript + Biome clean
- [ ] Set `ENABLE_FOUNDING_CLINIC=true` in Vercel when ready to launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)