### PR TITLE
fix: use explicit Gemini API key and update embedding model

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,4 +1,4 @@
-import { google } from '@ai-sdk/google';
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
 import { convertToModelMessages, streamText, type UIMessage } from 'ai';
@@ -94,6 +94,7 @@ export async function POST(req: Request) {
     const chunks = await findRelevantChunks(query, 5);
     const systemPrompt = buildSystemPrompt(chunks);
 
+    const google = createGoogleGenerativeAI({ apiKey: env.GEMINI_API_KEY });
     const result = streamText({
       model: google('gemini-2.5-flash-lite'),
       system: systemPrompt,

--- a/server/services/chatbot.test.ts
+++ b/server/services/chatbot.test.ts
@@ -9,9 +9,10 @@ mock.module('ai', () => ({
 }));
 
 mock.module('@ai-sdk/google', () => ({
-  google: Object.assign((model: string) => ({ modelId: model }), {
-    textEmbeddingModel: (model: string) => ({ modelId: model }),
-  }),
+  createGoogleGenerativeAI: () =>
+    Object.assign((model: string) => ({ modelId: model }), {
+      textEmbeddingModel: (model: string) => ({ modelId: model }),
+    }),
 }));
 
 // Mock the database — return an array-like (as drizzle postgres-js does)

--- a/server/services/chatbot.ts
+++ b/server/services/chatbot.ts
@@ -1,4 +1,4 @@
-import { google } from '@ai-sdk/google';
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { embed } from 'ai';
 import { sql } from 'drizzle-orm';
 import { serverEnv } from '@/lib/env';
@@ -15,13 +15,22 @@ export type KnowledgeChunk = {
   similarity?: number;
 };
 
+function getGoogleProvider() {
+  const env = serverEnv();
+  return createGoogleGenerativeAI({ apiKey: env.GEMINI_API_KEY });
+}
+
 /**
- * Generate a 768-dimension embedding using Gemini text-embedding-004.
+ * Generate a 768-dimension embedding using Gemini gemini-embedding-001.
  */
 export async function generateEmbedding(text: string): Promise<number[]> {
+  const google = getGoogleProvider();
   const { embedding } = await embed({
-    model: google.textEmbeddingModel('text-embedding-004'),
+    model: google.textEmbeddingModel('gemini-embedding-001'),
     value: text,
+    providerOptions: {
+      google: { outputDimensionality: 768 },
+    },
   });
   return embedding;
 }


### PR DESCRIPTION
## Summary
- Use `createGoogleGenerativeAI()` with explicit API key from `serverEnv()` instead of relying on `GOOGLE_GENERATIVE_AI_API_KEY` env var convention
- Update embedding model from deprecated `text-embedding-004` to `gemini-embedding-001`
- Update test mocks to match new imports

Discovered during chatbot deployment setup.

## Test plan
- [x] `bun run test` passes
- [x] `bun run typecheck` passes
- [x] Chatbot verified working locally with streaming responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)