### PR TITLE
feat: add clinic revenue calculator to how-it-works page

### DIFF
--- a/app/(marketing)/how-it-works/clinic-revenue-calculator.test.ts
+++ b/app/(marketing)/how-it-works/clinic-revenue-calculator.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'bun:test';
+import { CLINIC_SHARE_RATE } from '@/lib/constants';
+import { calculateClinicRevenue } from './clinic-revenue-calculator';
+
+describe('calculateClinicRevenue', () => {
+  test('calculates with default values', () => {
+    const result = calculateClinicRevenue(1200, 80, 20, 40);
+
+    // lostRevenue = $1,200 * 80 * 0.20 = $19,200 = 1_920_000 cents
+    expect(result.lostRevenueMonthlyCents).toBe(1_920_000);
+    expect(result.lostRevenueAnnualCents).toBe(1_920_000 * 12);
+
+    // recaptured = $19,200 * 0.40 = $7,680 = 768_000 cents
+    expect(result.recapturedMonthlyCents).toBe(768_000);
+    expect(result.recapturedAnnualCents).toBe(768_000 * 12);
+
+    // revenueShare = $7,680 * 0.03 = $230.40 = 23_040 cents
+    expect(result.revenueShareMonthlyCents).toBe(Math.round(768_000 * CLINIC_SHARE_RATE));
+    expect(result.revenueShareAnnualCents).toBe(result.revenueShareMonthlyCents * 12);
+
+    // bnplFee = $7,680 * 0.10 = $768 = 76_800 cents
+    expect(result.bnplFeeMonthlyCents).toBe(76_800);
+    expect(result.bnplFeeAnnualCents).toBe(76_800 * 12);
+  });
+
+  test('calculates with minimum slider values', () => {
+    const result = calculateClinicRevenue(500, 10, 5, 20);
+
+    // lostRevenue = $500 * 10 * 0.05 = $250 = 25_000 cents
+    expect(result.lostRevenueMonthlyCents).toBe(25_000);
+
+    // recaptured = $250 * 0.20 = $50 = 5_000 cents
+    expect(result.recapturedMonthlyCents).toBe(5_000);
+
+    // revenueShare = $50 * 0.03 = $1.50 = 150 cents
+    expect(result.revenueShareMonthlyCents).toBe(150);
+  });
+
+  test('calculates with maximum slider values', () => {
+    const result = calculateClinicRevenue(5000, 200, 40, 80);
+
+    // lostRevenue = $5,000 * 200 * 0.40 = $400,000 = 40_000_000 cents
+    expect(result.lostRevenueMonthlyCents).toBe(40_000_000);
+
+    // recaptured = $400,000 * 0.80 = $320,000 = 32_000_000 cents
+    expect(result.recapturedMonthlyCents).toBe(32_000_000);
+
+    // revenueShare = $320,000 * 0.03 = $9,600 = 960_000 cents
+    expect(result.revenueShareMonthlyCents).toBe(960_000);
+  });
+
+  test('annual values are 12x monthly', () => {
+    const result = calculateClinicRevenue(2000, 50, 15, 60);
+
+    expect(result.lostRevenueAnnualCents).toBe(result.lostRevenueMonthlyCents * 12);
+    expect(result.recapturedAnnualCents).toBe(result.recapturedMonthlyCents * 12);
+    expect(result.revenueShareAnnualCents).toBe(result.revenueShareMonthlyCents * 12);
+    expect(result.bnplFeeAnnualCents).toBe(result.bnplFeeMonthlyCents * 12);
+  });
+
+  test('all monetary values are integers (cents)', () => {
+    const result = calculateClinicRevenue(1337, 73, 17, 33);
+
+    expect(Number.isInteger(result.lostRevenueMonthlyCents)).toBe(true);
+    expect(Number.isInteger(result.recapturedMonthlyCents)).toBe(true);
+    expect(Number.isInteger(result.revenueShareMonthlyCents)).toBe(true);
+    expect(Number.isInteger(result.bnplFeeMonthlyCents)).toBe(true);
+    expect(Number.isInteger(result.lostRevenueAnnualCents)).toBe(true);
+    expect(Number.isInteger(result.recapturedAnnualCents)).toBe(true);
+    expect(Number.isInteger(result.revenueShareAnnualCents)).toBe(true);
+    expect(Number.isInteger(result.bnplFeeAnnualCents)).toBe(true);
+  });
+
+  test('zero decline rate means zero everything', () => {
+    // declineRate min is 5% in UI, but the function should handle edge cases
+    const result = calculateClinicRevenue(1200, 80, 0, 40);
+
+    expect(result.lostRevenueMonthlyCents).toBe(0);
+    expect(result.recapturedMonthlyCents).toBe(0);
+    expect(result.revenueShareMonthlyCents).toBe(0);
+    expect(result.bnplFeeMonthlyCents).toBe(0);
+  });
+
+  test('zero conversion rate means zero recaptured but nonzero lost', () => {
+    const result = calculateClinicRevenue(1200, 80, 20, 0);
+
+    expect(result.lostRevenueMonthlyCents).toBe(1_920_000);
+    expect(result.recapturedMonthlyCents).toBe(0);
+    expect(result.revenueShareMonthlyCents).toBe(0);
+    expect(result.bnplFeeMonthlyCents).toBe(0);
+  });
+});

--- a/app/(marketing)/how-it-works/clinic-revenue-calculator.tsx
+++ b/app/(marketing)/how-it-works/clinic-revenue-calculator.tsx
@@ -1,0 +1,250 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { CLINIC_SHARE_PERCENT, CLINIC_SHARE_RATE } from '@/lib/constants';
+import { formatCents, percentOfCents } from '@/lib/utils/money';
+
+const TYPICAL_BNPL_MERCHANT_FEE_RATE = 0.1;
+
+interface SliderConfig {
+  id: string;
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+  defaultValue: number;
+  format: (value: number) => string;
+}
+
+const sliders: SliderConfig[] = [
+  {
+    id: 'avgBill',
+    label: 'Average treatment cost',
+    min: 500,
+    max: 5000,
+    step: 50,
+    defaultValue: 1200,
+    format: (v) => `$${v.toLocaleString()}`,
+  },
+  {
+    id: 'patients',
+    label: 'Patients per month',
+    min: 10,
+    max: 200,
+    step: 5,
+    defaultValue: 80,
+    format: (v) => `${v}`,
+  },
+  {
+    id: 'declineRate',
+    label: '% who decline treatment due to cost',
+    min: 5,
+    max: 40,
+    step: 1,
+    defaultValue: 20,
+    format: (v) => `${v}%`,
+  },
+  {
+    id: 'conversionRate',
+    label: '% of decliners who would proceed with a payment plan',
+    min: 20,
+    max: 80,
+    step: 5,
+    defaultValue: 40,
+    format: (v) => `${v}%`,
+  },
+];
+
+/**
+ * Calculate clinic revenue estimates. All monetary values in integer cents.
+ */
+export function calculateClinicRevenue(
+  avgBillDollars: number,
+  patientsPerMonth: number,
+  declinePercent: number,
+  conversionPercent: number,
+) {
+  const avgBillCents = Math.round(avgBillDollars * 100);
+  const declineRate = declinePercent / 100;
+  const conversionRate = conversionPercent / 100;
+
+  const lostRevenueMonthlyCents = Math.round(avgBillCents * patientsPerMonth * declineRate);
+  const recapturedMonthlyCents = Math.round(lostRevenueMonthlyCents * conversionRate);
+  const revenueShareMonthlyCents = percentOfCents(recapturedMonthlyCents, CLINIC_SHARE_RATE);
+  const bnplFeeMonthlyCents = percentOfCents(
+    recapturedMonthlyCents,
+    TYPICAL_BNPL_MERCHANT_FEE_RATE,
+  );
+
+  return {
+    lostRevenueMonthlyCents,
+    lostRevenueAnnualCents: lostRevenueMonthlyCents * 12,
+    recapturedMonthlyCents,
+    recapturedAnnualCents: recapturedMonthlyCents * 12,
+    revenueShareMonthlyCents,
+    revenueShareAnnualCents: revenueShareMonthlyCents * 12,
+    bnplFeeMonthlyCents,
+    bnplFeeAnnualCents: bnplFeeMonthlyCents * 12,
+  };
+}
+
+export function ClinicRevenueCalculator() {
+  const [avgBill, setAvgBill] = useState(1200);
+  const [patients, setPatients] = useState(80);
+  const [declineRate, setDeclineRate] = useState(20);
+  const [conversionRate, setConversionRate] = useState(40);
+
+  const setters: Record<string, (v: number) => void> = {
+    avgBill: setAvgBill,
+    patients: setPatients,
+    declineRate: setDeclineRate,
+    conversionRate: setConversionRate,
+  };
+  const values: Record<string, number> = {
+    avgBill,
+    patients,
+    declineRate,
+    conversionRate,
+  };
+
+  const result = calculateClinicRevenue(avgBill, patients, declineRate, conversionRate);
+
+  // Calculate proportional bar widths (lost revenue is 100%)
+  const maxCents = result.lostRevenueMonthlyCents || 1;
+  const recapturedPercent = Math.round((result.recapturedMonthlyCents / maxCents) * 100);
+  const sharePercent = Math.max(1, Math.round((result.revenueShareMonthlyCents / maxCents) * 100));
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle className="text-xl">Estimate Your Revenue</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          See how much additional revenue your clinic could recapture by offering FuzzyCat payment
+          plans.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* Sliders */}
+        <div className="space-y-5">
+          {sliders.map((slider) => (
+            <div key={slider.id}>
+              <div className="mb-2 flex items-center justify-between">
+                <label htmlFor={slider.id} className="text-sm font-medium">
+                  {slider.label}
+                </label>
+                <span className="text-sm font-semibold tabular-nums">
+                  {slider.format(values[slider.id])}
+                </span>
+              </div>
+              <input
+                id={slider.id}
+                type="range"
+                min={slider.min}
+                max={slider.max}
+                step={slider.step}
+                value={values[slider.id]}
+                onChange={(e) => setters[slider.id](Number(e.target.value))}
+                className="w-full cursor-pointer accent-primary"
+              />
+              <div className="mt-0.5 flex justify-between text-xs text-muted-foreground">
+                <span>{slider.format(slider.min)}</span>
+                <span>{slider.format(slider.max)}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Visual Bars */}
+        <div className="space-y-4">
+          <h4 className="text-sm font-semibold">Monthly Impact</h4>
+
+          <BarRow
+            label="Revenue currently lost"
+            monthlyCents={result.lostRevenueMonthlyCents}
+            annualCents={result.lostRevenueAnnualCents}
+            widthPercent={100}
+            color="bg-red-400 dark:bg-red-500"
+          />
+          <BarRow
+            label="Revenue recaptured with FuzzyCat"
+            monthlyCents={result.recapturedMonthlyCents}
+            annualCents={result.recapturedAnnualCents}
+            widthPercent={recapturedPercent}
+            color="bg-teal-500 dark:bg-teal-400"
+          />
+          <BarRow
+            label={`${CLINIC_SHARE_PERCENT}% revenue share earned`}
+            monthlyCents={result.revenueShareMonthlyCents}
+            annualCents={result.revenueShareAnnualCents}
+            widthPercent={sharePercent}
+            color="bg-primary"
+          />
+        </div>
+
+        {/* BNPL Comparison */}
+        <div className="rounded-lg border border-teal-200 bg-teal-50 px-4 py-3 dark:border-teal-800 dark:bg-teal-950/50">
+          <p className="text-sm text-teal-800 dark:text-teal-300">
+            With most BNPL providers you would pay ~10% in merchant fees (
+            <strong>{formatCents(result.bnplFeeMonthlyCents)}/mo</strong>). With FuzzyCat you{' '}
+            <em>earn</em> {CLINIC_SHARE_PERCENT}% (
+            <strong>+{formatCents(result.revenueShareMonthlyCents)}/mo</strong>).
+          </p>
+        </div>
+
+        {/* Disclaimers */}
+        <div className="space-y-1.5 text-xs text-muted-foreground">
+          <p>
+            This calculator provides estimates based on your inputs. Results are not guaranteed.
+          </p>
+          <p>
+            Revenue share is earned on successfully collected payments only. FuzzyCat does not
+            guarantee client payments.
+          </p>
+          <p>
+            Actual results depend on client enrollment, payment completion, and your clinic&apos;s
+            patient mix.
+          </p>
+          <p>
+            <Link href="/terms" className="underline hover:text-foreground">
+              Terms of Service
+            </Link>
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function BarRow({
+  label,
+  monthlyCents,
+  annualCents,
+  widthPercent,
+  color,
+}: {
+  label: string;
+  monthlyCents: number;
+  annualCents: number;
+  widthPercent: number;
+  color: string;
+}) {
+  return (
+    <div>
+      <div className="mb-1 flex items-baseline justify-between gap-2">
+        <span className="text-sm text-muted-foreground">{label}</span>
+        <span className="whitespace-nowrap text-sm font-semibold tabular-nums">
+          {formatCents(monthlyCents)}{' '}
+          <span className="font-normal text-muted-foreground">({formatCents(annualCents)}/yr)</span>
+        </span>
+      </div>
+      <div className="h-3 w-full rounded-full bg-muted">
+        <div
+          className={`h-3 rounded-full transition-all duration-300 ${color}`}
+          style={{ width: `${widthPercent}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/(marketing)/how-it-works/page.tsx
+++ b/app/(marketing)/how-it-works/page.tsx
@@ -18,6 +18,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import { CLINIC_SHARE_PERCENT, DEPOSIT_RATE, FEE_PERCENT, NUM_INSTALLMENTS } from '@/lib/constants';
+import { ClinicRevenueCalculator } from './clinic-revenue-calculator';
 import { PaymentCalculator } from './payment-calculator';
 
 export const metadata: Metadata = {
@@ -255,6 +256,10 @@ export default function HowItWorksPage() {
                 </span>
               </li>
             </ol>
+          </div>
+
+          <div className="mx-auto mt-12 max-w-2xl">
+            <ClinicRevenueCalculator />
           </div>
 
           <div className="mt-8 text-center">


### PR DESCRIPTION
## Summary

- Add interactive "Estimate Your Revenue" calculator to the clinic section of the how-it-works page
- Four sliders let clinic owners estimate revenue lost to cost declines, revenue recaptured via FuzzyCat payment plans, and 3% revenue share earned
- Includes BNPL comparison line and required disclaimers

Closes #417

## Test plan

- [x] Unit tests for `calculateClinicRevenue` covering default, min, max values, edge cases, and integer-cents guarantee
- [x] `bun run check:fix` passes
- [x] `bun run typecheck` passes
- [x] `bun run test` passes (482 tests, 0 failures)
- [ ] Visual verification: sliders adjust values, bars update proportionally, formatting is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)