### PR TITLE
feat: add signup disclaimers, marketing copy, fix homepage text

### DIFF
--- a/app/(auth)/signup/client/page.tsx
+++ b/app/(auth)/signup/client/page.tsx
@@ -197,6 +197,37 @@ export default function ClientSignupPage() {
                   Sign in
                 </Link>
               </p>
+
+              {/* Marketing info */}
+              <div className="rounded-lg border bg-muted/50 p-4 space-y-3">
+                <h3 className="text-sm font-semibold">How FuzzyCat works</h3>
+                <p className="text-xs text-muted-foreground">
+                  Your clinic must be registered with FuzzyCat. Once registered, you can sign up by
+                  entering your debit card or bank information. You pay a 25% deposit on the total
+                  vet bill, and FuzzyCat debits your account for the balance every two weeks in
+                  equal amounts. An 8% platform fee applies to the total bill.
+                </p>
+                <ul className="text-xs text-muted-foreground space-y-1 list-disc pl-4">
+                  <li>No credit checks or high interest fees</li>
+                  <li>Payments go directly to your vet clinic</li>
+                  <li>All you need is a debit card or checking account</li>
+                </ul>
+                <p className="text-xs text-muted-foreground font-medium">
+                  * Ensure you can afford all payments. FuzzyCat will continue charging your account
+                  until the balance is paid. All overdraft fees or other charges are your
+                  responsibility. Do not sign up unless you can complete the entire payment schedule
+                  on time.
+                </p>
+              </div>
+
+              {/* Disclaimer */}
+              <p className="text-[11px] leading-relaxed text-muted-foreground/70">
+                <strong>Disclaimer:</strong> FuzzyCat is not responsible for any damages resulting
+                from use of the product. By signing up, you acknowledge that you have read the
+                information about automatic debits and that you are aware of the total charges that
+                will be incurred, including fees paid. Information is encrypted but FuzzyCat is not
+                responsible for any damages resulting from the use of the software.
+              </p>
             </>
           )}
         </div>

--- a/app/(auth)/signup/clinic/page.tsx
+++ b/app/(auth)/signup/clinic/page.tsx
@@ -201,6 +201,40 @@ export default function ClinicSignupPage() {
               Sign in
             </Link>
           </p>
+
+          {/* Marketing info */}
+          <div className="rounded-lg border bg-muted/50 p-4 space-y-3">
+            <h3 className="text-sm font-semibold">Why sign up for FuzzyCat?</h3>
+            <p className="text-xs text-muted-foreground">
+              When clients can&apos;t afford needed veterinary care, your clinic loses income too.
+              FuzzyCat helps your clients pay over time while boosting your earnings.
+            </p>
+            <div className="text-xs text-muted-foreground space-y-1">
+              <p className="font-medium">The problem:</p>
+              <ul className="list-disc pl-4 space-y-0.5">
+                <li>8 in 10 pet owners face financial stress over vet bills</li>
+                <li>Clinics lose revenue when clients delay or decline care</li>
+                <li>Current financing options involve high interest or credit denials</li>
+              </ul>
+            </div>
+            <div className="text-xs text-muted-foreground space-y-1">
+              <p className="font-medium">The FuzzyCat solution:</p>
+              <ul className="list-disc pl-4 space-y-0.5">
+                <li>Clients pay over time &mdash; no credit checks, no high interest</li>
+                <li>Your clinic earns 3% on every enrollment</li>
+                <li>Secure, encrypted platform with no charge to clinics</li>
+                <li>Clients pay 25% down, then biweekly debits for up to 12 weeks</li>
+                <li>Higher treatment acceptance and increased revenue</li>
+              </ul>
+            </div>
+          </div>
+
+          {/* Disclaimer */}
+          <p className="text-[11px] leading-relaxed text-muted-foreground/70">
+            <strong>Disclaimer:</strong> FuzzyCat is only an automatic payment service and no
+            collection services are included. Information is encrypted but FuzzyCat is not
+            responsible for any damages resulting from the use of the software.
+          </p>
         </div>
       </div>
 

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -178,7 +178,7 @@ export default function LandingPage() {
                   <p className="mt-4 text-lg text-teal-100">
                     FuzzyCat is the only payment plan that pays clinics a {clinicSharePercent}%
                     revenue share on every enrollment. Increase treatment acceptance, earn more
-                    revenue, and never absorb default risk.
+                    revenue, and reduce default risk.
                   </p>
                 </div>
                 <div className="space-y-4">


### PR DESCRIPTION
## Summary
- Change "never absorb default risk" to "reduce default risk" on homepage clinic CTA section
- Add legal disclaimer text to both client and clinic signup pages
- Add marketing/informational content explaining how FuzzyCat works on both signup pages

## Changes
- **Homepage** (`page.tsx`): Updated risk messaging per Karen's feedback
- **Client signup** (`signup/client/page.tsx`): Added "How FuzzyCat works" info section with payment flow, key benefits, responsible use warning, and legal disclaimer
- **Clinic signup** (`signup/clinic/page.tsx`): Added "Why sign up for FuzzyCat?" section with problem/solution framing, value props, and legal disclaimer

Closes #388, closes #389, closes #390

## Test plan
- [ ] Verify homepage clinic section says "reduce default risk"
- [ ] Verify client signup page shows marketing info and disclaimer below form
- [ ] Verify clinic signup page shows marketing info and disclaimer below form
- [ ] Verify mobile responsive layout on both signup pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)