### PR TITLE
fix: remove all support@fuzzycatapp.com references

### DIFF
--- a/app/(marketing)/api-docs/page.tsx
+++ b/app/(marketing)/api-docs/page.tsx
@@ -94,7 +94,8 @@ export default function ApiDocsPage() {
 
       <div className="mt-10 rounded-lg border bg-muted/30 p-6 text-center">
         <p className="text-sm text-muted-foreground">
-          Need help with your integration? Contact us at support@fuzzycatapp.com to reach our team.
+          Need help with your integration? Use the feedback button in the bottom-right corner of the
+          page.
         </p>
       </div>
     </div>

--- a/app/(marketing)/support/page.tsx
+++ b/app/(marketing)/support/page.tsx
@@ -23,8 +23,8 @@ export default function SupportPage() {
       <div className="text-center">
         <h1 className="text-4xl font-bold tracking-tight">Help &amp; Support</h1>
         <p className="mt-3 text-lg text-muted-foreground">
-          Find answers to common questions below. If you need further help, contact us at
-          support@fuzzycatapp.com.
+          Find answers to common questions below. If you need further help, use the feedback button
+          in the bottom-right corner of the page.
         </p>
       </div>
 
@@ -354,12 +354,12 @@ export default function SupportPage() {
               <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
                 <MessageCircle className="h-5 w-5" />
               </div>
-              <CardTitle className="text-lg">Contact Support</CardTitle>
+              <CardTitle className="text-lg">Send Feedback</CardTitle>
             </CardHeader>
             <CardContent>
               <p className="text-sm text-muted-foreground">
-                Email us at support@fuzzycatapp.com to report a problem, ask a question, or suggest
-                an improvement. Our team reviews every message.
+                Use the feedback button in the bottom-right corner of any page to report a problem,
+                ask a question, or suggest an improvement.
               </p>
             </CardContent>
           </Card>

--- a/app/(marketing)/terms/page.tsx
+++ b/app/(marketing)/terms/page.tsx
@@ -116,13 +116,11 @@ export default function TermsOfServicePage() {
           </ul>
           <p className="mt-3">
             This authorization remains in effect until your payment plan is completed, cancelled, or
-            defaulted. You may revoke this authorization at any time by contacting us at{' '}
-            <a href="mailto:support@fuzzycatapp.com" className="text-primary hover:underline">
-              support@fuzzycatapp.com
-            </a>
-            . Revocation must be received at least three (3) business days before the next scheduled
-            debit. Revoking ACH authorization does not cancel your payment plan obligations — see
-            Section 8 for cancellation terms.
+            defaulted. You may revoke this authorization at any time by submitting a request through
+            the feedback button in the bottom-right corner of any page. Revocation must be received
+            at least three (3) business days before the next scheduled debit. Revoking ACH
+            authorization does not cancel your payment plan obligations — see Section 8 for
+            cancellation terms.
           </p>
           <p className="mt-3">
             If you believe an ACH debit was initiated in error, you have the right to dispute the
@@ -216,11 +214,8 @@ export default function TermsOfServicePage() {
             applicable refunds.
           </p>
           <p className="mt-3">
-            To request cancellation, contact us at{' '}
-            <a href="mailto:support@fuzzycatapp.com" className="text-primary hover:underline">
-              support@fuzzycatapp.com
-            </a>
-            .
+            To request cancellation, submit a request through the feedback button in the
+            bottom-right corner of any page.
           </p>
         </section>
 

--- a/app/clinic/getting-started/page.tsx
+++ b/app/clinic/getting-started/page.tsx
@@ -77,7 +77,7 @@ export default function GettingStartedPage() {
 
       <div className="mt-8 rounded-lg border bg-muted/30 p-6 text-center">
         <p className="text-sm text-muted-foreground">
-          Need help? Contact us at support@fuzzycatapp.com to reach our team.
+          Need help? Use the feedback button in the bottom-right corner of the page.
         </p>
       </div>
     </div>

--- a/app/owner/settings/_components/account-safety-section.tsx
+++ b/app/owner/settings/_components/account-safety-section.tsx
@@ -10,7 +10,9 @@ export function AccountSafetySection() {
       'Are you sure you want to deactivate your account? This action cannot be undone.',
     );
     if (confirmed) {
-      window.alert('To deactivate your account, please contact us at support@fuzzycatapp.com.');
+      window.alert(
+        'To deactivate your account, please use the feedback button in the bottom-right corner of the page.',
+      );
     }
   }
 

--- a/server/api/app.ts
+++ b/server/api/app.ts
@@ -195,9 +195,8 @@ export function createApiApp() {
       version: '1.0.0',
       description: API_DESCRIPTION,
       contact: {
-        name: 'FuzzyCat Support',
-        url: 'https://www.fuzzycatapp.com',
-        email: 'support@fuzzycatapp.com',
+        name: 'FuzzyCat',
+        url: 'https://www.fuzzycatapp.com/support',
       },
     },
     servers: [{ url: '/api/v1', description: 'API v1' }],


### PR DESCRIPTION
## Summary
- Removed all `support@fuzzycatapp.com` references (8 occurrences across 6 files)
- Replaced with "use the feedback button in the bottom-right corner" which routes to Sentry
- FuzzyCat does not offer email support

## Files changed
- `app/(marketing)/support/page.tsx` — header text + "Contact Support" card
- `app/(marketing)/terms/page.tsx` — ACH revocation + cancellation sections
- `app/(marketing)/api-docs/page.tsx` — help text
- `app/clinic/getting-started/page.tsx` — help text
- `app/owner/settings/_components/account-safety-section.tsx` — deactivation alert
- `server/api/app.ts` — OpenAPI spec contact info

## Test plan
- [x] `grep -r support@fuzzycatapp.com` returns zero results
- [x] All 455 unit tests pass
- [x] Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)