### PR TITLE
feat: add inline disclaimers to clinic and owner-facing pages

### DIFF
--- a/app/(marketing)/enroll/[clinicId]/page.tsx
+++ b/app/(marketing)/enroll/[clinicId]/page.tsx
@@ -201,8 +201,12 @@ export default async function ClinicEnrollLandingPage({ params }: PageProps) {
               </Button>
             </Link>
           </div>
-          <p className="mt-6 text-xs text-muted-foreground">
-            FuzzyCat is a payment facilitation platform, not a lender. No credit check. No interest.
+          <p className="mx-auto mt-6 max-w-lg text-xs text-muted-foreground">
+            By enrolling, you authorize FuzzyCat to debit your account on the scheduled dates.
+            Overdraft fees or bank charges from failed debits are your responsibility.{' '}
+            <Link href="/terms" className="underline hover:text-foreground">
+              Terms of Service
+            </Link>
           </p>
         </div>
       </section>

--- a/app/(marketing)/how-it-works/page.tsx
+++ b/app/(marketing)/how-it-works/page.tsx
@@ -127,6 +127,14 @@ export default function HowItWorksPage() {
               </li>
             </ul>
           </div>
+
+          <p className="mt-6 text-xs text-muted-foreground">
+            By enrolling, you authorize FuzzyCat to debit your account on the scheduled dates.
+            Overdraft fees or bank charges from failed debits are your responsibility.{' '}
+            <Link href="/terms" className="underline hover:text-foreground">
+              Terms of Service
+            </Link>
+          </p>
         </div>
       </section>
 
@@ -256,6 +264,14 @@ export default function HowItWorksPage() {
                 <ArrowRight className="ml-1.5 h-4 w-4" />
               </Button>
             </Link>
+            <p className="mx-auto mt-4 max-w-lg text-xs text-muted-foreground">
+              FuzzyCat is a payment service, not a collection agency. If a client&apos;s payment
+              plan defaults after automated retries, the clinic is responsible for any remaining
+              balance.{' '}
+              <Link href="/terms" className="underline hover:text-foreground">
+                Terms of Service
+              </Link>
+            </p>
           </div>
         </div>
       </section>

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -205,6 +205,14 @@ export default function LandingPage() {
                       </Button>
                     </Link>
                   </div>
+                  <p className="mt-3 text-xs text-teal-200/80">
+                    FuzzyCat is a payment service, not a collection agency. If a client&apos;s
+                    payment plan defaults after automated retries, the clinic is responsible for any
+                    remaining balance.{' '}
+                    <Link href="/terms" className="underline hover:text-white">
+                      Terms of Service
+                    </Link>
+                  </p>
                 </div>
               </div>
             </div>
@@ -235,6 +243,13 @@ export default function LandingPage() {
               </Button>
             </Link>
           </div>
+          <p className="mx-auto mt-6 max-w-lg text-xs text-muted-foreground">
+            By enrolling, you authorize FuzzyCat to debit your account on the scheduled dates.
+            Overdraft fees or bank charges from failed debits are your responsibility.{' '}
+            <Link href="/terms" className="underline hover:text-foreground">
+              Terms of Service
+            </Link>
+          </p>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- Added brief, muted inline disclaimers near CTAs on marketing pages to surface key TOS protections
- **Clinic disclaimer** (landing page clinic CTA, how-it-works clinic section): FuzzyCat is a payment service, not a collection agency; clinics are responsible for defaulted balances
- **Owner disclaimer** (landing page client CTA, how-it-works client section, clinic enrollment page): ACH authorization notice and overdraft fee responsibility

## Changes
| File | Change |
|------|--------|
| `app/(marketing)/page.tsx` | Clinic disclaimer below "Partner With FuzzyCat" CTA; owner disclaimer below "Get Started" CTA |
| `app/(marketing)/how-it-works/page.tsx` | Owner disclaimer at end of "For Clients" section; clinic disclaimer below "Become a Partner Clinic" CTA |
| `app/(marketing)/enroll/[clinicId]/page.tsx` | Replaced generic "not a lender" text with specific owner disclaimer |

## Design
- `text-xs text-muted-foreground` styling (small, muted, non-alarming)
- Clinic section on dark bg uses `text-teal-200/80` for readability
- Each disclaimer links to `/terms` for full details
- No modals, banners, or checkboxes — just static inline text

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run check` passes (pre-existing unrelated error only)
- [x] `bun run test` passes (475/475)
- [ ] Visual review: disclaimers render correctly near CTAs on all three pages
- [ ] Links to `/terms` work correctly

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)