### PR TITLE
fix: direct owners to their clinic for financial difficulty

### DIFF
--- a/app/(marketing)/support/page.tsx
+++ b/app/(marketing)/support/page.tsx
@@ -103,8 +103,8 @@ export default function SupportPage() {
                 <p>
                   Payment plans cannot be cancelled once the deposit has been processed, as the
                   funds are forwarded to the veterinary clinic. If you are experiencing financial
-                  difficulty, please contact us at support@fuzzycatapp.com and we will work with you
-                  to find a solution.
+                  difficulty, please contact your veterinary clinic directly to discuss possible
+                  options.
                 </p>
               </AccordionContent>
             </AccordionItem>

--- a/server/emails/soft-collection-day14.tsx
+++ b/server/emails/soft-collection-day14.tsx
@@ -62,7 +62,7 @@ export function SoftCollectionDay14({
 
       <Text style={muted}>
         If you believe this notice was sent in error, or if you need to discuss your options, please
-        contact our support team immediately.
+        contact your veterinary clinic directly.
       </Text>
     </EmailLayout>
   );

--- a/server/emails/soft-collection-day7.tsx
+++ b/server/emails/soft-collection-day7.tsx
@@ -60,8 +60,8 @@ export function SoftCollectionDay7({
       </Section>
 
       <Text style={muted}>
-        If you are experiencing financial difficulty, please contact our support team. We may be
-        able to work out an alternative arrangement.
+        If you are experiencing financial difficulty, please contact your veterinary clinic directly
+        to discuss possible options.
       </Text>
     </EmailLayout>
   );


### PR DESCRIPTION
## Summary
- Owners experiencing financial difficulty are now directed to contact their veterinary clinic directly, not FuzzyCat support
- Updated in 3 places: support FAQ page, day 7 soft collection email, day 14 soft collection email
- FuzzyCat does not provide financial counseling or alternative payment arrangements

## Test plan
- [x] Biome lint/format clean
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)