### PR TITLE
feat: change platform fee from 9% to 6%

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # FuzzyCat
 
-Payment plan platform for veterinary clinics. Pet owners split vet bills into biweekly installments over 12 weeks (25% deposit + 6 installments). 9% platform fee to owner, 3% revenue share to clinic.
+Payment plan platform for veterinary clinics. Pet owners split vet bills into biweekly installments over 12 weeks (25% deposit + 6 installments). 6% platform fee to owner, 3% revenue share to clinic.
 
 **Not a lender.** No credit checks, no interest, no loan origination. FuzzyCat does **not** guarantee clinic payment — clinics are responsible for collecting from defaulting owners.
 
@@ -93,7 +93,7 @@ bunx drizzle-kit generate        # Generate SQL migrations
 
 ```
 ENROLLMENT:
-  1. Owner enters vet bill → system calculates 9% fee, 25% deposit, 6 installments
+  1. Owner enters vet bill → system calculates 6% fee, 25% deposit, 6 installments
   2. Owner connects debit card or bank account via Stripe
   3. Deposit charged immediately → plan becomes "active"
   4. Remaining 75% split into 6 biweekly ACH debits

--- a/app/__tests__/marketing-pages.test.tsx
+++ b/app/__tests__/marketing-pages.test.tsx
@@ -8,8 +8,8 @@ import {
 
 describe('Marketing page constants', () => {
   it('should use correct fee percentage', () => {
-    expect(PLATFORM_FEE_RATE).toBe(0.09);
-    expect(Math.round(PLATFORM_FEE_RATE * 100)).toBe(9);
+    expect(PLATFORM_FEE_RATE).toBe(0.06);
+    expect(Math.round(PLATFORM_FEE_RATE * 100)).toBe(6);
   });
 
   it('should use correct deposit percentage', () => {

--- a/docs/pci-dss-compliance.md
+++ b/docs/pci-dss-compliance.md
@@ -155,7 +155,7 @@ The platform stores only Stripe-issued tokenized references (`pm_*`, `pi_*`, `cu
 | Data retention policy | ✅ | 7 years payment records (IRS); 2 years account data |
 | Breach notification | ✅ | 72-hour notification standard in privacy policy |
 | No-lender disclaimer | ✅ | Explicit TILA/ECOA non-applicability statement |
-| Fee transparency | ✅ | 9% fee, 25% deposit, 6 installments clearly disclosed |
+| Fee transparency | ✅ | 6% fee, 25% deposit, 6 installments clearly disclosed |
 
 ---
 

--- a/e2e/tests/public/calculator-interaction.spec.ts
+++ b/e2e/tests/public/calculator-interaction.spec.ts
@@ -12,14 +12,14 @@ test.describe('Payment Calculator — Interactions', () => {
     await billInput.clear();
     await billInput.fill('1000');
 
-    // Platform fee: 9% of $1000 = $90
-    await expect(page.getByText(/\$90/).first()).toBeVisible({ timeout: 3000 });
+    // Platform fee: 6% of $1000 = $60
+    await expect(page.getByText(/\$60/).first()).toBeVisible({ timeout: 3000 });
 
-    // Total: $1090
-    await expect(page.getByText(/\$1,090|\$1090/).first()).toBeVisible({ timeout: 3000 });
+    // Total: $1060
+    await expect(page.getByText(/\$1,060|\$1060/).first()).toBeVisible({ timeout: 3000 });
 
-    // Deposit: 25% of $1090 = $272.50
-    await expect(page.getByText(/\$272\.50/).first()).toBeVisible({ timeout: 3000 });
+    // Deposit: 25% of $1060 = $265
+    await expect(page.getByText(/\$265/).first()).toBeVisible({ timeout: 3000 });
   });
 
   test('$500 minimum bill shows valid schedule', async ({ page }) => {
@@ -27,14 +27,14 @@ test.describe('Payment Calculator — Interactions', () => {
     await billInput.clear();
     await billInput.fill('500');
 
-    // Fee: 9% of $500 = $45
-    await expect(page.getByText(/\$45/).first()).toBeVisible({ timeout: 3000 });
+    // Fee: 6% of $500 = $30
+    await expect(page.getByText(/\$30/).first()).toBeVisible({ timeout: 3000 });
 
-    // Total: $545
-    await expect(page.getByText(/\$545/).first()).toBeVisible({ timeout: 3000 });
+    // Total: $530
+    await expect(page.getByText(/\$530/).first()).toBeVisible({ timeout: 3000 });
 
-    // Deposit: 25% of $545 = $136.25
-    await expect(page.getByText(/\$136\.25/).first()).toBeVisible({ timeout: 3000 });
+    // Deposit: 25% of $530 = $132.50
+    await expect(page.getByText(/\$132\.50/).first()).toBeVisible({ timeout: 3000 });
   });
 
   test('below minimum shows error or no schedule', async ({ page }) => {
@@ -66,11 +66,11 @@ test.describe('Payment Calculator — Interactions', () => {
     await billInput.clear();
     await billInput.fill('25000');
 
-    // Fee: 9% of $25,000 = $2,250
-    await expect(page.getByText(/\$2,250/).first()).toBeVisible({ timeout: 3000 });
+    // Fee: 6% of $25,000 = $1,500
+    await expect(page.getByText(/\$1,500/).first()).toBeVisible({ timeout: 3000 });
 
-    // Total: $27,250
-    await expect(page.getByText(/\$27,250/).first()).toBeVisible({ timeout: 3000 });
+    // Total: $26,500
+    await expect(page.getByText(/\$26,500/).first()).toBeVisible({ timeout: 3000 });
   });
 
   test('clear input resets display', async ({ page }) => {
@@ -79,7 +79,7 @@ test.describe('Payment Calculator — Interactions', () => {
     // First enter a value
     await billInput.clear();
     await billInput.fill('1000');
-    await expect(page.getByText(/\$1,090|\$1090/).first()).toBeVisible({ timeout: 3000 });
+    await expect(page.getByText(/\$1,060|\$1060/).first()).toBeVisible({ timeout: 3000 });
 
     // Clear the input
     await billInput.clear();

--- a/lib/__tests__/constants.test.ts
+++ b/lib/__tests__/constants.test.ts
@@ -9,8 +9,8 @@ import {
 } from '@/lib/constants';
 
 describe('business constants', () => {
-  it('platform fee rate is 9%', () => {
-    expect(PLATFORM_FEE_RATE).toBe(0.09);
+  it('platform fee rate is 6%', () => {
+    expect(PLATFORM_FEE_RATE).toBe(0.06);
   });
 
   it('deposit rate is 25%', () => {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,10 +1,10 @@
 // ── FuzzyCat business constants ──────────────────────────────────────
-// All rates are decimals (e.g., 0.09 = 9%). Monetary values in cents.
+// All rates are decimals (e.g., 0.06 = 6%). Monetary values in cents.
 
-/** Platform fee charged to pet owners (currently 9% of bill). */
-export const PLATFORM_FEE_RATE = 0.09;
+/** Platform fee charged to pet owners (currently 6% of bill). */
+export const PLATFORM_FEE_RATE = 0.06;
 
-/** Platform fee as a whole-number percentage (e.g. 9). Derived from PLATFORM_FEE_RATE. */
+/** Platform fee as a whole-number percentage (e.g. 6). Derived from PLATFORM_FEE_RATE. */
 export const FEE_PERCENT = Math.round(PLATFORM_FEE_RATE * 100);
 
 /** Upfront deposit as a fraction of total (bill + fee). */


### PR DESCRIPTION
## Summary
- Change `PLATFORM_FEE_RATE` from `0.09` to `0.06` in `lib/constants.ts`
- Update snapshot test assertions and E2E calculator expected values
- Update CLAUDE.md and compliance docs

## Test plan
- [x] `bun run test` — 456 tests pass
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)