### PR TITLE
fix: resolve enrollment deadlock from connection pool exhaustion

### DIFF
--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -7,7 +7,7 @@ function createDb() {
   const { DATABASE_URL } = serverEnv();
   const client = postgres(DATABASE_URL, {
     prepare: false,
-    max: 1,
+    max: 10,
     idle_timeout: 20,
     connect_timeout: 10,
   });

--- a/server/services/enrollment.ts
+++ b/server/services/enrollment.ts
@@ -162,7 +162,7 @@ export async function createEnrollment(
     }
 
     // 2. Check for referral discount (reduces platform fee, FuzzyCat absorbs as CAC)
-    const referralDiscountCents = await getReferralDiscount(ownerId);
+    const referralDiscountCents = await getReferralDiscount(ownerId, tx);
     const adjustedFeeCents = Math.max(0, schedule.feeCents - referralDiscountCents);
     const feeReduction = schedule.feeCents - adjustedFeeCents;
     const adjustedTotalWithFeeCents = schedule.totalWithFeeCents - feeReduction;

--- a/server/services/owner-referral.ts
+++ b/server/services/owner-referral.ts
@@ -133,8 +133,11 @@ export async function convertOwnerReferral(
  * Get the fee discount for a referred owner's enrollment.
  * Returns 0 if the owner was not referred.
  */
-export async function getReferralDiscount(ownerId: string): Promise<number> {
-  const [referral] = await db
+export async function getReferralDiscount(
+  ownerId: string,
+  queryDb: Pick<typeof db, 'select'> = db,
+): Promise<number> {
+  const [referral] = await queryDb
     .select({ id: ownerReferrals.id })
     .from(ownerReferrals)
     .where(and(eq(ownerReferrals.referredOwnerId, ownerId), eq(ownerReferrals.status, 'converted')))


### PR DESCRIPTION
## Summary
- **Root cause**: `getReferralDiscount()` used the global `db` inside `createEnrollment()`'s `db.transaction()`. With `max: 1` in the connection pool, this caused an indefinite deadlock — the transaction held the only connection while `getReferralDiscount` waited for another.
- Pass `tx` into `getReferralDiscount()` so it reuses the transaction connection
- Increase connection pool from `max: 1` to `max: 10` to prevent future pool exhaustion

## Test plan
- [x] All 455 unit tests pass
- [x] Typecheck passes
- [x] Biome lint clean
- [x] Scanned all 10 transaction sites — no other deadlock patterns found

🤖 Generated with [Claude Code](https://claude.com/claude-code)