### PR TITLE
fix: add E2E_ENV=production to e2e-production CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,7 @@ jobs:
       - name: Run production E2E tests
         run: bun run test:e2e:prod
         env:
+          E2E_ENV: production
           E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
           E2E_OWNER_EMAIL: e2e-owner@fuzzycatapp.com
           E2E_CLINIC_EMAIL: e2e-clinic@fuzzycatapp.com


### PR DESCRIPTION
## Summary
- Add `E2E_ENV: production` to the e2e-production job env block
- This tells Playwright to skip local server startup and hit the live production URL directly
- Without it, Playwright tries to build Next.js locally, which fails due to missing server-side secrets

## Test plan
- [ ] E2E production tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)