### PR TITLE
fix: soften user-facing payment status language

### DIFF
--- a/app/(marketing)/support/page.tsx
+++ b/app/(marketing)/support/page.tsx
@@ -86,14 +86,17 @@ export default function SupportPage() {
             </AccordionItem>
 
             <AccordionItem value="missed-payment">
-              <AccordionTrigger>What happens if a payment fails?</AccordionTrigger>
+              <AccordionTrigger>
+                What happens if a payment doesn&apos;t go through?
+              </AccordionTrigger>
               <AccordionContent>
                 <p>
-                  If a payment fails, we automatically retry up to 3 times, with retries aligned to
-                  common paydays (the next Friday, 1st, or 15th that is at least 2 days out). You
-                  will receive reminders via email at day 1, 7, and 14 after a missed payment. There
-                  are no late fees. If all 3 retries fail, the plan is marked as defaulted and the
-                  clinic is notified.
+                  If a payment doesn&apos;t go through, we&apos;ll automatically retry up to 3
+                  times, with retries aligned to common paydays (the next Friday, 1st, or 15th that
+                  is at least 2 days out). You&apos;ll receive friendly reminders via email at day
+                  1, 7, and 14. There are no late fees. If all 3 retries are unsuccessful, your plan
+                  will be paused and your clinic will be notified so you can work together on next
+                  steps.
                 </p>
               </AccordionContent>
             </AccordionItem>
@@ -229,14 +232,14 @@ export default function SupportPage() {
             </AccordionItem>
 
             <AccordionItem value="clinic-default">
-              <AccordionTrigger>What happens if a client defaults?</AccordionTrigger>
+              <AccordionTrigger>What happens if a client misses payments?</AccordionTrigger>
               <AccordionContent>
                 <p>
                   FuzzyCat uses an automated soft collection process with escalating reminders. If
-                  all payment retries fail, the plan is marked as defaulted and the clinic is
+                  all payment retries are unsuccessful, the plan is paused and the clinic is
                   notified with the owner&apos;s contact information for direct follow-up. FuzzyCat
                   does not guarantee payment &mdash; clinics retain responsibility for collecting
-                  from defaulting owners.
+                  outstanding balances.
                 </p>
               </AccordionContent>
             </AccordionItem>

--- a/app/client/settings/_components/active-plans-section.tsx
+++ b/app/client/settings/_components/active-plans-section.tsx
@@ -23,7 +23,7 @@ const STATUS_LABEL: Record<string, string> = {
   deposit_paid: 'Deposit Paid',
   completed: 'Completed',
   pending: 'Pending',
-  defaulted: 'Defaulted',
+  defaulted: 'Paused',
   cancelled: 'Cancelled',
 };
 

--- a/app/clinic/dashboard/_components/payment-flow-info.tsx
+++ b/app/clinic/dashboard/_components/payment-flow-info.tsx
@@ -53,11 +53,13 @@ export function PaymentFlowInfo() {
               </ul>
             </div>
             <div>
-              <p className="font-medium text-foreground">Default Risk</p>
+              <p className="font-medium text-foreground">Missed Payments</p>
               <ul className="mt-1 space-y-1 text-xs">
                 <li>FuzzyCat sends automated reminders for missed payments</li>
-                <li>3 failed retries mark a plan as defaulted</li>
-                <li>Clinics are responsible for collecting on defaulted plans</li>
+                <li>
+                  After 3 unsuccessful attempts, the plan is paused and the clinic is notified
+                </li>
+                <li>Clinics are responsible for collecting on paused plans</li>
                 <li>The {depositPercent}% deposit helps reduce your risk exposure</li>
               </ul>
             </div>


### PR DESCRIPTION
## Summary

- Changed client-facing "Defaulted" badge label to "Paused" in active plans section (keeps destructive variant)
- Rewrote the "missed payment" FAQ for clients: softer trigger text ("doesn't go through"), friendlier retry language, "paused" instead of "defaulted"
- Softened clinic FAQ: "What happens if a client misses payments?" replaces "defaults", "paused" replaces "defaulted"
- Updated payment flow info card: "Missed Payments" heading replaces "Default Risk", softer bullet language throughout

No changes to admin dashboards, database schema, email templates, API responses, or Terms of Service.

## Test plan

- [x] `bun run check:fix` passes
- [x] `bun run typecheck` passes
- [x] `bun run test` passes (475 tests, 0 failures)
- [ ] Visually verify client settings page shows "Paused" badge for defaulted plans
- [ ] Visually verify support page FAQ text updates
- [ ] Visually verify clinic dashboard payment flow info card

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)