### PR TITLE
fix: audit fixes — env vars, CLAUDE.md fee typo, PostHog pushState error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,11 +3,17 @@ NEXT_PUBLIC_SUPABASE_URL=           # Supabase project URL
 NEXT_PUBLIC_SUPABASE_ANON_KEY=      # Supabase anonymous key
 SUPABASE_SERVICE_ROLE_KEY=          # Supabase service role key (server only)
 DATABASE_URL=                       # Supabase Postgres connection string (for Drizzle)
+SUPABASE_ACCESS_TOKEN=              # Supabase personal access token (for CLI/management API)
 
 # ── Stripe ───────────────────────────────────────────────────────────
 STRIPE_SECRET_KEY=                  # Stripe secret key
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=  # Stripe publishable key (NEXT_PUBLIC_ for browser access)
 STRIPE_WEBHOOK_SECRET=              # Stripe webhook signing secret
+
+# ── Plaid (bank verification) ──────────────────────────────────────
+PLAID_CLIENT_ID=                    # Plaid client ID
+PLAID_SECRET=                       # Plaid secret key
+PLAID_ENV=sandbox                   # Plaid environment (sandbox, production)
 
 # ── Resend ───────────────────────────────────────────────────────────
 RESEND_API_KEY=                     # Resend API key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,8 +93,8 @@ bunx drizzle-kit generate        # Generate SQL migrations
 
 ```
 ENROLLMENT:
-  1. Owner enters vet bill → system calculates 6% fee, 25% deposit, 6 installments
-  2. Owner enters debit card (Stripe Checkout) for deposit, connects bank for ACH installments
+  1. Owner enters vet bill → system calculates 8% fee, 25% deposit, 6 installments
+  2. Owner connects debit card or bank account via Stripe
   3. Deposit charged immediately → plan becomes "active"
   4. Remaining 75% split into 6 biweekly ACH debits
 

--- a/lib/posthog/client.ts
+++ b/lib/posthog/client.ts
@@ -9,7 +9,9 @@ export async function initPostHog() {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com',
     capture_pageview: false, // handled by PostHogPageView component
+    capture_pageleave: false,
     person_profiles: 'identified_only',
+    disable_external_dependency_loading: true,
   });
 
   return posthog;

--- a/lib/posthog/provider.tsx
+++ b/lib/posthog/provider.tsx
@@ -50,7 +50,9 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
         posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY as string, {
           api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com',
           capture_pageview: false,
+          capture_pageleave: false,
           person_profiles: 'identified_only',
+          disable_external_dependency_loading: true,
         });
       });
     });


### PR DESCRIPTION
## Summary
- Add missing `PLAID_CLIENT_ID`, `PLAID_SECRET`, `PLAID_ENV`, `SUPABASE_ACCESS_TOKEN` to `.env.example`
- Fix CLAUDE.md Payment Flow: "6% fee" → "8% fee" to match `lib/constants.ts` (`PLATFORM_FEE_RATE = 0.08`)
- Mitigate PostHog `pushState` TypeError (Sentry JAVASCRIPT-NEXTJS-Y) by adding `capture_pageleave: false` and `disable_external_dependency_loading: true` to PostHog init

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run check` passes
- [x] `bun run test` — 455 tests pass

Closes #374
Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)