### PR TITLE
feat: add Calendly booking embed to landing page

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -12,6 +12,7 @@ import {
 import type { Metadata } from 'next';
 import Image from 'next/image';
 import Link from 'next/link';
+import { CalendlyEmbed } from '@/components/shared/calendly-embed';
 import { ClinicDisclaimer, OwnerDisclaimer } from '@/components/shared/disclaimers';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -234,6 +235,9 @@ export default function LandingPage() {
           <OwnerDisclaimer />
         </div>
       </section>
+
+      {/* Schedule a Demo */}
+      <CalendlyEmbed />
 
       <Separator />
     </>

--- a/components/shared/calendly-embed.tsx
+++ b/components/shared/calendly-embed.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { Calendar } from 'lucide-react';
+import { useTheme } from 'next-themes';
+
+const CALENDLY_URL = 'https://calendly.com/fuzzycatapp/30min';
+
+export function CalendlyEmbed() {
+  const { resolvedTheme } = useTheme();
+
+  const params = new URLSearchParams({
+    primary_color: '0d9488',
+    hide_gdpr_banner: '1',
+  });
+
+  if (resolvedTheme === 'dark') {
+    params.set('background_color', '0a0a0a');
+    params.set('text_color', 'e5e5e5');
+  }
+
+  const src = `${CALENDLY_URL}?${params.toString()}`;
+
+  return (
+    <section className="px-4 py-20 sm:px-6 sm:py-28 lg:px-8">
+      <div className="mx-auto max-w-5xl">
+        <div className="text-center">
+          <Calendar className="mx-auto mb-6 h-12 w-12 text-primary" />
+          <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">Schedule a Demo</h2>
+          <p className="mt-3 text-muted-foreground">
+            See how FuzzyCat can help your clinic increase treatment acceptance. Book a free
+            30-minute walkthrough.
+          </p>
+        </div>
+        <div className="mt-10 overflow-hidden rounded-xl border shadow-sm">
+          <iframe
+            src={src}
+            title="Schedule a demo with FuzzyCat"
+            width="100%"
+            height="660"
+            className="border-0"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -33,7 +33,7 @@ function buildCspDirectives(scriptSrc: string, sentryDsn?: string): string {
     "img-src 'self' data: blob: https:",
     "font-src 'self' https://fonts.scalar.com",
     "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.stripe.com https://*.posthog.com https://*.i.posthog.com https://*.ingest.us.sentry.io https://*.sentry-cdn.com",
-    'frame-src https://js.stripe.com https://challenges.cloudflare.com https://connect-js.stripe.com',
+    'frame-src https://js.stripe.com https://challenges.cloudflare.com https://connect-js.stripe.com https://calendly.com',
     "worker-src 'self' blob:",
     "object-src 'none'",
     "base-uri 'self'",


### PR DESCRIPTION
## Summary
- Add inline Calendly embed at the bottom of the landing page for clinics to book a demo
- Themed with teal primary color, dark mode support via `useTheme` from next-themes
- CSP updated to allow `https://calendly.com` in `frame-src`
- Closes #433

## Test plan
- [ ] Calendly embed renders on landing page
- [ ] Respects light/dark mode
- [ ] CSP doesn't block the iframe
- [ ] All CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)