### PR TITLE
fix: simplify clinic revenue calculator to 2 inputs

### DIFF
--- a/app/(marketing)/how-it-works/clinic-revenue-calculator.test.ts
+++ b/app/(marketing)/how-it-works/clinic-revenue-calculator.test.ts
@@ -4,53 +4,53 @@ import { calculateClinicRevenue } from './clinic-revenue-calculator';
 
 describe('calculateClinicRevenue', () => {
   test('calculates with default values', () => {
-    const result = calculateClinicRevenue(1200, 80, 20, 40);
+    const result = calculateClinicRevenue(10, 1200);
 
-    // lostRevenue = $1,200 * 80 * 0.20 = $19,200 = 1_920_000 cents
-    expect(result.lostRevenueMonthlyCents).toBe(1_920_000);
-    expect(result.lostRevenueAnnualCents).toBe(1_920_000 * 12);
+    // lostRevenue = 10 * $1,200 = $12,000 = 1_200_000 cents
+    expect(result.lostRevenueMonthlyCents).toBe(1_200_000);
+    expect(result.lostRevenueAnnualCents).toBe(1_200_000 * 12);
 
-    // recaptured = $19,200 * 0.40 = $7,680 = 768_000 cents
-    expect(result.recapturedMonthlyCents).toBe(768_000);
-    expect(result.recapturedAnnualCents).toBe(768_000 * 12);
+    // recaptured = $12,000 * 0.40 = $4,800 = 480_000 cents
+    expect(result.recapturedMonthlyCents).toBe(480_000);
+    expect(result.recapturedAnnualCents).toBe(480_000 * 12);
 
-    // revenueShare = $7,680 * 0.03 = $230.40 = 23_040 cents
-    expect(result.revenueShareMonthlyCents).toBe(Math.round(768_000 * CLINIC_SHARE_RATE));
+    // revenueShare = $4,800 * 0.03 = $144 = 14_400 cents
+    expect(result.revenueShareMonthlyCents).toBe(Math.round(480_000 * CLINIC_SHARE_RATE));
     expect(result.revenueShareAnnualCents).toBe(result.revenueShareMonthlyCents * 12);
 
-    // bnplFee = $7,680 * 0.10 = $768 = 76_800 cents
-    expect(result.bnplFeeMonthlyCents).toBe(76_800);
-    expect(result.bnplFeeAnnualCents).toBe(76_800 * 12);
+    // bnplFee = $4,800 * 0.10 = $480 = 48_000 cents
+    expect(result.bnplFeeMonthlyCents).toBe(48_000);
+    expect(result.bnplFeeAnnualCents).toBe(48_000 * 12);
   });
 
   test('calculates with minimum slider values', () => {
-    const result = calculateClinicRevenue(500, 10, 5, 20);
+    const result = calculateClinicRevenue(1, 500);
 
-    // lostRevenue = $500 * 10 * 0.05 = $250 = 25_000 cents
-    expect(result.lostRevenueMonthlyCents).toBe(25_000);
+    // lostRevenue = 1 * $500 = $500 = 50_000 cents
+    expect(result.lostRevenueMonthlyCents).toBe(50_000);
 
-    // recaptured = $250 * 0.20 = $50 = 5_000 cents
-    expect(result.recapturedMonthlyCents).toBe(5_000);
+    // recaptured = $500 * 0.40 = $200 = 20_000 cents
+    expect(result.recapturedMonthlyCents).toBe(20_000);
 
-    // revenueShare = $50 * 0.03 = $1.50 = 150 cents
-    expect(result.revenueShareMonthlyCents).toBe(150);
+    // revenueShare = $200 * 0.03 = $6 = 600 cents
+    expect(result.revenueShareMonthlyCents).toBe(600);
   });
 
   test('calculates with maximum slider values', () => {
-    const result = calculateClinicRevenue(5000, 200, 40, 80);
+    const result = calculateClinicRevenue(50, 5000);
 
-    // lostRevenue = $5,000 * 200 * 0.40 = $400,000 = 40_000_000 cents
-    expect(result.lostRevenueMonthlyCents).toBe(40_000_000);
+    // lostRevenue = 50 * $5,000 = $250,000 = 25_000_000 cents
+    expect(result.lostRevenueMonthlyCents).toBe(25_000_000);
 
-    // recaptured = $400,000 * 0.80 = $320,000 = 32_000_000 cents
-    expect(result.recapturedMonthlyCents).toBe(32_000_000);
+    // recaptured = $250,000 * 0.40 = $100,000 = 10_000_000 cents
+    expect(result.recapturedMonthlyCents).toBe(10_000_000);
 
-    // revenueShare = $320,000 * 0.03 = $9,600 = 960_000 cents
-    expect(result.revenueShareMonthlyCents).toBe(960_000);
+    // revenueShare = $100,000 * 0.03 = $3,000 = 300_000 cents
+    expect(result.revenueShareMonthlyCents).toBe(300_000);
   });
 
   test('annual values are 12x monthly', () => {
-    const result = calculateClinicRevenue(2000, 50, 15, 60);
+    const result = calculateClinicRevenue(15, 2000);
 
     expect(result.lostRevenueAnnualCents).toBe(result.lostRevenueMonthlyCents * 12);
     expect(result.recapturedAnnualCents).toBe(result.recapturedMonthlyCents * 12);
@@ -59,7 +59,7 @@ describe('calculateClinicRevenue', () => {
   });
 
   test('all monetary values are integers (cents)', () => {
-    const result = calculateClinicRevenue(1337, 73, 17, 33);
+    const result = calculateClinicRevenue(13, 1337);
 
     expect(Number.isInteger(result.lostRevenueMonthlyCents)).toBe(true);
     expect(Number.isInteger(result.recapturedMonthlyCents)).toBe(true);
@@ -71,20 +71,10 @@ describe('calculateClinicRevenue', () => {
     expect(Number.isInteger(result.bnplFeeAnnualCents)).toBe(true);
   });
 
-  test('zero decline rate means zero everything', () => {
-    // declineRate min is 5% in UI, but the function should handle edge cases
-    const result = calculateClinicRevenue(1200, 80, 0, 40);
+  test('zero declined clients means zero everything', () => {
+    const result = calculateClinicRevenue(0, 1200);
 
     expect(result.lostRevenueMonthlyCents).toBe(0);
-    expect(result.recapturedMonthlyCents).toBe(0);
-    expect(result.revenueShareMonthlyCents).toBe(0);
-    expect(result.bnplFeeMonthlyCents).toBe(0);
-  });
-
-  test('zero conversion rate means zero recaptured but nonzero lost', () => {
-    const result = calculateClinicRevenue(1200, 80, 20, 0);
-
-    expect(result.lostRevenueMonthlyCents).toBe(1_920_000);
     expect(result.recapturedMonthlyCents).toBe(0);
     expect(result.revenueShareMonthlyCents).toBe(0);
     expect(result.bnplFeeMonthlyCents).toBe(0);

--- a/app/(marketing)/how-it-works/clinic-revenue-calculator.tsx
+++ b/app/(marketing)/how-it-works/clinic-revenue-calculator.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { CLINIC_SHARE_PERCENT, CLINIC_SHARE_RATE } from '@/lib/constants';
 import { formatCents, percentOfCents } from '@/lib/utils/money';
 
+const PAYMENT_PLAN_CONVERSION_RATE = 0.4;
 const TYPICAL_BNPL_MERCHANT_FEE_RATE = 0.1;
 
 interface SliderConfig {
@@ -20,6 +21,15 @@ interface SliderConfig {
 
 const sliders: SliderConfig[] = [
   {
+    id: 'declinedClients',
+    label: 'Clients who decline due to cost per month',
+    min: 1,
+    max: 50,
+    step: 1,
+    defaultValue: 10,
+    format: (v) => `${v}`,
+  },
+  {
     id: 'avgBill',
     label: 'Average treatment cost',
     min: 500,
@@ -28,50 +38,16 @@ const sliders: SliderConfig[] = [
     defaultValue: 1200,
     format: (v) => `$${v.toLocaleString()}`,
   },
-  {
-    id: 'patients',
-    label: 'Patients per month',
-    min: 10,
-    max: 200,
-    step: 5,
-    defaultValue: 80,
-    format: (v) => `${v}`,
-  },
-  {
-    id: 'declineRate',
-    label: '% who decline treatment due to cost',
-    min: 5,
-    max: 40,
-    step: 1,
-    defaultValue: 20,
-    format: (v) => `${v}%`,
-  },
-  {
-    id: 'conversionRate',
-    label: '% of decliners who would proceed with a payment plan',
-    min: 20,
-    max: 80,
-    step: 5,
-    defaultValue: 40,
-    format: (v) => `${v}%`,
-  },
 ];
 
 /**
  * Calculate clinic revenue estimates. All monetary values in integer cents.
  */
-export function calculateClinicRevenue(
-  avgBillDollars: number,
-  patientsPerMonth: number,
-  declinePercent: number,
-  conversionPercent: number,
-) {
+export function calculateClinicRevenue(declinedClientsPerMonth: number, avgBillDollars: number) {
   const avgBillCents = Math.round(avgBillDollars * 100);
-  const declineRate = declinePercent / 100;
-  const conversionRate = conversionPercent / 100;
 
-  const lostRevenueMonthlyCents = Math.round(avgBillCents * patientsPerMonth * declineRate);
-  const recapturedMonthlyCents = Math.round(lostRevenueMonthlyCents * conversionRate);
+  const lostRevenueMonthlyCents = Math.round(avgBillCents * declinedClientsPerMonth);
+  const recapturedMonthlyCents = Math.round(lostRevenueMonthlyCents * PAYMENT_PLAN_CONVERSION_RATE);
   const revenueShareMonthlyCents = percentOfCents(recapturedMonthlyCents, CLINIC_SHARE_RATE);
   const bnplFeeMonthlyCents = percentOfCents(
     recapturedMonthlyCents,
@@ -91,25 +67,19 @@ export function calculateClinicRevenue(
 }
 
 export function ClinicRevenueCalculator() {
+  const [declinedClients, setDeclinedClients] = useState(10);
   const [avgBill, setAvgBill] = useState(1200);
-  const [patients, setPatients] = useState(80);
-  const [declineRate, setDeclineRate] = useState(20);
-  const [conversionRate, setConversionRate] = useState(40);
 
   const setters: Record<string, (v: number) => void> = {
+    declinedClients: setDeclinedClients,
     avgBill: setAvgBill,
-    patients: setPatients,
-    declineRate: setDeclineRate,
-    conversionRate: setConversionRate,
   };
   const values: Record<string, number> = {
+    declinedClients,
     avgBill,
-    patients,
-    declineRate,
-    conversionRate,
   };
 
-  const result = calculateClinicRevenue(avgBill, patients, declineRate, conversionRate);
+  const result = calculateClinicRevenue(declinedClients, avgBill);
 
   // Calculate proportional bar widths (lost revenue is 100%)
   const maxCents = result.lostRevenueMonthlyCents || 1;
@@ -158,30 +128,36 @@ export function ClinicRevenueCalculator() {
 
         {/* Visual Bars */}
         <div className="space-y-4">
-          <h4 className="text-sm font-semibold">Monthly Impact</h4>
+          <h4 className="text-sm font-semibold">Your Estimated Impact</h4>
 
           <BarRow
-            label="Revenue currently lost"
+            label="Revenue you're losing"
             monthlyCents={result.lostRevenueMonthlyCents}
             annualCents={result.lostRevenueAnnualCents}
             widthPercent={100}
             color="bg-red-400 dark:bg-red-500"
           />
           <BarRow
-            label="Revenue recaptured with FuzzyCat"
+            label="Revenue you could recapture"
             monthlyCents={result.recapturedMonthlyCents}
             annualCents={result.recapturedAnnualCents}
             widthPercent={recapturedPercent}
             color="bg-teal-500 dark:bg-teal-400"
           />
           <BarRow
-            label={`${CLINIC_SHARE_PERCENT}% revenue share earned`}
+            label={`Your ${CLINIC_SHARE_PERCENT}% revenue share`}
             monthlyCents={result.revenueShareMonthlyCents}
             annualCents={result.revenueShareAnnualCents}
             widthPercent={sharePercent}
             color="bg-primary"
           />
         </div>
+
+        {/* Assumption note */}
+        <p className="text-xs text-muted-foreground italic">
+          Assumes about 4 in 10 clients who currently decline would proceed if offered a payment
+          plan.
+        </p>
 
         {/* BNPL Comparison */}
         <div className="rounded-lg border border-teal-200 bg-teal-50 px-4 py-3 dark:border-teal-800 dark:bg-teal-950/50">


### PR DESCRIPTION
## Summary
- Replace 4 sliders with 2 intuitive inputs: "clients who decline due to cost per month" (1-50, default 10) and "average treatment cost" ($500-$5,000, default $1,200)
- Hardcode 40% payment plan conversion rate as a stated assumption displayed below the output bars
- Simplify bar labels: "Revenue you're losing", "Revenue you could recapture", "Your 3% revenue share"
- Update section header to "Your Estimated Impact"
- Update unit tests for new 2-parameter `calculateClinicRevenue` function

## Test plan
- [x] All 481 unit tests pass (`bun run test`)
- [x] Biome lint/format passes (`bun run check:fix`)
- [x] TypeScript compiles (`bun run typecheck`)
- [ ] Visual verification of calculator on how-it-works page
- [ ] Verify slider ranges and default values render correctly
- [ ] Verify assumption text appears below bars

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)