### PR TITLE
feat: consolidate clients with multiple plans in clinic list

### DIFF
--- a/app/clinic/clients/_components/client-list.tsx
+++ b/app/clinic/clients/_components/client-list.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { Eye, MoreHorizontal, Search } from 'lucide-react';
+import { AlertCircle, Eye, MoreHorizontal, Search } from 'lucide-react';
 import Link from 'next/link';
 import { useCallback, useRef, useState } from 'react';
 import { AvatarInitials } from '@/components/shared/avatar-initials';
 import { NumberedPagination } from '@/components/shared/numbered-pagination';
 import { StatusBadge } from '@/components/shared/status-badge';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -78,14 +79,14 @@ export function ClientList() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Client Plans</CardTitle>
+        <CardTitle>Clients</CardTitle>
 
         {/* Full-width search bar + filter */}
         <div className="flex flex-col gap-3 pt-2 sm:flex-row">
           <div className="relative flex-1">
             <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
             <Input
-              placeholder="Search by owner name or pet name..."
+              placeholder="Search by client name or pet name..."
               value={search}
               onChange={(e) => handleSearchChange(e.target.value)}
               className="pl-9"
@@ -122,6 +123,20 @@ export function ClientList() {
   );
 }
 
+interface ClientRow {
+  clientId: string;
+  ownerName: string | null;
+  ownerEmail: string | null;
+  planCount: number;
+  activePlanCount: number;
+  totalOutstandingCents: number;
+  totalPaidCents: number;
+  latestPlanId: string;
+  latestStatus: string;
+  nextPaymentAt: Date | null;
+  hasDefaulted: boolean;
+}
+
 function ClientListContent({
   isLoading,
   error,
@@ -137,16 +152,7 @@ function ClientListContent({
   error: unknown;
   data:
     | {
-        clients: {
-          planId: string;
-          ownerName: string | null;
-          ownerEmail: string | null;
-          petName: string | null;
-          planStatus: string;
-          totalBillCents: number;
-          totalPaidCents: number;
-          nextPaymentAt: Date | null;
-        }[];
+        clients: ClientRow[];
         pagination: { page: number; totalCount: number; totalPages: number };
       }
     | undefined;
@@ -181,17 +187,17 @@ function ClientListContent({
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>Pet Owner</TableHead>
-              <TableHead>Pet</TableHead>
+              <TableHead>Client</TableHead>
+              <TableHead>Plans</TableHead>
               <TableHead>Status</TableHead>
-              <TableHead className="text-right">Balance</TableHead>
+              <TableHead className="text-right">Total Outstanding</TableHead>
               <TableHead>Next Payment</TableHead>
               <TableHead />
             </TableRow>
           </TableHeader>
           <TableBody>
             {data.clients.map((client) => (
-              <TableRow key={client.planId}>
+              <TableRow key={client.clientId}>
                 <TableCell>
                   <div className="flex items-center gap-3">
                     <AvatarInitials name={client.ownerName ?? 'Unknown'} size="sm" />
@@ -201,12 +207,28 @@ function ClientListContent({
                     </div>
                   </div>
                 </TableCell>
-                <TableCell>{client.petName ?? '--'}</TableCell>
                 <TableCell>
-                  <StatusBadge status={client.planStatus} size="sm" />
+                  <div className="flex items-center gap-1.5">
+                    <Badge variant="outline" className="text-xs">
+                      {client.planCount} plan{client.planCount !== 1 ? 's' : ''}
+                    </Badge>
+                    {client.activePlanCount > 0 && (
+                      <Badge variant="default" className="text-xs">
+                        {client.activePlanCount} active
+                      </Badge>
+                    )}
+                  </div>
                 </TableCell>
-                <TableCell className="text-right">
-                  {formatCents(Math.max(0, client.totalBillCents - client.totalPaidCents))}
+                <TableCell>
+                  <div className="flex items-center gap-1.5">
+                    <StatusBadge status={client.latestStatus} size="sm" />
+                    {client.hasDefaulted && (
+                      <AlertCircle className="h-3.5 w-3.5 text-destructive" />
+                    )}
+                  </div>
+                </TableCell>
+                <TableCell className="text-right font-medium">
+                  {formatCents(client.totalOutstandingCents)}
                 </TableCell>
                 <TableCell className="text-muted-foreground">
                   {client.nextPaymentAt ? formatDate(client.nextPaymentAt) : '--'}
@@ -221,7 +243,7 @@ function ClientListContent({
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
                       <DropdownMenuItem asChild>
-                        <Link href={`/clinic/clients/${client.planId}`}>
+                        <Link href={`/clinic/clients/${client.latestPlanId}`}>
                           <Eye className="h-4 w-4" />
                           View Details
                         </Link>
@@ -238,7 +260,7 @@ function ClientListContent({
       {data.pagination.totalPages > 1 && (
         <div className="flex items-center justify-between pt-4">
           <p className="text-sm text-muted-foreground">
-            Showing {startItem} to {endItem} of {data.pagination.totalCount}
+            Showing {startItem} to {endItem} of {data.pagination.totalCount} clients
           </p>
           <NumberedPagination
             currentPage={page}

--- a/server/api/routes/clinic.ts
+++ b/server/api/routes/clinic.ts
@@ -87,17 +87,18 @@ const enrollmentTrendSchema = z.object({
 });
 
 const clientRowSchema = z.object({
-  planId: z.string().uuid(),
+  clientId: z.string().uuid(),
   ownerName: z.string().nullable(),
   ownerEmail: z.string().nullable(),
   ownerPhone: z.string().nullable(),
-  petName: z.string().nullable(),
-  totalBillCents: z.number().openapi({ example: 150000 }),
-  totalWithFeeCents: z.number().openapi({ example: 159000 }),
-  planStatus: z.string().openapi({ example: 'active' }),
-  nextPaymentAt: z.string().nullable().openapi({ example: '2026-02-01T00:00:00.000Z' }),
-  createdAt: z.string().nullable().openapi({ example: '2026-01-15T12:00:00.000Z' }),
+  planCount: z.number().openapi({ example: 2 }),
+  activePlanCount: z.number().openapi({ example: 1 }),
+  totalOutstandingCents: z.number().openapi({ example: 119250 }),
   totalPaidCents: z.number().openapi({ example: 39750 }),
+  latestPlanId: z.string().uuid(),
+  latestStatus: z.string().openapi({ example: 'active' }),
+  nextPaymentAt: z.string().nullable().openapi({ example: '2026-02-01T00:00:00.000Z' }),
+  hasDefaulted: z.boolean().openapi({ example: false }),
 });
 
 const clientsResponseSchema = z.object({
@@ -577,7 +578,6 @@ clinicRoutes.openapi(getClientsRoute, async (c) => {
     clients: result.clients.map((cl) => ({
       ...cl,
       nextPaymentAt: cl.nextPaymentAt?.toISOString() ?? null,
-      createdAt: cl.createdAt?.toISOString() ?? null,
     })),
   });
 });

--- a/server/routers/clinic.ts
+++ b/server/routers/clinic.ts
@@ -633,33 +633,35 @@ export const clinicRouter = router({
 
       const whereClause = and(...conditions);
 
+      // Group by client — one row per unique client across all their plans
       const [clientRows, countResult] = await Promise.all([
         ctx.db
           .select({
-            planId: plans.id,
+            clientId: clients.id,
             ownerName: clients.name,
             ownerEmail: clients.email,
             ownerPhone: clients.phone,
-            petName: clients.petName,
-            totalBillCents: plans.totalBillCents,
-            totalWithFeeCents: plans.totalWithFeeCents,
-            planStatus: plans.status,
-            nextPaymentAt: plans.nextPaymentAt,
-            createdAt: plans.createdAt,
+            planCount: sql<number>`count(distinct ${plans.id})`,
+            activePlanCount: sql<number>`count(distinct ${plans.id}) filter (where ${plans.status} in ('active', 'deposit_paid'))`,
+            totalOutstandingCents: sql<number>`coalesce(sum(${plans.totalWithFeeCents}), 0) - coalesce(sum(${payments.amountCents}) filter (where ${payments.status} = 'succeeded'), 0)`,
             totalPaidCents: sql<number>`coalesce(sum(${payments.amountCents}) filter (where ${payments.status} = 'succeeded'), 0)`,
+            latestPlanId: sql<string>`(array_agg(${plans.id} order by ${plans.createdAt} desc))[1]`,
+            latestStatus: sql<string>`(array_agg(${plans.status} order by ${plans.createdAt} desc))[1]`,
+            nextPaymentAt: sql<Date | null>`min(${plans.nextPaymentAt})`,
+            hasDefaulted: sql<boolean>`bool_or(${plans.status} = 'defaulted')`,
           })
           .from(plans)
-          .leftJoin(clients, eq(plans.clientId, clients.id))
+          .innerJoin(clients, eq(plans.clientId, clients.id))
           .leftJoin(payments, eq(plans.id, payments.planId))
           .where(whereClause)
-          .groupBy(plans.id, clients.id)
-          .orderBy(desc(plans.createdAt))
+          .groupBy(clients.id)
+          .orderBy(desc(sql`max(${plans.createdAt})`))
           .limit(input.pageSize)
           .offset(offset),
         ctx.db
-          .select({ total: sql<number>`count(*)` })
+          .select({ total: sql<number>`count(distinct ${clients.id})` })
           .from(plans)
-          .leftJoin(clients, eq(plans.clientId, clients.id))
+          .innerJoin(clients, eq(plans.clientId, clients.id))
           .where(whereClause),
       ]);
 
@@ -668,8 +670,18 @@ export const clinicRouter = router({
 
       return {
         clients: clientRows.map((row) => ({
-          ...row,
+          clientId: row.clientId as string,
+          ownerName: row.ownerName,
+          ownerEmail: row.ownerEmail,
+          ownerPhone: row.ownerPhone,
+          planCount: Number(row.planCount),
+          activePlanCount: Number(row.activePlanCount),
+          totalOutstandingCents: Math.max(0, Number(row.totalOutstandingCents)),
           totalPaidCents: Number(row.totalPaidCents),
+          latestPlanId: row.latestPlanId,
+          latestStatus: row.latestStatus,
+          nextPaymentAt: row.nextPaymentAt,
+          hasDefaulted: row.hasDefaulted ?? false,
         })),
         pagination: {
           page: input.page,

--- a/server/services/clinic-queries.ts
+++ b/server/services/clinic-queries.ts
@@ -211,33 +211,35 @@ export async function getClients(
 
   const whereClause = and(...conditions);
 
+  // Group by client — aggregate all plans per unique client into one row
   const [clientRows, countResult] = await Promise.all([
     db
       .select({
-        planId: plans.id,
+        clientId: clients.id,
         ownerName: clients.name,
         ownerEmail: clients.email,
         ownerPhone: clients.phone,
-        petName: clients.petName,
-        totalBillCents: plans.totalBillCents,
-        totalWithFeeCents: plans.totalWithFeeCents,
-        planStatus: plans.status,
-        nextPaymentAt: plans.nextPaymentAt,
-        createdAt: plans.createdAt,
+        planCount: sql<number>`count(distinct ${plans.id})`,
+        activePlanCount: sql<number>`count(distinct ${plans.id}) filter (where ${plans.status} in ('active', 'deposit_paid'))`,
+        totalOutstandingCents: sql<number>`coalesce(sum(${plans.totalWithFeeCents}), 0) - coalesce(sum(${payments.amountCents}) filter (where ${payments.status} = 'succeeded'), 0)`,
         totalPaidCents: sql<number>`coalesce(sum(${payments.amountCents}) filter (where ${payments.status} = 'succeeded'), 0)`,
+        latestPlanId: sql<string>`(array_agg(${plans.id} order by ${plans.createdAt} desc))[1]`,
+        latestStatus: sql<string>`(array_agg(${plans.status} order by ${plans.createdAt} desc))[1]`,
+        nextPaymentAt: sql<Date | null>`min(${plans.nextPaymentAt})`,
+        hasDefaulted: sql<boolean>`bool_or(${plans.status} = 'defaulted')`,
       })
       .from(plans)
-      .leftJoin(clients, eq(plans.clientId, clients.id))
+      .innerJoin(clients, eq(plans.clientId, clients.id))
       .leftJoin(payments, eq(plans.id, payments.planId))
       .where(whereClause)
-      .groupBy(plans.id, clients.id)
-      .orderBy(desc(plans.createdAt))
+      .groupBy(clients.id)
+      .orderBy(desc(sql`max(${plans.createdAt})`))
       .limit(pageSize)
       .offset(offset),
     db
-      .select({ total: sql<number>`count(*)` })
+      .select({ total: sql<number>`count(distinct ${clients.id})` })
       .from(plans)
-      .leftJoin(clients, eq(plans.clientId, clients.id))
+      .innerJoin(clients, eq(plans.clientId, clients.id))
       .where(whereClause),
   ]);
 
@@ -246,8 +248,18 @@ export async function getClients(
 
   return {
     clients: clientRows.map((row) => ({
-      ...row,
+      clientId: row.clientId as string,
+      ownerName: row.ownerName,
+      ownerEmail: row.ownerEmail,
+      ownerPhone: row.ownerPhone,
+      planCount: Number(row.planCount),
+      activePlanCount: Number(row.activePlanCount),
+      totalOutstandingCents: Math.max(0, Number(row.totalOutstandingCents)),
       totalPaidCents: Number(row.totalPaidCents),
+      latestPlanId: row.latestPlanId,
+      latestStatus: row.latestStatus,
+      nextPaymentAt: row.nextPaymentAt,
+      hasDefaulted: row.hasDefaulted ?? false,
     })),
     pagination: {
       page,

--- a/tests/isolated/api-clinic.test.ts
+++ b/tests/isolated/api-clinic.test.ts
@@ -271,7 +271,22 @@ describe('GET /clinic/clients', () => {
     const app = createApiApp();
     setupAuth(['clients:read']);
     mockGetClients.mockResolvedValue({
-      clients: [{ planId: PLAN_ID, ownerName: 'Jane' }],
+      clients: [
+        {
+          clientId: '22222222-2222-4222-a222-222222222222',
+          ownerName: 'Jane',
+          ownerEmail: 'jane@test.com',
+          ownerPhone: '555-1234',
+          planCount: 1,
+          activePlanCount: 1,
+          totalOutstandingCents: 72300,
+          totalPaidCents: 47700,
+          latestPlanId: PLAN_ID,
+          latestStatus: 'active',
+          nextPaymentAt: null,
+          hasDefaulted: false,
+        },
+      ],
       pagination: { page: 1, pageSize: 20, totalCount: 1, totalPages: 1 },
     });
 

--- a/tests/isolated/clinic-router.test.ts
+++ b/tests/isolated/clinic-router.test.ts
@@ -280,15 +280,20 @@ describe('clinic.getClients', () => {
   });
   afterEach(resetDbMocks);
 
-  it('returns paginated client list', async () => {
+  it('returns paginated client list grouped by client', async () => {
     const clientRow = {
-      planId: PLAN_ID,
+      clientId: '22222222-2222-4222-a222-222222222222',
       ownerName: 'Jane Doe',
       ownerEmail: 'jane@example.com',
-      petName: 'Whiskers',
-      totalBillCents: 120000,
-      planStatus: 'active',
+      ownerPhone: '555-1234',
+      planCount: '2',
+      activePlanCount: '1',
+      totalOutstandingCents: '72300',
       totalPaidCents: '47700',
+      latestPlanId: PLAN_ID,
+      latestStatus: 'active',
+      nextPaymentAt: null,
+      hasDefaulted: false,
     };
 
     createMockChain([
@@ -301,6 +306,7 @@ describe('clinic.getClients', () => {
     const result = await caller.getClients({ page: 1, pageSize: 20 });
     expect(result.clients).toHaveLength(1);
     expect(result.clients[0].ownerName).toBe('Jane Doe');
+    expect(result.clients[0].planCount).toBe(2);
     expect(result.pagination.totalCount).toBe(1);
   });
 


### PR DESCRIPTION
## Summary
- Client list now groups by client instead of by plan — each client appears once
- Shows aggregate metrics: plan count, active plan count, total outstanding balance, defaulted indicator
- Individual plan drill-down still works via existing client detail page
- Updated both tRPC router and REST API (Hono) with matching schema changes
- Updated isolated tests for both endpoints

Closes #384

## Test plan
- [ ] Verify clinic clients page shows one row per client (not per plan)
- [ ] Verify clients with multiple plans show correct aggregate balance
- [ ] Verify "View Details" still navigates to client detail with all plans
- [ ] Verify search and status filter still work
- [ ] Run `bun run test` — 456 tests pass
- [ ] Run isolated tests — 42 tests pass
- [ ] Run `bun run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)