### PR TITLE
fix: disable founding clinic promotion via feature flag

### DIFF
--- a/app/clinic/dashboard/_components/founding-clinic-banner.tsx
+++ b/app/clinic/dashboard/_components/founding-clinic-banner.tsx
@@ -24,7 +24,10 @@ export function FoundingClinicBanner() {
 
   if (isLoading || !status) return null;
 
-  // Already enrolled — show badge regardless of feature flag
+  // Feature disabled — hide everything (badge and promotional banner)
+  if (!status.enabled) return null;
+
+  // Already enrolled — show badge
   if (status.isFoundingClinic) {
     return (
       <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-950/30">
@@ -42,8 +45,8 @@ export function FoundingClinicBanner() {
     );
   }
 
-  // Feature disabled or no spots left — don't show promotional banner
-  if (!status.enabled || status.spotsRemaining <= 0) return null;
+  // No spots left — don't show promotional banner
+  if (status.spotsRemaining <= 0) return null;
 
   // Promotional banner
   return (

--- a/server/__tests__/services/founding-clinic.test.ts
+++ b/server/__tests__/services/founding-clinic.test.ts
@@ -212,32 +212,26 @@ describe('founding-clinic service', () => {
 
     it('returns disabled status when feature flag is off', async () => {
       mockServerEnv.mockReturnValue({ ENABLE_FOUNDING_CLINIC: '' });
-      mockSelectWhere.mockReturnValue({
-        limit: () => [{ foundingClinic: false, foundingExpiresAt: null }],
-      });
-      mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
-      mockSelect.mockReturnValue({ from: mockSelectFrom });
 
       const status = await getFoundingClinicStatus('clinic-1');
       expect(status.enabled).toBe(false);
+      expect(status.isFoundingClinic).toBe(false);
+      expect(status.expiresAt).toBeNull();
       expect(status.spotsRemaining).toBe(0);
+      // Should not have queried the DB at all
+      expect(mockSelect).not.toHaveBeenCalled();
       // Restore default
       mockServerEnv.mockReturnValue({ ENABLE_FOUNDING_CLINIC: 'true' });
     });
 
-    it('still shows founding badge when disabled but clinic was already enrolled', async () => {
+    it('hides founding status when disabled even if clinic was enrolled', async () => {
       mockServerEnv.mockReturnValue({ ENABLE_FOUNDING_CLINIC: '' });
-      const expiresAt = new Date('2027-01-01');
-      mockSelectWhere.mockReturnValue({
-        limit: () => [{ foundingClinic: true, foundingExpiresAt: expiresAt }],
-      });
-      mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
-      mockSelect.mockReturnValue({ from: mockSelectFrom });
 
       const status = await getFoundingClinicStatus('clinic-1');
       expect(status.enabled).toBe(false);
-      expect(status.isFoundingClinic).toBe(true);
-      expect(status.expiresAt).toEqual(expiresAt);
+      expect(status.isFoundingClinic).toBe(false);
+      expect(status.expiresAt).toBeNull();
+      expect(status.spotsRemaining).toBe(0);
       // Restore default
       mockServerEnv.mockReturnValue({ ENABLE_FOUNDING_CLINIC: 'true' });
     });

--- a/server/__tests__/services/payout-share-rate.test.ts
+++ b/server/__tests__/services/payout-share-rate.test.ts
@@ -1,10 +1,18 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it, mock } from 'bun:test';
 
 import { DEFAULT_CLINIC_SHARE_BPS, FOUNDING_CLINIC_SHARE_BPS } from '@/lib/constants';
-import { getEffectiveShareRate } from '@/server/services/payout';
 
-// ── getEffectiveShareRate ────────────────────────────────────────────
-// Pure function — no mocking needed.
+// ── Mocks ────────────────────────────────────────────────────────────
+
+const mockServerEnv = mock(() => ({ ENABLE_FOUNDING_CLINIC: 'true' }) as Record<string, string>);
+mock.module('@/lib/env', () => ({
+  serverEnv: mockServerEnv,
+  _resetEnvCache: () => {},
+}));
+
+const { getEffectiveShareRate } = await import('@/server/services/payout');
+
+// ── Tests ────────────────────────────────────────────────────────────
 
 describe('getEffectiveShareRate', () => {
   const defaultRate = DEFAULT_CLINIC_SHARE_BPS / 10_000; // 0.03
@@ -38,7 +46,8 @@ describe('getEffectiveShareRate', () => {
     expect(rate).toBe(defaultRate);
   });
 
-  it('returns enhanced rate for founding clinic with future expiry', () => {
+  it('returns enhanced rate for founding clinic with future expiry when feature enabled', () => {
+    mockServerEnv.mockReturnValue({ ENABLE_FOUNDING_CLINIC: 'true' });
     const futureDate = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000);
     const rate = getEffectiveShareRate({
       revenueShareBps: FOUNDING_CLINIC_SHARE_BPS,
@@ -48,7 +57,20 @@ describe('getEffectiveShareRate', () => {
     expect(rate).toBe(foundingRate);
   });
 
+  it('returns default rate for founding clinic when feature is disabled', () => {
+    mockServerEnv.mockReturnValue({ ENABLE_FOUNDING_CLINIC: '' });
+    const futureDate = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000);
+    const rate = getEffectiveShareRate({
+      revenueShareBps: FOUNDING_CLINIC_SHARE_BPS,
+      foundingClinic: true,
+      foundingExpiresAt: futureDate,
+    });
+    expect(rate).toBe(defaultRate);
+    mockServerEnv.mockReturnValue({ ENABLE_FOUNDING_CLINIC: 'true' });
+  });
+
   it('returns custom BPS rate for founding clinic with future expiry', () => {
+    mockServerEnv.mockReturnValue({ ENABLE_FOUNDING_CLINIC: 'true' });
     const futureDate = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000);
     const customBps = 700; // 7%
     const rate = getEffectiveShareRate({
@@ -70,15 +92,13 @@ describe('getEffectiveShareRate', () => {
   });
 
   it('returns default rate when expiry is exactly now (edge: not strictly greater)', () => {
-    // new Date() inside the function will be >= the value we set here,
-    // so the condition clinic.foundingExpiresAt > new Date() will be false.
+    mockServerEnv.mockReturnValue({ ENABLE_FOUNDING_CLINIC: 'true' });
     const now = new Date();
     const rate = getEffectiveShareRate({
       revenueShareBps: FOUNDING_CLINIC_SHARE_BPS,
       foundingClinic: true,
       foundingExpiresAt: now,
     });
-    // At best the dates are equal, so > fails → default rate
     expect(rate).toBe(defaultRate);
   });
 });

--- a/server/services/founding-clinic.ts
+++ b/server/services/founding-clinic.ts
@@ -43,20 +43,10 @@ export async function isFoundingClinicAvailable(): Promise<boolean> {
 
 export async function getFoundingClinicStatus(clinicId: string): Promise<FoundingClinicStatus> {
   if (!isFoundingClinicEnabled()) {
-    // Still show badge for clinics already enrolled, even when program is disabled
-    const [clinic] = await db
-      .select({
-        foundingClinic: clinics.foundingClinic,
-        foundingExpiresAt: clinics.foundingExpiresAt,
-      })
-      .from(clinics)
-      .where(eq(clinics.id, clinicId))
-      .limit(1);
-
     return {
       enabled: false,
-      isFoundingClinic: clinic?.foundingClinic ?? false,
-      expiresAt: clinic?.foundingExpiresAt ?? null,
+      isFoundingClinic: false,
+      expiresAt: null,
       spotsRemaining: 0,
     };
   }

--- a/server/services/payout.ts
+++ b/server/services/payout.ts
@@ -8,6 +8,7 @@ import {
 import { percentOfCents } from '@/lib/utils/money';
 import { db } from '@/server/db';
 import { payouts } from '@/server/db/schema';
+import { isFoundingClinicEnabled } from '@/server/services/founding-clinic';
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -114,7 +115,12 @@ export function getEffectiveShareRate(clinic: {
   foundingClinic: boolean;
   foundingExpiresAt: Date | null;
 }): number {
-  if (clinic.foundingClinic && clinic.foundingExpiresAt && clinic.foundingExpiresAt > new Date()) {
+  if (
+    isFoundingClinicEnabled() &&
+    clinic.foundingClinic &&
+    clinic.foundingExpiresAt &&
+    clinic.foundingExpiresAt > new Date()
+  ) {
     return clinic.revenueShareBps / 10_000;
   }
   return DEFAULT_CLINIC_SHARE_BPS / 10_000;


### PR DESCRIPTION
## Summary
- Gate all founding clinic UI and enhanced revenue share behind `ENABLE_FOUNDING_CLINIC` feature flag
- When disabled (default): banner hidden for all clinics (including enrolled ones), `getFoundingClinicStatus` returns disabled state without DB query, `getEffectiveShareRate` falls back to default 3% (300 BPS)
- One production clinic ("Sunset Veterinary Hospital") is enrolled at 500 BPS expiring Mar 2027 — they will now receive the default 3% rate

## Test plan
- [x] 455 unit tests pass (1 new test for disabled feature flag in payout share rate)
- [x] TypeScript compiles clean
- [x] Biome lint passes
- [x] Playwright verified: clinic dashboard shows no founding clinic banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)