### PR TITLE
fix: walkthrough bug fixes (CA state, CAPTCHA timeout, stale refs, CSP)

### DIFF
--- a/app/(marketing)/api-docs/page.tsx
+++ b/app/(marketing)/api-docs/page.tsx
@@ -94,8 +94,7 @@ export default function ApiDocsPage() {
 
       <div className="mt-10 rounded-lg border bg-muted/30 p-6 text-center">
         <p className="text-sm text-muted-foreground">
-          Need help with your integration? Use the feedback button in the bottom-right corner of any
-          page to reach our team.
+          Need help with your integration? Contact us at support@fuzzycatapp.com to reach our team.
         </p>
       </div>
     </div>

--- a/app/(marketing)/request/page.tsx
+++ b/app/(marketing)/request/page.tsx
@@ -14,6 +14,7 @@ const US_STATES = [
   'AK',
   'AZ',
   'AR',
+  'CA',
   'CO',
   'CT',
   'DE',

--- a/app/(marketing)/support/page.tsx
+++ b/app/(marketing)/support/page.tsx
@@ -23,8 +23,8 @@ export default function SupportPage() {
       <div className="text-center">
         <h1 className="text-4xl font-bold tracking-tight">Help &amp; Support</h1>
         <p className="mt-3 text-lg text-muted-foreground">
-          Find answers to common questions below. If you need further help, use the feedback button
-          in the bottom-right corner of any page.
+          Find answers to common questions below. If you need further help, contact us at
+          support@fuzzycatapp.com.
         </p>
       </div>
 
@@ -103,7 +103,7 @@ export default function SupportPage() {
                 <p>
                   Payment plans cannot be cancelled once the deposit has been processed, as the
                   funds are forwarded to the veterinary clinic. If you are experiencing financial
-                  difficulty, please reach out using the feedback button and we will work with you
+                  difficulty, please contact us at support@fuzzycatapp.com and we will work with you
                   to find a solution.
                 </p>
               </AccordionContent>
@@ -354,12 +354,12 @@ export default function SupportPage() {
               <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
                 <MessageCircle className="h-5 w-5" />
               </div>
-              <CardTitle className="text-lg">Send Feedback</CardTitle>
+              <CardTitle className="text-lg">Contact Support</CardTitle>
             </CardHeader>
             <CardContent>
               <p className="text-sm text-muted-foreground">
-                Use the feedback button in the bottom-right corner of any page to report a problem,
-                ask a question, or suggest an improvement. Our team reviews every submission.
+                Email us at support@fuzzycatapp.com to report a problem, ask a question, or suggest
+                an improvement. Our team reviews every message.
               </p>
             </CardContent>
           </Card>

--- a/app/clinic/getting-started/page.tsx
+++ b/app/clinic/getting-started/page.tsx
@@ -77,8 +77,7 @@ export default function GettingStartedPage() {
 
       <div className="mt-8 rounded-lg border bg-muted/30 p-6 text-center">
         <p className="text-sm text-muted-foreground">
-          Need help? Use the feedback button in the bottom-right corner of any page to reach our
-          team.
+          Need help? Contact us at support@fuzzycatapp.com to reach our team.
         </p>
       </div>
     </div>

--- a/app/owner/settings/_components/account-safety-section.tsx
+++ b/app/owner/settings/_components/account-safety-section.tsx
@@ -10,9 +10,7 @@ export function AccountSafetySection() {
       'Are you sure you want to deactivate your account? This action cannot be undone.',
     );
     if (confirmed) {
-      window.alert(
-        'To deactivate your account, use the feedback button in the bottom-right corner of the page.',
-      );
+      window.alert('To deactivate your account, please contact us at support@fuzzycatapp.com.');
     }
   }
 

--- a/components/shared/captcha.tsx
+++ b/components/shared/captcha.tsx
@@ -40,8 +40,19 @@ export const Captcha = forwardRef<CaptchaHandle, CaptchaProps>(function Captcha(
       // Reset the widget before each execution to avoid stale/expired tokens
       turnstileRef.current?.reset();
       return new Promise<string>((resolve, reject) => {
-        resolveRef.current = resolve;
-        rejectRef.current = reject;
+        const timeout = setTimeout(() => {
+          resolveRef.current = null;
+          rejectRef.current = null;
+          reject(new Error('Captcha verification timed out. Please try again.'));
+        }, 30_000);
+        resolveRef.current = (token: string) => {
+          clearTimeout(timeout);
+          resolve(token);
+        };
+        rejectRef.current = (err: Error) => {
+          clearTimeout(timeout);
+          reject(err);
+        };
         turnstileRef.current?.execute();
       });
     },

--- a/proxy.ts
+++ b/proxy.ts
@@ -31,7 +31,7 @@ function buildCspDirectives(scriptSrc: string, sentryDsn?: string): string {
     scriptSrc,
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: blob: https:",
-    "font-src 'self'",
+    "font-src 'self' https://fonts.scalar.com",
     "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.stripe.com https://*.posthog.com https://*.i.posthog.com https://*.ingest.us.sentry.io https://*.sentry-cdn.com",
     'frame-src https://js.stripe.com https://challenges.cloudflare.com https://connect-js.stripe.com',
     "worker-src 'self' blob:",

--- a/vercel.json
+++ b/vercel.json
@@ -20,7 +20,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://js.stripe.com https://challenges.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://*.stripe.com https://*.supabase.co https://us.i.posthog.com https://vitals.vercel-insights.com https://va.vercel-scripts.com; frame-src https://js.stripe.com https://challenges.cloudflare.com; object-src 'none'; base-uri 'self'; form-action 'self'"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://js.stripe.com https://challenges.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' https://fonts.scalar.com; connect-src 'self' https://*.stripe.com https://*.supabase.co https://us.i.posthog.com https://vitals.vercel-insights.com https://va.vercel-scripts.com; frame-src https://js.stripe.com https://challenges.cloudflare.com; object-src 'none'; base-uri 'self'; form-action 'self'"
         }
       ]
     },

--- a/walkthrough/BUG_REPORT.md
+++ b/walkthrough/BUG_REPORT.md
@@ -1,0 +1,103 @@
+# Comprehensive Playwright Walkthrough Bug Report
+
+**Date**: March 3, 2026
+**Environment**: Production (https://www.fuzzycatapp.com)
+
+## Pages Tested
+
+### Marketing Pages (All OK)
+- Homepage - OK (8% fee, correct CTAs)
+- How It Works - OK (calculator works, 8% fee)
+- Support/FAQ - OK (accordions work, content correct)
+- Privacy Policy - OK (comprehensive, correct)
+- Terms of Service - OK (comprehensive, 8% fee)
+- API Documentation - OK (links to Scalar docs)
+- Request FuzzyCat at Your Clinic - **BUG #1** (missing CA state)
+
+### Registration Flows
+- Clinic Signup (`/signup/clinic`) - **BUG #2** (CAPTCHA timeout)
+- Owner Signup (`/signup/owner`) - OK (password toggle works)
+- Generic Signup (`/signup`) - OK (tabs work, both roles)
+
+### Login Flows
+- Clinic Login (`/login/clinic`) - OK (redirects correctly with proper app_metadata)
+- Owner Login (`/login/owner`) - OK
+- Generic Login (`/login`) - OK (portal links + direct login)
+- Forgot Password (`/forgot-password`) - OK (form renders)
+
+### Clinic Dashboard (Authenticated)
+- Dashboard (`/clinic/dashboard`) - OK (stats, activity, upcoming payments)
+- Getting Started (`/clinic/getting-started`) - OK (5-step checklist)
+- Clients (`/clinic/clients`) - OK (search, filter, stats)
+- Payouts (`/clinic/payouts`) - OK (history, stats)
+- Reports (`/clinic/reports`) - OK (revenue, trends, export)
+- Settings (`/clinic/settings`) - OK (profile, Stripe, API keys, MFA)
+- Enroll (`/clinic/enroll`) - OK (client search, form, payment method)
+- Onboarding (`/clinic/onboarding`) - OK (2-step setup)
+- Materials (`/clinic/materials`) - OK (3 tabs, QR code, print)
+- Referrals (`/clinic/referrals`) - OK (code, invite, history)
+
+### Owner Dashboard (Authenticated)
+- Dashboard (`/owner/payments`) - OK (stats, quick links)
+- Referrals (`/owner/referrals`) - OK ($20 referral, code, history)
+- Settings (`/owner/settings`) - OK (profile, pets, payment, deactivate)
+
+### Admin Panel (Authenticated)
+- Dashboard (`/admin/dashboard`) - OK (metrics, clinics table, audit log)
+- Clinics (`/admin/clinics`) - OK (tabs, approve/suspend/reactivate)
+- Payments (`/admin/payments`) - OK (49 payments, tabs, pagination)
+- Platform Reserve (`/admin/risk`) - OK (reserve health, soft collections, defaults)
+
+### API
+- `/api/health` - OK
+- `/api/v1/health` - OK
+- `/api/v1/docs` (Scalar) - **BUG #3** (font loading errors)
+
+---
+
+## Bugs Found
+
+### BUG #1: California (CA) Missing from State Dropdown [CRITICAL]
+- **Location**: `app/(marketing)/request/page.tsx` line 12, `US_STATES` array
+- **Impact**: California residents cannot select their state on the clinic request form. This is the company's home state.
+- **Details**: The array jumps from 'AR' (Arkansas) to 'CO' (Colorado), skipping 'CA' (California).
+- **Fix**: Add `'CA'` between `'AR'` and `'CO'` in the US_STATES array.
+
+### BUG #2: CAPTCHA Timeout - Form Hangs Forever [MEDIUM]
+- **Location**: `components/shared/captcha.tsx`
+- **Impact**: If the Turnstile CAPTCHA challenge fails to resolve (e.g., timeout, network issue, automated browser), the form button stays on "Registering..." / "Creating account..." forever with no error message. Users must refresh the page (losing form data).
+- **Details**: The `execute()` method returns a Promise that may never resolve if the Turnstile widget fails silently.
+- **Fix**: Add a timeout (e.g., 30 seconds) to the CAPTCHA execute promise. If it times out, reject with a user-friendly error.
+
+### BUG #3: Stale "Feedback Button" References [MEDIUM]
+- **Location**: 6 files reference a non-existent feedback button
+  - `app/(marketing)/support/page.tsx` (3 occurrences)
+  - `app/(marketing)/api-docs/page.tsx` (1 occurrence)
+  - `app/clinic/getting-started/page.tsx` (1 occurrence)
+  - `app/owner/settings/_components/account-safety-section.tsx` (1 occurrence)
+- **Impact**: Users are told to use a "feedback button in the bottom-right corner" that doesn't exist since the Sentry feedbackIntegration was removed.
+- **Fix**: Replace with "contact us at support@fuzzycatapp.com" or similar.
+
+### BUG #4: Scalar API Docs Font Loading Errors [LOW]
+- **Location**: `/api/v1/docs`
+- **Impact**: 14 console errors loading fonts from `fonts.scalar.com`. CSP blocks the font domain. Docs are still functional but use fallback fonts.
+- **Fix**: Add `fonts.scalar.com` to the CSP font-src directive, or accept fallback fonts.
+
+### BUG #5: Password Reset Email Sender [UX]
+- **Location**: Supabase Auth configuration (dashboard only — not a code change)
+- **Impact**: Password reset emails come from Supabase's default sender (noreply@mail.app.supabase.io) instead of a FuzzyCat-branded address. This confuses users.
+- **Fix**: Configure custom SMTP in Supabase Dashboard:
+  1. Go to https://supabase.com/dashboard → Production project → Authentication → SMTP Settings
+  2. Enable Custom SMTP
+  3. Set: Host = `smtp.resend.com`, Port = `465`, Username = `resend`, Password = Resend API key
+  4. Set Sender email = `noreply@fuzzycatapp.com` (domain must be verified in Resend)
+  5. Set Sender name = `FuzzyCat`
+  6. Also update email templates (Authentication → Email Templates) to use FuzzyCat branding
+- **Status**: Requires manual dashboard configuration — cannot be automated via code
+
+---
+
+## Non-Issues (Expected Behavior)
+- Permissions-Policy warnings for 'browsing-topics' and 'interest-cohort' - Browser noise
+- Turnstile CAPTCHA blocking automated browsers - Expected bot protection
+- NY state excluded from state dropdowns - Intentional per business rules


### PR DESCRIPTION
## Summary
- **BUG #1**: Add missing California (CA) to US_STATES dropdown on `/request` page — CA residents couldn't select their state
- **BUG #2**: Add 30-second timeout to Turnstile CAPTCHA `execute()` — forms hung forever if CAPTCHA failed silently
- **BUG #3**: Replace 6 stale "feedback button" references with `support@fuzzycatapp.com` across 5 files — Sentry feedback widget was removed
- **BUG #4**: Add `fonts.scalar.com` to CSP `font-src` in both `proxy.ts` and `vercel.json` — Scalar API docs had 14 font loading errors
- **BUG #5**: Documented Supabase custom SMTP configuration steps in bug report (requires dashboard config, not code)

Full walkthrough bug report at `walkthrough/BUG_REPORT.md`.

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run check` passes (Biome lint + format)
- [x] `bun run test` passes (473 tests)
- [x] Isolated tests pass (16 files)
- [ ] Verify CA appears in state dropdown on `/request`
- [ ] Verify CAPTCHA timeout shows error after 30s instead of hanging
- [ ] Verify no "feedback button" text appears in app
- [ ] Verify Scalar docs fonts load without CSP errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)