### PR TITLE
feat: front-load platform fee and clinic share into deposit payout

### DIFF
--- a/authorization-matrix.test.ts
+++ b/authorization-matrix.test.ts
@@ -228,8 +228,10 @@ mock.module('@/server/services/collection', () => ({
   getRetrySuccessRate: mock(() => Promise.resolve({ rate: 0, total: 0, succeeded: 0 })),
 }));
 mock.module('@/server/services/payout', () => ({
-  calculatePayoutBreakdown: mock(),
-  calculateApplicationFee: mock(),
+  calculateDepositPayoutBreakdown: mock(),
+  calculateInstallmentPayoutBreakdown: mock(),
+  calculateDepositApplicationFee: mock(),
+  calculateInstallmentApplicationFee: mock(),
   getClinicPayoutHistory: mock(() => Promise.resolve([])),
   getClinicEarnings: mock(() =>
     Promise.resolve({ totalEarnings: 0, pendingPayouts: 0, completedPayouts: 0 }),

--- a/server/__tests__/payout.test.ts
+++ b/server/__tests__/payout.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
-import { CLINIC_SHARE_RATE, PLATFORM_FEE_RATE, PLATFORM_RESERVE_RATE } from '@/lib/constants';
+import {
+  CLINIC_SHARE_RATE,
+  DEPOSIT_RATE,
+  NUM_INSTALLMENTS,
+  PLATFORM_FEE_RATE,
+  PLATFORM_RESERVE_RATE,
+} from '@/lib/constants';
 import { percentOfCents } from '@/lib/utils/money';
 
 // ── Mocks ────────────────────────────────────────────────────────────
@@ -17,54 +23,109 @@ mock.module('@/server/db', () => ({
 }));
 
 const {
-  calculatePayoutBreakdown,
-  calculateApplicationFee,
+  calculateDepositPayoutBreakdown,
+  calculateInstallmentPayoutBreakdown,
+  calculateDepositApplicationFee,
+  calculateInstallmentApplicationFee,
   getClinicPayoutHistory,
   getClinicEarnings,
 } = await import('@/server/services/payout');
 
-// ── calculatePayoutBreakdown tests ───────────────────────────────────
+// ── Helpers ──────────────────────────────────────────────────────────
 
-describe('calculatePayoutBreakdown', () => {
-  it('correctly splits a $1,200 bill installment payment', () => {
-    // A payment from a $1,200 bill with PLATFORM_FEE_RATE fee.
-    const paymentAmountCents = 15_900;
-    const breakdown = calculatePayoutBreakdown(paymentAmountCents);
+/** Generate plan values for a given bill amount in cents. */
+function planValues(billCents: number) {
+  const feeCents = Math.round(billCents * PLATFORM_FEE_RATE);
+  const totalWithFeeCents = billCents + feeCents;
+  const depositCents = Math.round(totalWithFeeCents * DEPOSIT_RATE);
+  const remainingCents = totalWithFeeCents - depositCents;
+  const installmentCents = Math.round(remainingCents / NUM_INSTALLMENTS);
+  return { billCents, feeCents, totalWithFeeCents, depositCents, installmentCents };
+}
 
-    // Bill portion = 15900 / 1.06 = 15000 (rounded)
-    const expectedBillPortion = Math.round(paymentAmountCents / (1 + PLATFORM_FEE_RATE));
-    const expectedPlatformFee = paymentAmountCents - expectedBillPortion;
-    const expectedRiskPool = percentOfCents(expectedBillPortion, PLATFORM_RESERVE_RATE);
-    const expectedClinicShare = percentOfCents(paymentAmountCents, CLINIC_SHARE_RATE);
-    const expectedTransfer = expectedBillPortion - expectedRiskPool + expectedClinicShare;
+// ── calculateDepositPayoutBreakdown tests ───────────────────────────
 
-    expect(breakdown.paymentAmountCents).toBe(paymentAmountCents);
-    expect(breakdown.platformFeeCents).toBe(expectedPlatformFee);
-    expect(breakdown.riskPoolCents).toBe(expectedRiskPool);
-    expect(breakdown.clinicShareCents).toBe(expectedClinicShare);
-    expect(breakdown.transferAmountCents).toBe(expectedTransfer);
+describe('calculateDepositPayoutBreakdown', () => {
+  it('extracts entire platform fee and pays entire clinic share on deposit ($1,000 bill)', () => {
+    const plan = planValues(100_000); // $1,000
+    const breakdown = calculateDepositPayoutBreakdown(
+      plan.depositCents,
+      plan.feeCents,
+      plan.totalWithFeeCents,
+    );
+
+    expect(breakdown.paymentAmountCents).toBe(plan.depositCents);
+    expect(breakdown.platformFeeCents).toBe(plan.feeCents); // entire 6%
+    expect(breakdown.clinicShareCents).toBe(
+      percentOfCents(plan.totalWithFeeCents, CLINIC_SHARE_RATE),
+    ); // entire 3%
   });
 
-  it('correctly handles a deposit payment of 31,800 cents', () => {
-    const paymentAmountCents = 31_800;
-    const breakdown = calculatePayoutBreakdown(paymentAmountCents);
+  it('risk pool is 1% of deposit bill portion', () => {
+    const plan = planValues(100_000);
+    const breakdown = calculateDepositPayoutBreakdown(
+      plan.depositCents,
+      plan.feeCents,
+      plan.totalWithFeeCents,
+    );
 
-    const expectedBillPortion = Math.round(paymentAmountCents / (1 + PLATFORM_FEE_RATE));
-    const expectedPlatformFee = paymentAmountCents - expectedBillPortion;
-    const expectedRiskPool = percentOfCents(expectedBillPortion, PLATFORM_RESERVE_RATE);
-    const expectedClinicShare = percentOfCents(paymentAmountCents, CLINIC_SHARE_RATE);
-    const expectedTransfer = expectedBillPortion - expectedRiskPool + expectedClinicShare;
-
-    expect(breakdown.platformFeeCents).toBe(expectedPlatformFee);
-    expect(breakdown.riskPoolCents).toBe(expectedRiskPool);
-    expect(breakdown.clinicShareCents).toBe(expectedClinicShare);
-    expect(breakdown.transferAmountCents).toBe(expectedTransfer);
+    const depositBillPortion = plan.depositCents - plan.feeCents;
+    expect(breakdown.riskPoolCents).toBe(percentOfCents(depositBillPortion, PLATFORM_RESERVE_RATE));
   });
 
-  it('uses integer cents throughout (no floating point)', () => {
-    // Use an amount that could produce fractional cents
-    const paymentAmountCents = 12_345;
-    const breakdown = calculatePayoutBreakdown(paymentAmountCents);
+  it('application fee = platformFee + riskPool - clinicShare', () => {
+    const plan = planValues(100_000);
+    const breakdown = calculateDepositPayoutBreakdown(
+      plan.depositCents,
+      plan.feeCents,
+      plan.totalWithFeeCents,
+    );
+
+    const applicationFee = plan.depositCents - breakdown.transferAmountCents;
+    expect(applicationFee).toBe(
+      breakdown.platformFeeCents + breakdown.riskPoolCents - breakdown.clinicShareCents,
+    );
+  });
+
+  it('transfer + applicationFee = deposit amount', () => {
+    const plan = planValues(100_000);
+    const breakdown = calculateDepositPayoutBreakdown(
+      plan.depositCents,
+      plan.feeCents,
+      plan.totalWithFeeCents,
+    );
+
+    const applicationFee = plan.depositCents - breakdown.transferAmountCents;
+    expect(breakdown.transferAmountCents + applicationFee).toBe(plan.depositCents);
+  });
+
+  it('application fee is always positive (minimum $500 bill)', () => {
+    const plan = planValues(50_000); // $500 minimum
+    const applicationFee = calculateDepositApplicationFee(
+      plan.depositCents,
+      plan.feeCents,
+      plan.totalWithFeeCents,
+    );
+    expect(applicationFee).toBeGreaterThan(0);
+  });
+
+  it('application fee is always positive (maximum $25,000 bill)', () => {
+    const plan = planValues(2_500_000);
+    const applicationFee = calculateDepositApplicationFee(
+      plan.depositCents,
+      plan.feeCents,
+      plan.totalWithFeeCents,
+    );
+    expect(applicationFee).toBeGreaterThan(0);
+  });
+
+  it('uses integer cents throughout', () => {
+    const plan = planValues(123_456); // odd amount to stress rounding
+    const breakdown = calculateDepositPayoutBreakdown(
+      plan.depositCents,
+      plan.feeCents,
+      plan.totalWithFeeCents,
+    );
 
     expect(Number.isInteger(breakdown.platformFeeCents)).toBe(true);
     expect(Number.isInteger(breakdown.riskPoolCents)).toBe(true);
@@ -72,97 +133,249 @@ describe('calculatePayoutBreakdown', () => {
     expect(Number.isInteger(breakdown.transferAmountCents)).toBe(true);
   });
 
-  it('ensures platform fee + bill portion = payment amount', () => {
-    const paymentAmountCents = 15_900;
-    const breakdown = calculatePayoutBreakdown(paymentAmountCents);
+  it('works with founding clinic custom share rate (5%)', () => {
+    const plan = planValues(100_000);
+    const foundingRate = 0.05;
+    const breakdown = calculateDepositPayoutBreakdown(
+      plan.depositCents,
+      plan.feeCents,
+      plan.totalWithFeeCents,
+      foundingRate,
+    );
 
-    const billPortion = Math.round(paymentAmountCents / (1 + PLATFORM_FEE_RATE));
-    expect(billPortion + breakdown.platformFeeCents).toBe(paymentAmountCents);
-  });
-
-  it('ensures clinic share is exactly 3% of payment amount', () => {
-    const paymentAmountCents = 15_900;
-    const breakdown = calculatePayoutBreakdown(paymentAmountCents);
-
-    expect(breakdown.clinicShareCents).toBe(percentOfCents(paymentAmountCents, CLINIC_SHARE_RATE));
-  });
-
-  it('ensures transfer amount includes clinic share bonus', () => {
-    const paymentAmountCents = 15_900;
-    const breakdown = calculatePayoutBreakdown(paymentAmountCents);
-
-    // Transfer = bill portion - risk pool + clinic share
-    const billPortion = Math.round(paymentAmountCents / (1 + PLATFORM_FEE_RATE));
-    const withoutBonus = billPortion - breakdown.riskPoolCents;
-    expect(breakdown.transferAmountCents).toBe(withoutBonus + breakdown.clinicShareCents);
+    expect(breakdown.clinicShareCents).toBe(percentOfCents(plan.totalWithFeeCents, foundingRate));
+    // Application fee should still be positive: 6% fee > 5% share for all bills
+    const applicationFee = plan.depositCents - breakdown.transferAmountCents;
+    expect(applicationFee).toBeGreaterThan(0);
   });
 
   it('throws for zero amount', () => {
-    expect(() => calculatePayoutBreakdown(0)).toThrow(RangeError);
+    expect(() => calculateDepositPayoutBreakdown(0, 6_000, 106_000)).toThrow(RangeError);
   });
 
   it('throws for negative amount', () => {
-    expect(() => calculatePayoutBreakdown(-100)).toThrow(RangeError);
+    expect(() => calculateDepositPayoutBreakdown(-100, 6_000, 106_000)).toThrow(RangeError);
   });
 
   it('throws for NaN', () => {
-    expect(() => calculatePayoutBreakdown(Number.NaN)).toThrow(RangeError);
+    expect(() => calculateDepositPayoutBreakdown(Number.NaN, 6_000, 106_000)).toThrow(RangeError);
   });
 
   it('throws for Infinity', () => {
-    expect(() => calculatePayoutBreakdown(Number.POSITIVE_INFINITY)).toThrow(RangeError);
-  });
-
-  it('handles minimum bill installment ($500 bill)', () => {
-    // $500 bill + PLATFORM_FEE_RATE fee
-    const paymentAmountCents = 6_625;
-    const breakdown = calculatePayoutBreakdown(paymentAmountCents);
-
-    expect(breakdown.paymentAmountCents).toBe(6_625);
-    expect(breakdown.transferAmountCents).toBeGreaterThan(0);
-    expect(breakdown.platformFeeCents).toBeGreaterThan(0);
-    expect(breakdown.riskPoolCents).toBeGreaterThan(0);
-    expect(breakdown.clinicShareCents).toBeGreaterThan(0);
-  });
-
-  it('handles large bill amounts ($10,000 bill)', () => {
-    // $10,000 + PLATFORM_FEE_RATE fee
-    const paymentAmountCents = 265_000;
-    const breakdown = calculatePayoutBreakdown(paymentAmountCents);
-
-    expect(breakdown.paymentAmountCents).toBe(265_000);
-    expect(breakdown.transferAmountCents).toBeGreaterThan(0);
-    // Platform fee should be roughly fee/(1+fee) of the payment
-    expect(breakdown.platformFeeCents).toBeGreaterThan(0);
+    expect(() => calculateDepositPayoutBreakdown(Number.POSITIVE_INFINITY, 6_000, 106_000)).toThrow(
+      RangeError,
+    );
   });
 });
 
-// ── calculateApplicationFee tests ────────────────────────────────────
+// ── calculateInstallmentPayoutBreakdown tests ───────────────────────
 
-describe('calculateApplicationFee', () => {
-  it('satisfies applicationFee + transferAmount = paymentAmount', () => {
-    const paymentAmountCents = 15_900;
-    const fee = calculateApplicationFee(paymentAmountCents);
-    const breakdown = calculatePayoutBreakdown(paymentAmountCents);
-    expect(fee + breakdown.transferAmountCents).toBe(paymentAmountCents);
+describe('calculateInstallmentPayoutBreakdown', () => {
+  it('has zero platform fee and zero clinic share', () => {
+    const plan = planValues(100_000);
+    const breakdown = calculateInstallmentPayoutBreakdown(plan.installmentCents);
+
+    expect(breakdown.platformFeeCents).toBe(0);
+    expect(breakdown.clinicShareCents).toBe(0);
+  });
+
+  it('risk pool is 1% of full installment amount', () => {
+    const plan = planValues(100_000);
+    const breakdown = calculateInstallmentPayoutBreakdown(plan.installmentCents);
+
+    expect(breakdown.riskPoolCents).toBe(
+      percentOfCents(plan.installmentCents, PLATFORM_RESERVE_RATE),
+    );
+  });
+
+  it('transfer = installment - riskPool', () => {
+    const plan = planValues(100_000);
+    const breakdown = calculateInstallmentPayoutBreakdown(plan.installmentCents);
+
+    expect(breakdown.transferAmountCents).toBe(plan.installmentCents - breakdown.riskPoolCents);
+  });
+
+  it('application fee equals risk pool', () => {
+    const plan = planValues(100_000);
+    const appFee = calculateInstallmentApplicationFee(plan.installmentCents);
+
+    expect(appFee).toBe(percentOfCents(plan.installmentCents, PLATFORM_RESERVE_RATE));
+  });
+
+  it('transfer + applicationFee = installment amount', () => {
+    const plan = planValues(100_000);
+    const breakdown = calculateInstallmentPayoutBreakdown(plan.installmentCents);
+    const appFee = plan.installmentCents - breakdown.transferAmountCents;
+
+    expect(breakdown.transferAmountCents + appFee).toBe(plan.installmentCents);
+  });
+
+  it('uses integer cents throughout', () => {
+    const breakdown = calculateInstallmentPayoutBreakdown(12_345);
+
+    expect(Number.isInteger(breakdown.platformFeeCents)).toBe(true);
+    expect(Number.isInteger(breakdown.riskPoolCents)).toBe(true);
+    expect(Number.isInteger(breakdown.clinicShareCents)).toBe(true);
+    expect(Number.isInteger(breakdown.transferAmountCents)).toBe(true);
+  });
+
+  it('handles minimum bill installment ($500 bill)', () => {
+    const plan = planValues(50_000);
+    const breakdown = calculateInstallmentPayoutBreakdown(plan.installmentCents);
+
+    expect(breakdown.paymentAmountCents).toBe(plan.installmentCents);
+    expect(breakdown.transferAmountCents).toBeGreaterThan(0);
+    expect(breakdown.riskPoolCents).toBeGreaterThan(0);
+  });
+
+  it('handles large bill amounts ($25,000 bill)', () => {
+    const plan = planValues(2_500_000);
+    const breakdown = calculateInstallmentPayoutBreakdown(plan.installmentCents);
+
+    expect(breakdown.paymentAmountCents).toBe(plan.installmentCents);
+    expect(breakdown.transferAmountCents).toBeGreaterThan(0);
+  });
+
+  it('throws for zero amount', () => {
+    expect(() => calculateInstallmentPayoutBreakdown(0)).toThrow(RangeError);
+  });
+
+  it('throws for negative amount', () => {
+    expect(() => calculateInstallmentPayoutBreakdown(-100)).toThrow(RangeError);
+  });
+
+  it('throws for NaN', () => {
+    expect(() => calculateInstallmentPayoutBreakdown(Number.NaN)).toThrow(RangeError);
+  });
+
+  it('throws for Infinity', () => {
+    expect(() => calculateInstallmentPayoutBreakdown(Number.POSITIVE_INFINITY)).toThrow(RangeError);
+  });
+});
+
+// ── calculateDepositApplicationFee tests ────────────────────────────
+
+describe('calculateDepositApplicationFee', () => {
+  it('satisfies applicationFee + transferAmount = depositAmount', () => {
+    const plan = planValues(100_000);
+    const fee = calculateDepositApplicationFee(
+      plan.depositCents,
+      plan.feeCents,
+      plan.totalWithFeeCents,
+    );
+    const breakdown = calculateDepositPayoutBreakdown(
+      plan.depositCents,
+      plan.feeCents,
+      plan.totalWithFeeCents,
+    );
+    expect(fee + breakdown.transferAmountCents).toBe(plan.depositCents);
   });
 
   it('returns integer cents', () => {
-    expect(Number.isInteger(calculateApplicationFee(12_345))).toBe(true);
-    expect(Number.isInteger(calculateApplicationFee(15_900))).toBe(true);
-    expect(Number.isInteger(calculateApplicationFee(265_000))).toBe(true);
+    const plans = [planValues(100_000), planValues(123_456), planValues(2_500_000)];
+    for (const plan of plans) {
+      const fee = calculateDepositApplicationFee(
+        plan.depositCents,
+        plan.feeCents,
+        plan.totalWithFeeCents,
+      );
+      expect(Number.isInteger(fee)).toBe(true);
+    }
+  });
+
+  it('is positive for all valid bill amounts', () => {
+    for (const billCents of [50_000, 100_000, 500_000, 2_500_000]) {
+      const plan = planValues(billCents);
+      const fee = calculateDepositApplicationFee(
+        plan.depositCents,
+        plan.feeCents,
+        plan.totalWithFeeCents,
+      );
+      expect(fee).toBeGreaterThan(0);
+    }
+  });
+
+  it('delegates validation to breakdown function', () => {
+    expect(() => calculateDepositApplicationFee(0, 6_000, 106_000)).toThrow(RangeError);
+    expect(() => calculateDepositApplicationFee(-100, 6_000, 106_000)).toThrow(RangeError);
+    expect(() => calculateDepositApplicationFee(Number.NaN, 6_000, 106_000)).toThrow(RangeError);
+  });
+});
+
+// ── calculateInstallmentApplicationFee tests ────────────────────────
+
+describe('calculateInstallmentApplicationFee', () => {
+  it('satisfies applicationFee + transferAmount = installmentAmount', () => {
+    const plan = planValues(100_000);
+    const fee = calculateInstallmentApplicationFee(plan.installmentCents);
+    const breakdown = calculateInstallmentPayoutBreakdown(plan.installmentCents);
+    expect(fee + breakdown.transferAmountCents).toBe(plan.installmentCents);
+  });
+
+  it('returns integer cents', () => {
+    expect(Number.isInteger(calculateInstallmentApplicationFee(12_345))).toBe(true);
+    expect(Number.isInteger(calculateInstallmentApplicationFee(15_900))).toBe(true);
+    expect(Number.isInteger(calculateInstallmentApplicationFee(265_000))).toBe(true);
   });
 
   it('is positive for all valid payment amounts', () => {
-    expect(calculateApplicationFee(6_625)).toBeGreaterThan(0);
-    expect(calculateApplicationFee(15_900)).toBeGreaterThan(0);
-    expect(calculateApplicationFee(265_000)).toBeGreaterThan(0);
+    expect(calculateInstallmentApplicationFee(6_625)).toBeGreaterThan(0);
+    expect(calculateInstallmentApplicationFee(15_900)).toBeGreaterThan(0);
+    expect(calculateInstallmentApplicationFee(265_000)).toBeGreaterThan(0);
   });
 
-  it('delegates validation to calculatePayoutBreakdown', () => {
-    expect(() => calculateApplicationFee(0)).toThrow(RangeError);
-    expect(() => calculateApplicationFee(-100)).toThrow(RangeError);
-    expect(() => calculateApplicationFee(Number.NaN)).toThrow(RangeError);
+  it('delegates validation to breakdown function', () => {
+    expect(() => calculateInstallmentApplicationFee(0)).toThrow(RangeError);
+    expect(() => calculateInstallmentApplicationFee(-100)).toThrow(RangeError);
+    expect(() => calculateInstallmentApplicationFee(Number.NaN)).toThrow(RangeError);
+  });
+});
+
+// ── Cross-cutting: deposit vs installment consistency ───────────────
+
+describe('front-loaded fee consistency', () => {
+  it('total transfers + total application fees = total owner payments ($1,000 bill)', () => {
+    const plan = planValues(100_000);
+
+    const depositBreakdown = calculateDepositPayoutBreakdown(
+      plan.depositCents,
+      plan.feeCents,
+      plan.totalWithFeeCents,
+    );
+    const installmentBreakdown = calculateInstallmentPayoutBreakdown(plan.installmentCents);
+
+    const totalTransfers =
+      depositBreakdown.transferAmountCents +
+      installmentBreakdown.transferAmountCents * NUM_INSTALLMENTS;
+    const totalAppFees =
+      plan.depositCents -
+      depositBreakdown.transferAmountCents +
+      (plan.installmentCents - installmentBreakdown.transferAmountCents) * NUM_INSTALLMENTS;
+    const totalOwnerPayments = plan.depositCents + plan.installmentCents * NUM_INSTALLMENTS;
+
+    expect(totalTransfers + totalAppFees).toBe(totalOwnerPayments);
+  });
+
+  it('installment payout has no fee or clinic share', () => {
+    const plan = planValues(100_000);
+    const breakdown = calculateInstallmentPayoutBreakdown(plan.installmentCents);
+
+    expect(breakdown.platformFeeCents).toBe(0);
+    expect(breakdown.clinicShareCents).toBe(0);
+  });
+
+  it('deposit payout contains entire plan fee and entire clinic share', () => {
+    const plan = planValues(100_000);
+    const breakdown = calculateDepositPayoutBreakdown(
+      plan.depositCents,
+      plan.feeCents,
+      plan.totalWithFeeCents,
+    );
+
+    expect(breakdown.platformFeeCents).toBe(plan.feeCents);
+    expect(breakdown.clinicShareCents).toBe(
+      percentOfCents(plan.totalWithFeeCents, CLINIC_SHARE_RATE),
+    );
   });
 });
 
@@ -183,19 +396,14 @@ describe('getClinicPayoutHistory', () => {
   ];
 
   beforeEach(() => {
-    // Use argument-based differentiation instead of brittle callCount.
-    // The data query calls .from().where().orderBy().limit().offset(),
-    // while the count query calls .from().where() and resolves directly.
     mockSelect.mockImplementation((fields: Record<string, unknown>) => {
       if ('total' in fields) {
-        // Count query: db.select({ total: count() })
         return {
           from: mock(() => ({
             where: mock(() => Promise.resolve([{ total: 1 }])),
           })),
         };
       }
-      // Data query: db.select({ id, planId, ... })
       return {
         from: mock(() => ({
           where: mock(() => ({
@@ -235,11 +443,8 @@ describe('getClinicPayoutHistory', () => {
 
 describe('getClinicEarnings', () => {
   beforeEach(() => {
-    // Use argument-based differentiation instead of brittle callCount.
-    // Each select call passes different field names, so we inspect the keys.
     mockSelect.mockImplementation((fields: Record<string, unknown>) => {
       if ('totalPayout' in fields) {
-        // Succeeded totals: db.select({ totalPayout, totalShare })
         return {
           from: mock(() => ({
             where: mock(() => Promise.resolve([{ totalPayout: '150000', totalShare: '4500' }])),
@@ -247,14 +452,12 @@ describe('getClinicEarnings', () => {
         };
       }
       if ('pendingPayout' in fields) {
-        // Pending totals: db.select({ pendingPayout })
         return {
           from: mock(() => ({
             where: mock(() => Promise.resolve([{ pendingPayout: '15900' }])),
           })),
         };
       }
-      // Completed count: db.select({ completedCount })
       return {
         from: mock(() => ({
           where: mock(() => Promise.resolve([{ completedCount: 10 }])),

--- a/server/__tests__/services/payment.test.ts
+++ b/server/__tests__/services/payment.test.ts
@@ -132,6 +132,8 @@ mock.module('@/server/db/schema', () => ({
     clientId: 'plans.client_id',
     clinicId: 'plans.clinic_id',
     depositCents: 'plans.deposit_cents',
+    feeCents: 'plans.fee_cents',
+    totalWithFeeCents: 'plans.total_with_fee_cents',
     totalBillCents: 'plans.total_bill_cents',
     remainingCents: 'plans.remaining_cents',
     status: 'plans.status',
@@ -288,6 +290,8 @@ describe('processDeposit', () => {
         clientId: 'owner-1',
         clinicId: 'clinic-1',
         depositCents: 26_500,
+        feeCents: 6_000,
+        totalWithFeeCents: 106_000,
         status: 'active',
       },
     ]);
@@ -309,6 +313,8 @@ describe('processDeposit', () => {
           clientId: 'owner-1',
           clinicId: 'clinic-1',
           depositCents: 26_500,
+          feeCents: 6_000,
+          totalWithFeeCents: 106_000,
           status: 'pending',
         },
       ])
@@ -331,6 +337,8 @@ describe('processDeposit', () => {
           clientId: 'owner-1',
           clinicId: 'clinic-1',
           depositCents: 26_500,
+          feeCents: 6_000,
+          totalWithFeeCents: 106_000,
           status: 'pending',
         },
       ])
@@ -356,6 +364,8 @@ describe('processDeposit', () => {
           clientId: 'owner-1',
           clinicId: 'clinic-1',
           depositCents: 26_500,
+          feeCents: 6_000,
+          totalWithFeeCents: 106_000,
           status: 'pending',
         },
       ])
@@ -389,6 +399,8 @@ describe('processDeposit', () => {
           clientId: 'owner-1',
           clinicId: 'clinic-1',
           depositCents: 26_500,
+          feeCents: 6_000,
+          totalWithFeeCents: 106_000,
           status: 'pending',
         },
       ])
@@ -716,6 +728,8 @@ describe('handlePaymentSuccess', () => {
           clinicId: 'clinic-1',
           status: 'active',
           totalBillCents: 120_000,
+          feeCents: 7_200,
+          totalWithFeeCents: 127_200,
           stripeCustomerId: 'cus_owner_1',
         },
       ])
@@ -782,6 +796,8 @@ describe('handlePaymentSuccess', () => {
           clinicId: 'clinic-1',
           status: 'active',
           totalBillCents: 120_000,
+          feeCents: 7_200,
+          totalWithFeeCents: 127_200,
           stripeCustomerId: 'cus_owner_1',
         },
       ])
@@ -901,6 +917,8 @@ describe('handlePaymentSuccess — deposit plan activation', () => {
           clinicId: 'clinic-1',
           status: 'pending',
           totalBillCents: 106_000,
+          feeCents: 6_000,
+          totalWithFeeCents: 106_000,
           stripeCustomerId: 'cus_owner_1',
         },
       ])
@@ -945,6 +963,8 @@ describe('handlePaymentSuccess — deposit plan activation', () => {
           clinicId: 'clinic-1',
           status: 'active',
           totalBillCents: 106_000,
+          feeCents: 6_000,
+          totalWithFeeCents: 106_000,
           stripeCustomerId: 'cus_owner_1',
         },
       ])
@@ -988,6 +1008,8 @@ describe('handlePaymentSuccess — installment plan completion', () => {
           clinicId: 'clinic-1',
           status: 'active',
           totalBillCents: 106_000,
+          feeCents: 6_000,
+          totalWithFeeCents: 106_000,
           stripeCustomerId: 'cus_owner_1',
         },
       ])
@@ -1033,6 +1055,8 @@ describe('handlePaymentSuccess — installment plan completion', () => {
           clinicId: 'clinic-1',
           status: 'active',
           totalBillCents: 106_000,
+          feeCents: 6_000,
+          totalWithFeeCents: 106_000,
           stripeCustomerId: 'cus_owner_1',
         },
       ])
@@ -1110,6 +1134,8 @@ describe('handlePaymentSuccess — payout idempotency', () => {
           clinicId: 'clinic-1',
           status: 'active',
           totalBillCents: 120_000,
+          feeCents: 7_200,
+          totalWithFeeCents: 127_200,
           stripeCustomerId: 'cus_owner_1',
         },
       ])
@@ -1156,6 +1182,8 @@ describe('handlePaymentSuccess — deposit card save', () => {
           clinicId: 'clinic-1',
           status: 'pending',
           totalBillCents: 106_000,
+          feeCents: 6_000,
+          totalWithFeeCents: 106_000,
           stripeCustomerId: 'cus_owner_1',
         },
       ])
@@ -1198,6 +1226,8 @@ describe('handlePaymentSuccess — deposit card save', () => {
           clinicId: 'clinic-1',
           status: 'pending',
           totalBillCents: 106_000,
+          feeCents: 6_000,
+          totalWithFeeCents: 106_000,
           stripeCustomerId: 'cus_owner_1',
         },
       ])
@@ -1229,6 +1259,8 @@ describe('handlePaymentSuccess — deposit card save', () => {
           clinicId: 'clinic-1',
           status: 'active',
           totalBillCents: 106_000,
+          feeCents: 6_000,
+          totalWithFeeCents: 106_000,
           stripeCustomerId: 'cus_owner_1',
         },
       ])
@@ -1267,6 +1299,8 @@ describe('handlePaymentSuccess — deposit card save', () => {
           clinicId: 'clinic-1',
           status: 'pending',
           totalBillCents: 106_000,
+          feeCents: 6_000,
+          totalWithFeeCents: 106_000,
           stripeCustomerId: 'cus_owner_1',
         },
       ])

--- a/server/services/payment.ts
+++ b/server/services/payment.ts
@@ -8,8 +8,10 @@ import { db } from '@/server/db';
 import { clients, clinics, payments, payouts, plans, riskPool } from '@/server/db/schema';
 import { logAuditEvent } from '@/server/services/audit';
 import {
-  calculateApplicationFee,
-  calculatePayoutBreakdown,
+  calculateDepositApplicationFee,
+  calculateDepositPayoutBreakdown,
+  calculateInstallmentApplicationFee,
+  calculateInstallmentPayoutBreakdown,
   getEffectiveShareRate,
 } from '@/server/services/payout';
 import { createInstallmentPaymentIntent } from '@/server/services/stripe/ach';
@@ -40,6 +42,8 @@ export async function processDeposit(params: {
       clientId: plans.clientId,
       clinicId: plans.clinicId,
       depositCents: plans.depositCents,
+      feeCents: plans.feeCents,
+      totalWithFeeCents: plans.totalWithFeeCents,
       status: plans.status,
     })
     .from(plans)
@@ -133,7 +137,12 @@ export async function processDeposit(params: {
     successUrl: params.successUrl,
     cancelUrl: params.cancelUrl,
     clinicStripeAccountId: clinic.stripeAccountId,
-    applicationFeeCents: calculateApplicationFee(plan.depositCents, clinicShareRate),
+    applicationFeeCents: calculateDepositApplicationFee(
+      plan.depositCents,
+      plan.feeCents,
+      plan.totalWithFeeCents,
+      clinicShareRate,
+    ),
   });
 }
 
@@ -267,13 +276,10 @@ export async function processInstallment(params: {
     throw new Error(`Plan for payment ${params.paymentId} has no clinic`);
   }
 
-  // Fetch the clinic's Stripe Connect account and revenue share info
+  // Fetch the clinic's Stripe Connect account
   const [clinic] = await db
     .select({
       stripeAccountId: clinics.stripeAccountId,
-      revenueShareBps: clinics.revenueShareBps,
-      foundingClinic: clinics.foundingClinic,
-      foundingExpiresAt: clinics.foundingExpiresAt,
     })
     .from(clinics)
     .where(eq(clinics.id, plan.clinicId))
@@ -323,8 +329,7 @@ export async function processInstallment(params: {
     }
   }
 
-  const clinicShareRate = getEffectiveShareRate(clinic);
-
+  // Installment application fee is just the risk pool (1%) — no platform fee or clinic share
   return createInstallmentPaymentIntent({
     paymentId: params.paymentId,
     planId: payment.planId,
@@ -333,7 +338,7 @@ export async function processInstallment(params: {
     paymentMethodId: resolved.paymentMethodId,
     paymentMethodType: resolved.paymentMethodType,
     clinicStripeAccountId: clinic.stripeAccountId,
-    applicationFeeCents: calculateApplicationFee(payment.amountCents, clinicShareRate),
+    applicationFeeCents: calculateInstallmentApplicationFee(payment.amountCents),
   });
 }
 
@@ -461,7 +466,12 @@ async function recordDestinationPayout(
     clinicId: string;
     planId: string;
     paymentId: string;
+    paymentType: 'deposit' | 'installment';
     amountCents: number;
+    /** Required for deposit payouts: the entire plan fee in cents. */
+    totalFeeCents?: number;
+    /** Required for deposit payouts: plan total including fee in cents. */
+    totalWithFeeCents?: number;
     clinicShareRate?: number;
   },
 ): Promise<void> {
@@ -480,7 +490,15 @@ async function recordDestinationPayout(
     return;
   }
 
-  const breakdown = calculatePayoutBreakdown(params.amountCents, params.clinicShareRate);
+  const breakdown =
+    params.paymentType === 'deposit'
+      ? calculateDepositPayoutBreakdown(
+          params.amountCents,
+          params.totalFeeCents ?? 0,
+          params.totalWithFeeCents ?? 0,
+          params.clinicShareRate,
+        )
+      : calculateInstallmentPayoutBreakdown(params.amountCents);
 
   // Record as succeeded — Stripe already transferred the funds via destination charge
   const [payoutRecord] = await tx
@@ -509,6 +527,64 @@ async function recordDestinationPayout(
     },
     tx,
   );
+}
+
+/**
+ * Handle payment-type-specific actions after a successful payment.
+ * Activates plan for deposits, completes plan for final installments,
+ * records risk pool contribution, and records the destination charge payout.
+ */
+async function handlePaymentTypeActions(
+  tx: DrizzleTx,
+  payment: { id: string; planId: string; amountCents: number; type: string },
+  planRow: {
+    clientId: string | null;
+    clinicId: string;
+    status: string;
+    feeCents: number | null;
+    totalWithFeeCents: number | null;
+    stripeCustomerId: string | null;
+    revenueShareBps: number | null;
+    foundingClinic: boolean | null;
+    foundingExpiresAt: Date | null;
+  },
+  stripePaymentMethodId?: string,
+): Promise<void> {
+  // Deposit payment: activate the plan and save card for future use
+  if (payment.type === 'deposit') {
+    await activatePlanForDeposit(tx, payment.planId, planRow.status);
+    await saveCardPaymentMethod(
+      tx,
+      planRow.clientId,
+      stripePaymentMethodId,
+      planRow.stripeCustomerId,
+    );
+  }
+
+  // Installment payment: check if all payments are now succeeded -> complete plan
+  if (payment.type === 'installment') {
+    await completePlanIfAllPaid(tx, payment.planId, planRow.status);
+  }
+
+  // Risk pool contribution: 1% of payment amount
+  await recordRiskPoolContribution(tx, payment.planId, payment.amountCents);
+
+  // Record the destination charge payout as succeeded (Stripe already split the funds)
+  const clinicShareRate = getEffectiveShareRate({
+    revenueShareBps: planRow.revenueShareBps ?? 300,
+    foundingClinic: planRow.foundingClinic ?? false,
+    foundingExpiresAt: planRow.foundingExpiresAt,
+  });
+  await recordDestinationPayout(tx, {
+    clinicId: planRow.clinicId,
+    planId: payment.planId,
+    paymentId: payment.id,
+    paymentType: payment.type as 'deposit' | 'installment',
+    amountCents: payment.amountCents,
+    totalFeeCents: planRow.feeCents ?? 0,
+    totalWithFeeCents: planRow.totalWithFeeCents ?? 0,
+    clinicShareRate,
+  });
 }
 
 /**
@@ -585,6 +661,8 @@ export async function handlePaymentSuccess(
         clinicId: plans.clinicId,
         status: plans.status,
         totalBillCents: plans.totalBillCents,
+        feeCents: plans.feeCents,
+        totalWithFeeCents: plans.totalWithFeeCents,
         stripeCustomerId: clients.stripeCustomerId,
         revenueShareBps: clinics.revenueShareBps,
         foundingClinic: clinics.foundingClinic,
@@ -598,38 +676,17 @@ export async function handlePaymentSuccess(
 
     if (!planRow?.clinicId) return;
 
-    // Deposit payment: activate the plan and save card for future use
-    if (payment.type === 'deposit') {
-      await activatePlanForDeposit(tx, payment.planId, planRow.status);
-      await saveCardPaymentMethod(
-        tx,
-        planRow.clientId,
-        stripePaymentMethodId,
-        planRow.stripeCustomerId,
-      );
-    }
-
-    // Installment payment: check if all payments are now succeeded -> complete plan
-    if (payment.type === 'installment') {
-      await completePlanIfAllPaid(tx, payment.planId, planRow.status);
-    }
-
-    // Risk pool contribution: 1% of payment amount
-    await recordRiskPoolContribution(tx, payment.planId, payment.amountCents);
-
-    // Record the destination charge payout as succeeded (Stripe already split the funds)
-    const clinicShareRate = getEffectiveShareRate({
-      revenueShareBps: planRow.revenueShareBps ?? 300,
-      foundingClinic: planRow.foundingClinic ?? false,
-      foundingExpiresAt: planRow.foundingExpiresAt,
-    });
-    await recordDestinationPayout(tx, {
-      clinicId: planRow.clinicId,
-      planId: payment.planId,
-      paymentId: payment.id,
-      amountCents: payment.amountCents,
-      clinicShareRate,
-    });
+    await handlePaymentTypeActions(
+      tx,
+      {
+        id: payment.id,
+        planId: payment.planId,
+        amountCents: payment.amountCents,
+        type: payment.type,
+      },
+      planRow as typeof planRow & { clinicId: string },
+      stripePaymentMethodId,
+    );
   });
 }
 

--- a/server/services/payout.ts
+++ b/server/services/payout.ts
@@ -2,7 +2,6 @@ import { and, desc, eq, sql, sum } from 'drizzle-orm';
 import {
   CLINIC_SHARE_RATE,
   DEFAULT_CLINIC_SHARE_BPS,
-  PLATFORM_FEE_RATE,
   PLATFORM_RESERVE_RATE,
 } from '@/lib/constants';
 import { percentOfCents } from '@/lib/utils/money';
@@ -46,61 +45,103 @@ export interface ClinicEarnings {
 // ── Payout calculation ───────────────────────────────────────────────
 
 /**
- * Calculate the payout breakdown for a given payment amount.
+ * Validate that a payment amount is a positive finite number.
+ */
+function assertValidAmount(amountCents: number, label: string): void {
+  if (amountCents <= 0 || !Number.isFinite(amountCents)) {
+    throw new RangeError(`${label}: invalid payment amount ${amountCents}`);
+  }
+}
+
+/**
+ * Calculate the payout breakdown for a DEPOSIT payment.
  *
- * The payment amount from the pet owner includes the PLATFORM_FEE_RATE platform fee.
- * From each payment, FuzzyCat retains:
- *   - Platform fee portion (proportional share of the PLATFORM_FEE_RATE fee)
- *   - Risk pool contribution (1% of the original bill portion)
- *
- * The clinic receives:
- *   - The original bill portion of the payment (minus risk pool)
- *   - Plus a 3% clinic share bonus (platform administration compensation)
+ * All platform fee extraction (entire 6%) and all clinic revenue share (entire 3%)
+ * happen on the deposit. This front-loads FuzzyCat's revenue and the clinic's share,
+ * reducing cash-flow risk from defaults on later installments.
  *
  * All arithmetic uses integer cents — no floating point.
  */
-export function calculatePayoutBreakdown(
-  paymentAmountCents: number,
+export function calculateDepositPayoutBreakdown(
+  depositAmountCents: number,
+  totalFeeCents: number,
+  totalWithFeeCents: number,
   clinicShareRate = CLINIC_SHARE_RATE,
 ): PayoutBreakdown {
-  if (paymentAmountCents <= 0 || !Number.isFinite(paymentAmountCents)) {
-    throw new RangeError(`calculatePayoutBreakdown: invalid payment amount ${paymentAmountCents}`);
-  }
+  assertValidAmount(depositAmountCents, 'calculateDepositPayoutBreakdown');
 
-  // The payment amount includes the platform fee. Reverse-calculate the original bill portion.
-  // paymentAmount = billPortion + feePortion
-  // paymentAmount = billPortion * (1 + PLATFORM_FEE_RATE)
-  // billPortion = paymentAmount / (1 + PLATFORM_FEE_RATE)
-  const billPortionCents = Math.round(paymentAmountCents / (1 + PLATFORM_FEE_RATE));
-  const platformFeeCents = paymentAmountCents - billPortionCents;
-  const riskPoolCents = percentOfCents(billPortionCents, PLATFORM_RESERVE_RATE);
-  const clinicShareCents = percentOfCents(paymentAmountCents, clinicShareRate);
-
-  // Transfer = bill portion - risk pool + clinic share
-  const transferAmountCents = billPortionCents - riskPoolCents + clinicShareCents;
+  // depositBillPortion = deposit minus the entire plan fee
+  // This is safe because deposit (25% of bill × 1.06 = 0.265 × bill) always exceeds
+  // the fee (6% of bill = 0.06 × bill) for all positive bills.
+  const depositBillPortion = depositAmountCents - totalFeeCents;
+  const riskPoolCents = percentOfCents(depositBillPortion, PLATFORM_RESERVE_RATE);
+  const totalClinicShareCents = percentOfCents(totalWithFeeCents, clinicShareRate);
+  const applicationFeeCents = totalFeeCents + riskPoolCents - totalClinicShareCents;
+  const transferAmountCents = depositAmountCents - applicationFeeCents;
 
   return {
-    paymentAmountCents,
-    platformFeeCents,
+    paymentAmountCents: depositAmountCents,
+    platformFeeCents: totalFeeCents,
     riskPoolCents,
-    clinicShareCents,
+    clinicShareCents: totalClinicShareCents,
     transferAmountCents,
   };
 }
 
 /**
- * Calculate the application_fee_amount for a Stripe destination charge.
+ * Calculate the payout breakdown for an INSTALLMENT payment.
+ *
+ * Installments have no platform fee and no clinic share — only the 1% risk pool
+ * is deducted. The full installment amount is treated as bill (no fee component).
+ *
+ * All arithmetic uses integer cents — no floating point.
+ */
+export function calculateInstallmentPayoutBreakdown(
+  installmentAmountCents: number,
+): PayoutBreakdown {
+  assertValidAmount(installmentAmountCents, 'calculateInstallmentPayoutBreakdown');
+
+  const riskPoolCents = percentOfCents(installmentAmountCents, PLATFORM_RESERVE_RATE);
+  const applicationFeeCents = riskPoolCents;
+  const transferAmountCents = installmentAmountCents - applicationFeeCents;
+
+  return {
+    paymentAmountCents: installmentAmountCents,
+    platformFeeCents: 0,
+    riskPoolCents,
+    clinicShareCents: 0,
+    transferAmountCents,
+  };
+}
+
+/**
+ * Calculate the application_fee_amount for a deposit Stripe destination charge.
  * This is the amount FuzzyCat retains when Stripe atomically splits the payment.
  *
- * applicationFee = paymentAmount - transferToClinic
- *                = platformFee + riskPool - clinicShare
+ * applicationFee = totalPlatformFee + riskPool - totalClinicShare
  */
-export function calculateApplicationFee(
-  paymentAmountCents: number,
+export function calculateDepositApplicationFee(
+  depositAmountCents: number,
+  totalFeeCents: number,
+  totalWithFeeCents: number,
   clinicShareRate = CLINIC_SHARE_RATE,
 ): number {
-  const breakdown = calculatePayoutBreakdown(paymentAmountCents, clinicShareRate);
-  return paymentAmountCents - breakdown.transferAmountCents;
+  const breakdown = calculateDepositPayoutBreakdown(
+    depositAmountCents,
+    totalFeeCents,
+    totalWithFeeCents,
+    clinicShareRate,
+  );
+  return depositAmountCents - breakdown.transferAmountCents;
+}
+
+/**
+ * Calculate the application_fee_amount for an installment Stripe destination charge.
+ * For installments, this is simply the risk pool (1% of the payment).
+ */
+export function calculateInstallmentApplicationFee(installmentAmountCents: number): number {
+  const breakdown = calculateInstallmentPayoutBreakdown(installmentAmountCents);
+  return installmentAmountCents - breakdown.transferAmountCents;
 }
 
 // ── Revenue share resolution ────────────────────────────────────────

--- a/tests/isolated/api-payouts.test.ts
+++ b/tests/isolated/api-payouts.test.ts
@@ -8,8 +8,10 @@ const mockGetClinicEarnings = mock();
 mock.module('@/server/services/payout', () => ({
   getClinicPayoutHistory: mockGetClinicPayoutHistory,
   getClinicEarnings: mockGetClinicEarnings,
-  calculatePayoutBreakdown: mock(),
-  calculateApplicationFee: mock(),
+  calculateDepositPayoutBreakdown: mock(),
+  calculateInstallmentPayoutBreakdown: mock(),
+  calculateDepositApplicationFee: mock(),
+  calculateInstallmentApplicationFee: mock(),
 }));
 
 const mockValidateApiKey = mock();

--- a/tests/isolated/api-permission-boundaries.test.ts
+++ b/tests/isolated/api-permission-boundaries.test.ts
@@ -36,8 +36,10 @@ mock.module('@/server/services/clinic-queries', () => ({
 mock.module('@/server/services/payout', () => ({
   getClinicPayoutHistory: mock(),
   getClinicEarnings: mock(),
-  calculatePayoutBreakdown: mock(),
-  calculateApplicationFee: mock(),
+  calculateDepositPayoutBreakdown: mock(),
+  calculateInstallmentPayoutBreakdown: mock(),
+  calculateDepositApplicationFee: mock(),
+  calculateInstallmentApplicationFee: mock(),
 }));
 
 mock.module('@/server/services/webhook', () => ({


### PR DESCRIPTION
## Summary

- Front-loads all platform fee extraction (6%) and all clinic revenue share (3%) into the deposit payment, instead of spreading them proportionally across all 7 payments
- Installment payouts now only deduct the 1% risk pool — no platform fee or clinic share
- Owner-facing payment amounts are completely unchanged; only the Stripe `application_fee_amount` and transfer amounts change on each charge
- Extracts `handlePaymentTypeActions()` helper from `handlePaymentSuccess()` to reduce cognitive complexity

## Key changes

| File | What changed |
|------|-------------|
| `server/services/payout.ts` | Replaced single `calculatePayoutBreakdown()` with `calculateDepositPayoutBreakdown()` and `calculateInstallmentPayoutBreakdown()` |
| `server/services/payment.ts` | `processDeposit` now passes full plan fee data for deposit application fee; `processInstallment` uses risk-pool-only fee; `recordDestinationPayout` branches by payment type |
| `server/__tests__/payout.test.ts` | Rewritten: tests for deposit breakdown, installment breakdown, cross-cutting consistency |
| `server/__tests__/services/payment.test.ts` | Updated mock data to include `feeCents`/`totalWithFeeCents` |
| 3 isolated test files | Updated payout module mocks to export new function names |

## Test plan

- [x] All 475 unit tests pass (`bun run test`)
- [x] Biome lint + format clean (`bun run check`)
- [x] TypeScript strict mode passes (`bun run typecheck`)
- [ ] CI passes
- [ ] Verify deposit application fee is positive for min ($500) and max ($25,000) bills
- [ ] Verify installment application fee equals 1% risk pool only

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)