### PR TITLE
feat: clarify payout math, add dashboard info, improve mobile UX

### DIFF
--- a/app/(auth)/signup/clinic/page.tsx
+++ b/app/(auth)/signup/clinic/page.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { PasswordInput } from '@/components/ui/password-input';
+import { CLINIC_SHARE_PERCENT } from '@/lib/constants';
 
 export default function ClinicSignupPage() {
   const router = useRouter();
@@ -221,7 +222,7 @@ export default function ClinicSignupPage() {
               <p className="font-medium">The FuzzyCat solution:</p>
               <ul className="list-disc pl-4 space-y-0.5">
                 <li>Clients pay over time &mdash; no credit checks, no high interest</li>
-                <li>Your clinic earns 3% on every enrollment</li>
+                <li>Your clinic earns {CLINIC_SHARE_PERCENT}% on every enrollment</li>
                 <li>Secure, encrypted platform with no charge to clinics</li>
                 <li>Clients pay 25% down, then biweekly debits for up to 12 weeks</li>
                 <li>Higher treatment acceptance and increased revenue</li>
@@ -245,7 +246,7 @@ export default function ClinicSignupPage() {
           <div className="space-y-6">
             <FeatureCard
               icon={<HandCoins className="h-5 w-5" />}
-              title="Earn 3% revenue share"
+              title={`Earn ${CLINIC_SHARE_PERCENT}% revenue share`}
               description="The only payment plan that pays clinics instead of charging them."
             />
             <FeatureCard

--- a/app/(marketing)/how-it-works/page.tsx
+++ b/app/(marketing)/how-it-works/page.tsx
@@ -17,12 +17,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
-import {
-  CLINIC_SHARE_RATE,
-  DEPOSIT_RATE,
-  NUM_INSTALLMENTS,
-  PLATFORM_FEE_RATE,
-} from '@/lib/constants';
+import { CLINIC_SHARE_PERCENT, DEPOSIT_RATE, FEE_PERCENT, NUM_INSTALLMENTS } from '@/lib/constants';
 import { PaymentCalculator } from './payment-calculator';
 
 export const metadata: Metadata = {
@@ -36,9 +31,9 @@ export const metadata: Metadata = {
 };
 
 export default function HowItWorksPage() {
-  const feePercent = Math.round(PLATFORM_FEE_RATE * 100);
+  const feePercent = FEE_PERCENT;
   const depositPercent = Math.round(DEPOSIT_RATE * 100);
-  const clinicSharePercent = Math.round(CLINIC_SHARE_RATE * 100);
+  const clinicSharePercent = CLINIC_SHARE_PERCENT;
 
   return (
     <>

--- a/app/(marketing)/layout.tsx
+++ b/app/(marketing)/layout.tsx
@@ -4,14 +4,14 @@ import Link from 'next/link';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
-import { FEE_PERCENT } from '@/lib/constants';
+import { CLINIC_SHARE_PERCENT, FEE_PERCENT } from '@/lib/constants';
 
 export const metadata: Metadata = {
   title: {
     template: '%s | FuzzyCat',
     default: 'FuzzyCat - Flexible Payment Plans for Veterinary Care',
   },
-  description: `Pay your vet bill in easy biweekly installments. No credit check. Flat ${FEE_PERCENT}% fee. Clinics earn 3% on every enrollment.`,
+  description: `Pay your vet bill in easy biweekly installments. No credit check. Flat ${FEE_PERCENT}% fee. Clinics earn ${CLINIC_SHARE_PERCENT}% on every enrollment.`,
 };
 
 function Header() {

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -17,7 +17,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import {
-  CLINIC_SHARE_RATE,
+  CLINIC_SHARE_PERCENT,
   DEPOSIT_RATE,
   FEE_PERCENT,
   NUM_INSTALLMENTS,
@@ -26,7 +26,7 @@ import {
 
 export const metadata: Metadata = {
   title: 'FuzzyCat - Flexible Payment Plans for Veterinary Care',
-  description: `Pay your vet bill in easy biweekly installments over 12 weeks. No credit check. Flat ${FEE_PERCENT}% fee. Clinics earn 3% on every enrollment. Flexible payment plans for veterinary care.`,
+  description: `Pay your vet bill in easy biweekly installments over 12 weeks. No credit check. Flat ${FEE_PERCENT}% fee. Clinics earn ${CLINIC_SHARE_PERCENT}% on every enrollment. Flexible payment plans for veterinary care.`,
   openGraph: {
     title: 'FuzzyCat - Flexible Payment Plans for Veterinary Care',
     description:
@@ -38,7 +38,7 @@ export const metadata: Metadata = {
 export default function LandingPage() {
   const feePercent = FEE_PERCENT;
   const depositPercent = Math.round(DEPOSIT_RATE * 100);
-  const clinicSharePercent = Math.round(CLINIC_SHARE_RATE * 100);
+  const clinicSharePercent = CLINIC_SHARE_PERCENT;
 
   return (
     <>

--- a/app/(marketing)/support/page.tsx
+++ b/app/(marketing)/support/page.tsx
@@ -10,7 +10,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
-import { FEE_PERCENT } from '@/lib/constants';
+import { CLINIC_SHARE_PERCENT, FEE_PERCENT } from '@/lib/constants';
 
 export const metadata: Metadata = {
   title: 'Support',
@@ -184,20 +184,22 @@ export default function SupportPage() {
               <AccordionContent>
                 <p>
                   Nothing. FuzzyCat is free for veterinary clinics. The {FEE_PERCENT}% platform fee
-                  is paid entirely by the client. Clinics earn a 3% revenue share on every
-                  enrollment as platform administration compensation.
+                  is paid entirely by the client. Clinics earn a {CLINIC_SHARE_PERCENT}% revenue
+                  share on every enrollment as platform administration compensation.
                 </p>
               </AccordionContent>
             </AccordionItem>
 
             <AccordionItem value="clinic-revenue-share">
-              <AccordionTrigger>How does the 3% revenue share work?</AccordionTrigger>
+              <AccordionTrigger>
+                How does the {CLINIC_SHARE_PERCENT}% revenue share work?
+              </AccordionTrigger>
               <AccordionContent>
                 <p>
-                  For each enrollment, the clinic receives a 3% share of the total bill as platform
-                  administration compensation. This is paid out via Stripe Connect along with
-                  regular payment transfers. You can track your revenue share in the Payouts section
-                  of your clinic portal.
+                  For each enrollment, the clinic receives a {CLINIC_SHARE_PERCENT}% share of each
+                  payment amount (bill + fee) as platform administration compensation. This is paid
+                  out via Stripe Connect along with regular payment transfers. You can track your
+                  revenue share in the Payouts section of your clinic portal.
                 </p>
               </AccordionContent>
             </AccordionItem>
@@ -287,8 +289,8 @@ export default function SupportPage() {
                 <p>
                   FuzzyCat is a payment plan platform for veterinary clinics. Pet owners split their
                   vet bill into a 25% deposit and 6 biweekly installments over 12 weeks. There is no
-                  interest, no credit check, and no loan. Clinics earn a 3% revenue share on every
-                  enrollment at zero cost.
+                  interest, no credit check, and no loan. Clinics earn a {CLINIC_SHARE_PERCENT}%
+                  revenue share on every enrollment at zero cost.
                 </p>
               </AccordionContent>
             </AccordionItem>

--- a/app/(marketing)/terms/page.tsx
+++ b/app/(marketing)/terms/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Separator } from '@/components/ui/separator';
-import { FEE_PERCENT } from '@/lib/constants';
+import { CLINIC_SHARE_PERCENT, FEE_PERCENT } from '@/lib/constants';
 
 export const metadata: Metadata = {
   title: 'Terms of Service',
@@ -164,8 +164,8 @@ export default function TermsOfServicePage() {
               connected bank account.
             </li>
             <li>
-              You will receive a 3% platform administration compensation on each enrollment, paid as
-              part of your payout schedule.
+              You will receive a {CLINIC_SHARE_PERCENT}% platform administration compensation on
+              each enrollment, paid as part of your payout schedule.
             </li>
             <li>
               You are responsible for collecting any outstanding balance from clients whose plans

--- a/app/client/payments/_components/payment-history-table.tsx
+++ b/app/client/payments/_components/payment-history-table.tsx
@@ -68,7 +68,8 @@ export function PaymentHistoryTable({ planId }: PaymentHistoryTableProps) {
 
   return (
     <div className="space-y-4">
-      <div className="rounded-md border">
+      {/* Desktop table */}
+      <div className="hidden rounded-md border sm:block">
         <Table>
           <TableHeader>
             <TableRow>
@@ -105,6 +106,31 @@ export function PaymentHistoryTable({ planId }: PaymentHistoryTableProps) {
             ))}
           </TableBody>
         </Table>
+      </div>
+
+      {/* Mobile stacked layout */}
+      <div className="space-y-2 sm:hidden">
+        {data.payments.map((payment) => (
+          <div key={payment.id} className="flex items-center justify-between rounded-md border p-3">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium capitalize">
+                  {payment.type}
+                  {payment.sequenceNum !== null && payment.type === 'installment'
+                    ? ` #${payment.sequenceNum}`
+                    : ''}
+                </span>
+                <Badge variant={STATUS_VARIANT[payment.status] ?? 'secondary'} className="text-xs">
+                  {STATUS_LABEL[payment.status] ?? payment.status}
+                </Badge>
+              </div>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                {formatDate(payment.processedAt ?? payment.scheduledAt)}
+              </p>
+            </div>
+            <span className="ml-3 text-sm font-semibold">{formatCents(payment.amountCents)}</span>
+          </div>
+        ))}
       </div>
 
       {/* Pagination */}

--- a/app/client/payments/_components/recent-payments.tsx
+++ b/app/client/payments/_components/recent-payments.tsx
@@ -53,37 +53,62 @@ export function RecentPayments() {
         <CardTitle className="text-base">Recent Payments</CardTitle>
       </CardHeader>
       <CardContent>
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Date</TableHead>
-              <TableHead>Description</TableHead>
-              <TableHead className="text-right">Amount</TableHead>
-              <TableHead>Status</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {recentPayments.map((payment) => (
-              <TableRow key={payment.id}>
-                <TableCell className="text-muted-foreground">
-                  {formatDate(payment.scheduledAt)}
-                </TableCell>
-                <TableCell>
-                  <span className="font-medium capitalize">{payment.type}</span>
-                  {payment.clinicName && (
-                    <span className="text-muted-foreground"> &middot; {payment.clinicName}</span>
-                  )}
-                </TableCell>
-                <TableCell className="text-right font-medium">
-                  {formatCents(payment.amountCents)}
-                </TableCell>
-                <TableCell>
-                  <StatusBadge status={payment.status} size="sm" />
-                </TableCell>
+        {/* Desktop table */}
+        <div className="hidden sm:block">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Date</TableHead>
+                <TableHead>Description</TableHead>
+                <TableHead className="text-right">Amount</TableHead>
+                <TableHead>Status</TableHead>
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+            </TableHeader>
+            <TableBody>
+              {recentPayments.map((payment) => (
+                <TableRow key={payment.id}>
+                  <TableCell className="text-muted-foreground">
+                    {formatDate(payment.scheduledAt)}
+                  </TableCell>
+                  <TableCell>
+                    <span className="font-medium capitalize">{payment.type}</span>
+                    {payment.clinicName && (
+                      <span className="text-muted-foreground"> &middot; {payment.clinicName}</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right font-medium">
+                    {formatCents(payment.amountCents)}
+                  </TableCell>
+                  <TableCell>
+                    <StatusBadge status={payment.status} size="sm" />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+
+        {/* Mobile stacked cards */}
+        <div className="space-y-3 sm:hidden">
+          {recentPayments.map((payment) => (
+            <div
+              key={payment.id}
+              className="flex items-center justify-between rounded-md border p-3"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium capitalize">{payment.type}</span>
+                  <StatusBadge status={payment.status} size="sm" />
+                </div>
+                <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                  {formatDate(payment.scheduledAt)}
+                  {payment.clinicName && ` \u00B7 ${payment.clinicName}`}
+                </p>
+              </div>
+              <span className="ml-3 text-sm font-semibold">{formatCents(payment.amountCents)}</span>
+            </div>
+          ))}
+        </div>
       </CardContent>
     </Card>
   );

--- a/app/client/plans/[planId]/_components/plan-detail-content.tsx
+++ b/app/client/plans/[planId]/_components/plan-detail-content.tsx
@@ -195,33 +195,60 @@ function OwnerPaymentSchedule({ planId }: { planId: string }) {
   }
 
   return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead>Type</TableHead>
-          <TableHead>Amount</TableHead>
-          <TableHead>Status</TableHead>
-          <TableHead>Date</TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
+    <>
+      {/* Desktop table */}
+      <div className="hidden sm:block">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Type</TableHead>
+              <TableHead>Amount</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Date</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {data.payments.map((payment) => (
+              <TableRow key={payment.id}>
+                <TableCell className="capitalize">
+                  {payment.type === 'installment' && payment.sequenceNum
+                    ? `Installment ${payment.sequenceNum}`
+                    : 'Deposit'}
+                </TableCell>
+                <TableCell>{formatCents(payment.amountCents)}</TableCell>
+                <TableCell>
+                  <StatusBadge status={payment.status} size="sm" />
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {formatDate(payment.processedAt ?? payment.scheduledAt)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Mobile stacked layout */}
+      <div className="space-y-2 sm:hidden">
         {data.payments.map((payment) => (
-          <TableRow key={payment.id}>
-            <TableCell className="capitalize">
-              {payment.type === 'installment' && payment.sequenceNum
-                ? `Installment ${payment.sequenceNum}`
-                : 'Deposit'}
-            </TableCell>
-            <TableCell>{formatCents(payment.amountCents)}</TableCell>
-            <TableCell>
-              <StatusBadge status={payment.status} size="sm" />
-            </TableCell>
-            <TableCell className="text-muted-foreground">
-              {formatDate(payment.processedAt ?? payment.scheduledAt)}
-            </TableCell>
-          </TableRow>
+          <div key={payment.id} className="flex items-center justify-between rounded-md border p-3">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium capitalize">
+                  {payment.type === 'installment' && payment.sequenceNum
+                    ? `Inst. ${payment.sequenceNum}`
+                    : 'Deposit'}
+                </span>
+                <StatusBadge status={payment.status} size="sm" />
+              </div>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                {formatDate(payment.processedAt ?? payment.scheduledAt)}
+              </p>
+            </div>
+            <span className="ml-3 text-sm font-semibold">{formatCents(payment.amountCents)}</span>
+          </div>
         ))}
-      </TableBody>
-    </Table>
+      </div>
+    </>
   );
 }

--- a/app/clinic/clients/[clientId]/plans/[planId]/page.tsx
+++ b/app/clinic/clients/[clientId]/plans/[planId]/page.tsx
@@ -17,6 +17,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { CLINIC_SHARE_PERCENT } from '@/lib/constants';
 import { useTRPC } from '@/lib/trpc/client';
 import { formatDate } from '@/lib/utils/date';
 import { formatCents } from '@/lib/utils/money';
@@ -202,7 +203,7 @@ export default function ClinicPlanDetailPage({
               <TableHeader>
                 <TableRow>
                   <TableHead>Amount</TableHead>
-                  <TableHead>3% Share</TableHead>
+                  <TableHead>{CLINIC_SHARE_PERCENT}% Share</TableHead>
                   <TableHead>Status</TableHead>
                   <TableHead>Date</TableHead>
                 </TableRow>

--- a/app/clinic/clients/_components/client-plan-details.tsx
+++ b/app/clinic/clients/_components/client-plan-details.tsx
@@ -13,6 +13,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { CLINIC_SHARE_PERCENT } from '@/lib/constants';
 import { useTRPC } from '@/lib/trpc/client';
 import { formatDate } from '@/lib/utils/date';
 import { formatCents } from '@/lib/utils/money';
@@ -186,7 +187,7 @@ export function ClientPlanDetails({ planId }: ClientPlanDetailsProps) {
             <TableHeader>
               <TableRow>
                 <TableHead>Amount</TableHead>
-                <TableHead>3% Share</TableHead>
+                <TableHead>{CLINIC_SHARE_PERCENT}% Share</TableHead>
                 <TableHead>Status</TableHead>
                 <TableHead>Date</TableHead>
                 <TableHead>Transfer ID</TableHead>

--- a/app/clinic/dashboard/_components/dashboard-stats.tsx
+++ b/app/clinic/dashboard/_components/dashboard-stats.tsx
@@ -1,6 +1,7 @@
 import { AlertCircle, CheckCircle2, Clock, DollarSign, FileText, TrendingUp } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import { CLINIC_SHARE_PERCENT } from '@/lib/constants';
 import { formatCents } from '@/lib/utils/money';
 
 export interface Enrollment {
@@ -63,7 +64,9 @@ export function DashboardStats({ data }: { data: DashboardStatsData }) {
         </CardHeader>
         <CardContent>
           <div className="text-2xl font-bold">{formatCents(data.totalRevenueCents)}</div>
-          <p className="mt-1 text-xs text-muted-foreground">3% platform administration share</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {CLINIC_SHARE_PERCENT}% share on each payment (bill + fee)
+          </p>
         </CardContent>
       </Card>
 

--- a/app/clinic/dashboard/_components/payment-flow-info.tsx
+++ b/app/clinic/dashboard/_components/payment-flow-info.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { ChevronDown, ChevronUp, Info } from 'lucide-react';
+import { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { CLINIC_SHARE_PERCENT, DEPOSIT_RATE, FEE_PERCENT, NUM_INSTALLMENTS } from '@/lib/constants';
+
+const depositPercent = Math.round(DEPOSIT_RATE * 100);
+
+export function PaymentFlowInfo() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Card className="border-muted">
+      <CardHeader
+        className="cursor-pointer pb-3"
+        onClick={() => setOpen(!open)}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') setOpen(!open);
+        }}
+      >
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Info className="h-4 w-4 text-muted-foreground" />
+            <CardTitle className="text-sm font-medium">How FuzzyCat Payment Plans Work</CardTitle>
+          </div>
+          {open ? (
+            <ChevronUp className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+          )}
+        </div>
+      </CardHeader>
+      {open && (
+        <CardContent className="space-y-4 pt-0 text-sm text-muted-foreground">
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div>
+              <p className="font-medium text-foreground">Payment Structure</p>
+              <ul className="mt-1 space-y-1 text-xs">
+                <li>Pet owner pays {FEE_PERCENT}% platform fee on their bill</li>
+                <li>{depositPercent}% deposit collected up front via debit card</li>
+                <li>Remaining 75% split into {NUM_INSTALLMENTS} biweekly ACH payments</li>
+              </ul>
+            </div>
+            <div>
+              <p className="font-medium text-foreground">Your Revenue</p>
+              <ul className="mt-1 space-y-1 text-xs">
+                <li>You earn a {CLINIC_SHARE_PERCENT}% revenue share on each payment</li>
+                <li>Share is calculated on the full payment (bill + fee)</li>
+                <li>Payouts transfer to your connected Stripe account</li>
+              </ul>
+            </div>
+            <div>
+              <p className="font-medium text-foreground">Default Risk</p>
+              <ul className="mt-1 space-y-1 text-xs">
+                <li>FuzzyCat sends automated reminders for missed payments</li>
+                <li>3 failed retries mark a plan as defaulted</li>
+                <li>Clinics are responsible for collecting on defaulted plans</li>
+                <li>The {depositPercent}% deposit helps reduce your risk exposure</li>
+              </ul>
+            </div>
+          </div>
+        </CardContent>
+      )}
+    </Card>
+  );
+}

--- a/app/clinic/dashboard/_components/revenue-table.tsx
+++ b/app/clinic/dashboard/_components/revenue-table.tsx
@@ -11,6 +11,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { CLINIC_SHARE_PERCENT } from '@/lib/constants';
 import { useTRPC } from '@/lib/trpc/client';
 import { formatCents } from '@/lib/utils/money';
 
@@ -46,7 +47,8 @@ export function RevenueTable() {
       <CardHeader>
         <CardTitle>Monthly Revenue</CardTitle>
         <CardDescription>
-          Payout totals and your 3% platform administration share by month.
+          Payout totals and your {CLINIC_SHARE_PERCENT}% platform administration share by month. The
+          share is calculated on the full payment amount (bill + fee).
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -61,7 +63,7 @@ export function RevenueTable() {
                 <TableHead>Month</TableHead>
                 <TableHead className="text-right">Payouts</TableHead>
                 <TableHead className="text-right">Total Received</TableHead>
-                <TableHead className="text-right">3% Share</TableHead>
+                <TableHead className="text-right">{CLINIC_SHARE_PERCENT}% Share</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>

--- a/app/clinic/dashboard/page.tsx
+++ b/app/clinic/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { createServerHelpers } from '@/lib/trpc/server';
 import { DashboardContent } from './_components/dashboard-content';
 import { FoundingClinicBanner } from './_components/founding-clinic-banner';
 import { InitiateEnrollmentButton } from './_components/initiate-enrollment-button';
+import { PaymentFlowInfo } from './_components/payment-flow-info';
 import { RevenueTable } from './_components/revenue-table';
 
 export const metadata: Metadata = {
@@ -33,6 +34,10 @@ export default async function ClinicDashboardPage() {
 
         <div className="mt-4">
           <FoundingClinicBanner />
+        </div>
+
+        <div className="mt-4">
+          <PaymentFlowInfo />
         </div>
 
         <DashboardContent />

--- a/app/clinic/payouts/_components/payout-earnings.tsx
+++ b/app/clinic/payouts/_components/payout-earnings.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { CheckCircle2, Clock, DollarSign, TrendingUp } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import { CLINIC_SHARE_PERCENT } from '@/lib/constants';
 import { useTRPC } from '@/lib/trpc/client';
 import { formatCents } from '@/lib/utils/money';
 
@@ -42,15 +43,19 @@ export function PayoutEarnings() {
         </CardContent>
       </Card>
 
-      {/* 3% Revenue Share */}
+      {/* Clinic Revenue Share */}
       <Card className="border-primary/20 bg-primary/5">
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">3% Revenue Share</CardTitle>
+          <CardTitle className="text-sm font-medium">
+            {CLINIC_SHARE_PERCENT}% Revenue Share
+          </CardTitle>
           <TrendingUp className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
           <div className="text-2xl font-bold">{formatCents(earnings.totalClinicShareCents)}</div>
-          <p className="text-xs text-muted-foreground mt-1">Platform administration share</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Calculated on each payment amount (bill + fee)
+          </p>
         </CardContent>
       </Card>
 

--- a/app/clinic/payouts/_components/payout-explainer.tsx
+++ b/app/clinic/payouts/_components/payout-explainer.tsx
@@ -1,0 +1,43 @@
+import { Info } from 'lucide-react';
+import { CLINIC_SHARE_PERCENT, FEE_PERCENT, PLATFORM_RESERVE_RATE } from '@/lib/constants';
+
+const reservePercent = Math.round(PLATFORM_RESERVE_RATE * 100);
+
+export function PayoutExplainer() {
+  return (
+    <div className="rounded-lg border border-muted bg-muted/30 p-4">
+      <div className="flex items-start gap-3">
+        <Info className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+        <div className="space-y-2 text-sm text-muted-foreground">
+          <p className="font-medium text-foreground">How payouts are calculated</p>
+          <p>
+            When a pet owner makes a payment, FuzzyCat transfers funds to your clinic. Each payout
+            includes a <strong>{CLINIC_SHARE_PERCENT}% revenue share</strong> calculated on the
+            total payment amount (vet bill portion + the {FEE_PERCENT}% platform fee the owner
+            pays).
+          </p>
+          <div className="rounded-md border bg-background p-3 text-xs">
+            <p className="font-medium text-foreground">Example: $1,000 vet bill</p>
+            <ul className="mt-1 space-y-0.5">
+              <li>Owner pays: $1,000 + {FEE_PERCENT}% fee = $1,080 total</li>
+              <li>Each installment: $1,080 &divide; 7 payments &asymp; $154.29</li>
+              <li>
+                Your {CLINIC_SHARE_PERCENT}% share per payment: $154.29 &times;{' '}
+                {CLINIC_SHARE_PERCENT}% = $4.63
+              </li>
+              <li>
+                Payout per payment: bill portion &minus; {reservePercent}% reserve +{' '}
+                {CLINIC_SHARE_PERCENT}% share
+              </li>
+            </ul>
+          </div>
+          <p className="text-xs">
+            <strong>Total Received</strong> = all funds transferred to your account (bill + revenue
+            share). <strong>{CLINIC_SHARE_PERCENT}% Revenue Share</strong> = your platform
+            administration compensation, included in each payout.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/clinic/payouts/_components/payout-history.tsx
+++ b/app/clinic/payouts/_components/payout-history.tsx
@@ -15,6 +15,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { CLINIC_SHARE_PERCENT } from '@/lib/constants';
 import { useTRPC } from '@/lib/trpc/client';
 import { formatDate } from '@/lib/utils/date';
 import { formatCents } from '@/lib/utils/money';
@@ -68,7 +69,7 @@ export function PayoutHistory() {
                 <TableRow>
                   <TableHead>Date</TableHead>
                   <TableHead className="text-right">Amount</TableHead>
-                  <TableHead className="text-right">3% Share</TableHead>
+                  <TableHead className="text-right">{CLINIC_SHARE_PERCENT}% Share</TableHead>
                   <TableHead>Status</TableHead>
                   <TableHead>Transfer ID</TableHead>
                 </TableRow>

--- a/app/clinic/payouts/page.tsx
+++ b/app/clinic/payouts/page.tsx
@@ -2,6 +2,7 @@ import { HydrationBoundary } from '@tanstack/react-query';
 import type { Metadata } from 'next';
 import { createServerHelpers } from '@/lib/trpc/server';
 import { PayoutEarnings } from './_components/payout-earnings';
+import { PayoutExplainer } from './_components/payout-explainer';
 import { PayoutHistory } from './_components/payout-history';
 
 export const metadata: Metadata = {
@@ -27,6 +28,7 @@ export default async function ClinicPayoutsPage() {
         </div>
 
         <PayoutEarnings />
+        <PayoutExplainer />
         <PayoutHistory />
       </div>
     </HydrationBoundary>

--- a/e2e/tests/public/how-it-works-interaction.spec.ts
+++ b/e2e/tests/public/how-it-works-interaction.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { CLINIC_SHARE_PERCENT } from '@/lib/constants';
 
 test.describe('How It Works — Interactions', () => {
   test.beforeEach(async ({ page }) => {
@@ -20,9 +21,11 @@ test.describe('How It Works — Interactions', () => {
   });
 
   test('clinic benefits section shows key value props', async ({ page }) => {
-    // "Earn 3%" — uses first() because multiple elements may contain "3%"
-    await expect(page.getByText('3%', { exact: false }).first()).toBeVisible();
-    await expect(page.getByText('Earn 3% on every enrollment')).toBeVisible();
+    // Clinic share percentage — uses first() because multiple elements may contain it
+    await expect(
+      page.getByText(`${CLINIC_SHARE_PERCENT}%`, { exact: false }).first(),
+    ).toBeVisible();
+    await expect(page.getByText(`Earn ${CLINIC_SHARE_PERCENT}% on every enrollment`)).toBeVisible();
     await expect(page.getByText('Automated payment recovery')).toBeVisible();
     await expect(page.getByText('Fast payouts')).toBeVisible();
   });

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -13,6 +13,9 @@ export const DEPOSIT_RATE = 0.25;
 /** Revenue share paid to clinics per enrollment. */
 export const CLINIC_SHARE_RATE = 0.03;
 
+/** Clinic share as a whole-number percentage (e.g. 3). Derived from CLINIC_SHARE_RATE. */
+export const CLINIC_SHARE_PERCENT = Math.round(CLINIC_SHARE_RATE * 100);
+
 /** Fraction of each transaction allocated to the platform reserve. */
 export const PLATFORM_RESERVE_RATE = 0.01;
 

--- a/server/emails/clinic-welcome.tsx
+++ b/server/emails/clinic-welcome.tsx
@@ -1,4 +1,5 @@
 import { Button, Hr, Section, Text } from '@react-email/components';
+import { CLINIC_SHARE_PERCENT } from '@/lib/constants';
 import { EmailLayout } from '@/server/emails/components/layout';
 import {
   heading,
@@ -45,13 +46,15 @@ export function ClinicWelcome({
           2. Clients pay 25% upfront and the rest in 6 biweekly installments
         </Text>
         <Text style={tableRow}>3. Your clinic receives payments as each installment clears</Text>
-        <Text style={tableRow}>4. Earn a 3% revenue share on every enrollment</Text>
+        <Text style={tableRow}>
+          4. Earn a {CLINIC_SHARE_PERCENT}% revenue share on every enrollment
+        </Text>
       </Section>
 
       <Section style={infoBox}>
         <Text style={{ ...paragraph, color: '#1e40af', margin: '0' }}>
-          Your clinic earns 3% on every FuzzyCat enrollment. This is paid as platform administration
-          compensation alongside each payment transfer.
+          Your clinic earns {CLINIC_SHARE_PERCENT}% on every FuzzyCat enrollment. This is paid as
+          platform administration compensation alongside each payment transfer.
         </Text>
       </Section>
 

--- a/tests/fast/marketing/how-it-works.test.ts
+++ b/tests/fast/marketing/how-it-works.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { FEE_PERCENT } from '@/lib/constants';
+import { CLINIC_SHARE_PERCENT, FEE_PERCENT } from '@/lib/constants';
 import { fetchPage } from '../helpers/fetch';
 
 describe('How It Works /how-it-works', () => {
@@ -41,7 +41,7 @@ describe('How It Works /how-it-works', () => {
   test('clinic benefits (3 cards)', async () => {
     const { $ } = await fetchPage('/how-it-works');
     const text = $('body').text();
-    expect(text).toContain('Earn 3% on every enrollment');
+    expect(text).toContain(`Earn ${CLINIC_SHARE_PERCENT}% on every enrollment`);
     expect(text).toContain('Automated payment recovery');
     expect(text).toContain('Fast payouts');
   });

--- a/tests/fast/marketing/landing.test.ts
+++ b/tests/fast/marketing/landing.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { CLINIC_SHARE_PERCENT } from '@/lib/constants';
 import { fetchPage } from '../helpers/fetch';
 
 describe('Landing page /', () => {
@@ -36,12 +37,12 @@ describe('Landing page /', () => {
     expect(text).toContain('12-Week Plans');
   });
 
-  test('clinic section with 3% revenue share', async () => {
+  test(`clinic section with ${CLINIC_SHARE_PERCENT}% revenue share`, async () => {
     const { $ } = await fetchPage('/');
     const text = $('body').text();
     expect(text).toContain('For Veterinary Clinics');
     expect(text).toContain('Get paid to offer payment plans');
-    expect(text).toContain('Earn 3% on every plan');
+    expect(text).toContain(`Earn ${CLINIC_SHARE_PERCENT}% on every plan`);
     expect(text).toContain('Built-in default protection');
     expect(text).toContain('Zero setup cost');
     expect(text).toContain('Partner With FuzzyCat');


### PR DESCRIPTION
## Summary
- **#385 Payout clarity**: Added `CLINIC_SHARE_PERCENT` constant and replaced all hardcoded "3%" references across the codebase. Added a payout explainer component on the clinic payouts page showing exactly how the revenue share is calculated (on total payment amount including fee). Updated revenue table description and card labels to clarify calculation basis.
- **#386 Dashboard info**: Added a collapsible "How FuzzyCat Payment Plans Work" info panel to the clinic dashboard explaining payment structure, revenue share, and default risk responsibility.
- **#383 Mobile UX**: Replaced payment tables with stacked card layouts on mobile (below sm breakpoint) for recent payments, payment history, and installment schedule views. Tables remain on desktop.
- **Bonus**: Made clinic share percentage programmatic (`CLINIC_SHARE_PERCENT`) everywhere — email templates, signup pages, marketing pages, support FAQ, terms of service, and all test assertions.

Closes #383, closes #385, closes #386

## Test plan
- [ ] Verify clinic payouts page shows explainer with correct math example
- [ ] Verify clinic dashboard shows collapsible info panel
- [ ] Verify client payment views render stacked cards on mobile viewport
- [ ] Verify all "3%" text is derived from `CLINIC_SHARE_PERCENT` constant
- [ ] Run `bun run test` — 456 tests pass
- [ ] Run `bun run typecheck` — clean
- [ ] Run `bun run check` — clean (except next-env.d.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)