### PR TITLE
feat: add Book a Demo link to navigation

### DIFF
--- a/app/(marketing)/layout.tsx
+++ b/app/(marketing)/layout.tsx
@@ -38,6 +38,12 @@ function Header() {
           >
             Support
           </Link>
+          <Link
+            href="/#book-demo"
+            className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Book a Demo
+          </Link>
           <ThemeToggle />
           <Link href="/login">
             <Button size="sm">Sign In</Button>
@@ -47,9 +53,15 @@ function Header() {
         <nav className="flex items-center gap-3 md:hidden">
           <Link
             href="/how-it-works"
-            className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+            className="hidden text-xs font-medium text-muted-foreground transition-colors hover:text-foreground sm:inline"
           >
             How It Works
+          </Link>
+          <Link
+            href="/#book-demo"
+            className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Book a Demo
           </Link>
           <ThemeToggle />
           <Link href="/login">

--- a/app/globals.css
+++ b/app/globals.css
@@ -173,6 +173,9 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html {
+    scroll-behavior: smooth;
+  }
   body {
     @apply bg-background text-foreground;
   }

--- a/components/shared/calendly-embed.tsx
+++ b/components/shared/calendly-embed.tsx
@@ -21,7 +21,7 @@ export function CalendlyEmbed() {
   const src = `${CALENDLY_URL}?${params.toString()}`;
 
   return (
-    <section className="px-4 py-20 sm:px-6 sm:py-28 lg:px-8">
+    <section id="book-demo" className="scroll-mt-20 px-4 py-20 sm:px-6 sm:py-28 lg:px-8">
       <div className="mx-auto max-w-5xl">
         <div className="text-center">
           <Calendar className="mx-auto mb-6 h-12 w-12 text-primary" />


### PR DESCRIPTION
## Summary
- Add "Book a Demo" anchor link to desktop and mobile navigation
- Links to `#book-demo` section with Calendly embed on landing page
- Mobile: "How It Works" hidden on smallest screens (`hidden sm:inline`) to make room; "Book a Demo" always visible
- Added `scroll-behavior: smooth` to global CSS and `scroll-mt-20` on the Calendly section for proper scroll offset

## Test plan
- [ ] Desktop nav shows "Book a Demo" link after "Support"
- [ ] Mobile nav shows "Book a Demo" link
- [ ] Clicking link scrolls smoothly to Calendly section
- [ ] Works from other pages (navigates to landing page + scrolls)
- [ ] All CI checks pass (test, typecheck, lint, build verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)