### PR TITLE
fix: resolve hydration mismatch in ThemeToggle component

### DIFF
--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -2,17 +2,28 @@
 
 import { Moon, Sun } from 'lucide-react';
 import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 
 export function ThemeToggle() {
   const { setTheme, resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    return (
+      <Button variant="ghost" size="icon" aria-label="Toggle theme">
+        <span className="h-4 w-4" />
+      </Button>
+    );
+  }
 
   return (
     <Button
       variant="ghost"
       size="icon"
       onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
-      suppressHydrationWarning
     >
       <Sun className="h-4 w-4 rotate-0 scale-100 transition-transform dark:-rotate-90 dark:scale-0" />
       <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-transform dark:rotate-0 dark:scale-100" />


### PR DESCRIPTION
## Summary
- Fix `ThemeToggle` to defer rendering until client mount, preventing SSR/client hydration mismatch from `next-themes` `useTheme()` hook
- Resolves all 3 unresolved Sentry issues:
  - **NEXTJS-8/9**: Hydration errors on `/admin/dashboard` caused by theme state differing between server and client
  - **NEXTJS-Y**: `pushState` TypeError (already fixed in PR #377, resolved in Sentry)

## Test plan
- [ ] Verify no hydration warnings in browser console on `/admin/dashboard`
- [ ] Verify theme toggle still works (light/dark switch)
- [ ] Verify no layout shift on initial load (placeholder button matches dimensions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)