### PR TITLE
chore: improve test coverage and codecov configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,14 +137,22 @@ jobs:
         run: bun test authorization-matrix.test.ts --coverage --coverage-reporter=lcov --coverage-dir=coverage-authz
       - name: Run isolated tests (one-per-process — mock.module leaks)
         run: |
+          mkdir -p coverage-isolated
+          i=0
           for f in tests/isolated/*.test.ts; do
             echo "=== Running $f ==="
-            TURNSTILE_SECRET_KEY='1x0000000000000000000000000000000AA' NEXT_PUBLIC_TURNSTILE_SITE_KEY='1x00000000000000000000AA' bun test "$f" || exit 1
+            TURNSTILE_SECRET_KEY='1x0000000000000000000000000000000AA' NEXT_PUBLIC_TURNSTILE_SITE_KEY='1x00000000000000000000AA' bun test "$f" --coverage --coverage-reporter=lcov --coverage-dir="coverage-isolated/run-$i" || exit 1
+            i=$((i + 1))
           done
+      - name: Merge isolated coverage reports
+        run: |
+          if ls coverage-isolated/*/lcov.info 1>/dev/null 2>&1; then
+            cat coverage-isolated/*/lcov.info > coverage-isolated/lcov.info
+          fi
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         if: hashFiles('coverage/lcov.info') != ''
         with:
-          files: coverage/lcov.info,coverage-proxy/lcov.info,coverage-authz/lcov.info
+          files: coverage/lcov.info,coverage-proxy/lcov.info,coverage-authz/lcov.info,coverage-isolated/lcov.info
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,8 +14,11 @@ comment:
 
 ignore:
   - "**/*.config.ts"
+  - "app/**/*.tsx"           # React components tested by fast tests + E2E, not unit tests
   - "components/ui/**"
   - "drizzle/migrations"
   - "e2e"
+  - "instrumentation*.ts"    # Sentry instrumentation
+  - "middleware.ts"           # Next.js middleware (tested by E2E)
   - "scripts"
   - "server/emails/**"

--- a/lib/utils/__tests__/date.test.ts
+++ b/lib/utils/__tests__/date.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'bun:test';
+
+import { addDays, addMonths, daysUntil, formatCountdown, formatDate } from '../date';
+
+// ── formatDate ──────────────────────────────────────────────────────
+
+describe('formatDate', () => {
+  it('formats a Date object', () => {
+    const date = new Date('2026-02-20T00:00:00Z');
+    expect(formatDate(date)).toBe('Feb 20, 2026');
+  });
+
+  it('formats an ISO string', () => {
+    expect(formatDate('2026-12-25T00:00:00Z')).toBe('Dec 25, 2026');
+  });
+
+  it('returns em-dash for null', () => {
+    expect(formatDate(null)).toBe('\u2014');
+  });
+
+  it('uses UTC timezone to avoid timezone issues', () => {
+    // A date near midnight UTC — should always format as the UTC date
+    const date = new Date('2026-01-01T23:59:59Z');
+    expect(formatDate(date)).toBe('Jan 1, 2026');
+  });
+});
+
+// ── daysUntil ───────────────────────────────────────────────────────
+
+describe('daysUntil', () => {
+  it('returns positive number for future dates', () => {
+    const future = new Date();
+    future.setUTCDate(future.getUTCDate() + 5);
+    expect(daysUntil(future)).toBe(5);
+  });
+
+  it('returns negative number for past dates', () => {
+    const past = new Date();
+    past.setUTCDate(past.getUTCDate() - 3);
+    expect(daysUntil(past)).toBe(-3);
+  });
+
+  it('returns 0 for today', () => {
+    expect(daysUntil(new Date())).toBe(0);
+  });
+
+  it('accepts ISO string input', () => {
+    const future = new Date();
+    future.setUTCDate(future.getUTCDate() + 10);
+    expect(daysUntil(future.toISOString())).toBe(10);
+  });
+});
+
+// ── formatCountdown ─────────────────────────────────────────────────
+
+describe('formatCountdown', () => {
+  it('returns "Overdue" for past dates', () => {
+    const past = new Date();
+    past.setUTCDate(past.getUTCDate() - 1);
+    expect(formatCountdown(past)).toBe('Overdue');
+  });
+
+  it('returns "Today" for today', () => {
+    expect(formatCountdown(new Date())).toBe('Today');
+  });
+
+  it('returns "Tomorrow" for tomorrow', () => {
+    const tomorrow = new Date();
+    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+    expect(formatCountdown(tomorrow)).toBe('Tomorrow');
+  });
+
+  it('returns "In N days" for dates further out', () => {
+    const future = new Date();
+    future.setUTCDate(future.getUTCDate() + 7);
+    expect(formatCountdown(future)).toBe('In 7 days');
+  });
+
+  it('accepts ISO string input', () => {
+    const future = new Date();
+    future.setUTCDate(future.getUTCDate() + 3);
+    expect(formatCountdown(future.toISOString())).toBe('In 3 days');
+  });
+});
+
+// ── addDays ─────────────────────────────────────────────────────────
+
+describe('addDays', () => {
+  it('adds positive days', () => {
+    const date = new Date('2026-01-15T00:00:00Z');
+    const result = addDays(date, 10);
+    expect(result.toISOString()).toStartWith('2026-01-25');
+  });
+
+  it('subtracts with negative days', () => {
+    const date = new Date('2026-01-15T00:00:00Z');
+    const result = addDays(date, -5);
+    expect(result.toISOString()).toStartWith('2026-01-10');
+  });
+
+  it('crosses month boundary', () => {
+    const date = new Date('2026-01-30T00:00:00Z');
+    const result = addDays(date, 5);
+    expect(result.toISOString()).toStartWith('2026-02-04');
+  });
+
+  it('does not mutate the original date', () => {
+    const date = new Date('2026-01-15T00:00:00Z');
+    const original = date.getTime();
+    addDays(date, 10);
+    expect(date.getTime()).toBe(original);
+  });
+});
+
+// ── addMonths ───────────────────────────────────────────────────────
+
+describe('addMonths', () => {
+  it('adds months to a normal date', () => {
+    const date = new Date('2026-01-15T00:00:00Z');
+    const result = addMonths(date, 2);
+    expect(result.toISOString()).toStartWith('2026-03-15');
+  });
+
+  it('clamps to last day of month when day overflows', () => {
+    // Jan 31 + 1 month → should clamp to Feb 28 (non-leap year)
+    const date = new Date('2026-01-31T00:00:00Z');
+    const result = addMonths(date, 1);
+    expect(result.getUTCMonth()).toBe(1); // February
+    expect(result.getUTCDate()).toBe(28);
+  });
+
+  it('handles leap year Feb 29 correctly', () => {
+    // Jan 31 + 1 month in a leap year (2028) → Feb 29
+    const date = new Date('2028-01-31T00:00:00Z');
+    const result = addMonths(date, 1);
+    expect(result.getUTCMonth()).toBe(1); // February
+    expect(result.getUTCDate()).toBe(29);
+  });
+
+  it('subtracts months with negative values', () => {
+    const date = new Date('2026-03-15T00:00:00Z');
+    const result = addMonths(date, -1);
+    expect(result.toISOString()).toStartWith('2026-02-15');
+  });
+
+  it('crosses year boundary', () => {
+    const date = new Date('2026-11-15T00:00:00Z');
+    const result = addMonths(date, 3);
+    expect(result.getUTCFullYear()).toBe(2027);
+    expect(result.getUTCMonth()).toBe(1); // February
+  });
+
+  it('does not mutate the original date', () => {
+    const date = new Date('2026-01-15T00:00:00Z');
+    const original = date.getTime();
+    addMonths(date, 3);
+    expect(date.getTime()).toBe(original);
+  });
+
+  it('clamps Mar 31 + 1 month to Apr 30', () => {
+    const date = new Date('2026-03-31T00:00:00Z');
+    const result = addMonths(date, 1);
+    expect(result.getUTCMonth()).toBe(3); // April
+    expect(result.getUTCDate()).toBe(30);
+  });
+});

--- a/server/__tests__/services/clinic-referral.test.ts
+++ b/server/__tests__/services/clinic-referral.test.ts
@@ -76,6 +76,7 @@ const {
   generateClinicReferralCode,
   getClinicReferralCode,
   getClinicReferrals,
+  createClinicReferral,
   convertClinicReferral,
 } = await import('@/server/services/clinic-referral');
 
@@ -319,6 +320,83 @@ describe('clinic-referral service', () => {
 
       const result = await convertClinicReferral('FC-INVALID-0000', 'clinic-referred');
       expect(result.success).toBe(false);
+    });
+
+    it('succeeds without applying bonus when referrer clinic not found', async () => {
+      let txSelectCallCount = 0;
+      mockTxSelectWhere.mockImplementation(() => {
+        txSelectCallCount++;
+        if (txSelectCallCount === 1) {
+          return {
+            limit: () => [{ id: 'ref-1', referrerClinicId: 'clinic-gone', status: 'pending' }],
+          };
+        }
+        // Referrer clinic lookup returns empty (clinic deleted or not found)
+        return { limit: () => [] };
+      });
+      mockTxSelectFrom.mockReturnValue({ where: mockTxSelectWhere });
+      mockTxSelect.mockReturnValue({ from: mockTxSelectFrom });
+
+      const result = await convertClinicReferral('FC-CODE-1234', 'clinic-referred');
+      expect(result.success).toBe(true);
+
+      // Should have updated the referral status but NOT updated BPS
+      const setCalls = mockTxUpdateSet.mock.calls;
+      const bpsUpdate = setCalls.find(
+        (call: unknown[]) =>
+          typeof call[0] === 'object' &&
+          call[0] !== null &&
+          'revenueShareBps' in (call[0] as Record<string, unknown>),
+      );
+      expect(bpsUpdate).toBeUndefined();
+    });
+  });
+
+  // ── createClinicReferral ────────────────────────────────────────
+
+  describe('createClinicReferral', () => {
+    it('creates a referral and returns id, code, and shareUrl', async () => {
+      // Wire getClinicReferralCode to return existing code
+      mockSelectLimit.mockReturnValue([{ referralCode: 'FC-TEST-ABCD', name: 'Test Vet' }]);
+      mockSelectWhere.mockReturnValue({ limit: mockSelectLimit });
+      mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
+      mockSelect.mockReturnValue({ from: mockSelectFrom });
+
+      mockInsertReturning.mockResolvedValue([{ id: 'ref-new-1' }]);
+      mockInsertValues.mockReturnValue({ returning: mockInsertReturning });
+      mockInsert.mockReturnValue({ values: mockInsertValues });
+
+      const result = await createClinicReferral('clinic-1', 'newclinic@example.com');
+      expect(result.id).toBe('ref-new-1');
+      expect(result.referralCode).toBe('FC-TEST-ABCD');
+      expect(result.shareUrl).toContain('FC-TEST-ABCD');
+      expect(result.shareUrl).toStartWith('https://www.fuzzycatapp.com/signup/clinic?ref=');
+
+      // Verify insert was called with correct values
+      expect(mockInsert).toHaveBeenCalled();
+      expect(mockInsertValues).toHaveBeenCalledWith({
+        referrerClinicId: 'clinic-1',
+        referredEmail: 'newclinic@example.com',
+        referralCode: 'FC-TEST-ABCD',
+      });
+    });
+
+    it('generates a new code if clinic has none, then creates referral', async () => {
+      mockSelectLimit.mockReturnValue([{ referralCode: null, name: 'No Code Vet' }]);
+      mockSelectWhere.mockReturnValue({ limit: mockSelectLimit });
+      mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
+      mockSelect.mockReturnValue({ from: mockSelectFrom });
+
+      mockInsertReturning.mockResolvedValue([{ id: 'ref-new-2' }]);
+      mockInsertValues.mockReturnValue({ returning: mockInsertReturning });
+      mockInsert.mockReturnValue({ values: mockInsertValues });
+
+      const result = await createClinicReferral('clinic-2', 'other@example.com');
+      expect(result.id).toBe('ref-new-2');
+      expect(result.referralCode).toMatch(/^FC-NOCODEVET-[A-F0-9]{4}$/);
+
+      // Should have called update to persist the new code
+      expect(mockUpdate).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add ignore list in `codecov.yml` for React component files (`app/**/*.tsx`), Sentry instrumentation, and Next.js middleware — these are tested by fast tests and E2E but not unit tests
- Add `--coverage` flag to isolated test runs in CI and merge lcov reports into codecov upload
- Add comprehensive unit tests for `lib/utils/date.ts` covering `addDays`, `addMonths` (including month-end clamping and leap years), `formatDate`, `daysUntil`, and `formatCountdown`
- Add `createClinicReferral` tests and `convertClinicReferral` edge case (referrer clinic not found) to `clinic-referral.test.ts`

## Test plan
- [x] `bun run check:fix` passes (no lint/format issues)
- [x] `bun run typecheck` passes
- [x] `bun run test` passes (508 tests, 0 failures)
- [ ] CI passes on this PR
- [ ] `codecov/patch` check passes on subsequent PRs with new UI components

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)