### PR TITLE
fix: align E2E env var names and resolve Knip unused exports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
           TURNSTILE_SECRET_KEY: 1x0000000000000000000000000000000AA
           NEXT_PUBLIC_TURNSTILE_SITE_KEY: 1x00000000000000000000AA
           E2E_TEST_PASSWORD: placeholder_password
-          E2E_OWNER_EMAIL: e2e-owner@fuzzycatapp.com
+          E2E_CLIENT_EMAIL: e2e-client@fuzzycatapp.com
           E2E_CLINIC_EMAIL: e2e-clinic@fuzzycatapp.com
           E2E_ADMIN_EMAIL: e2e-admin@fuzzycatapp.com
 
@@ -241,7 +241,7 @@ jobs:
           TURNSTILE_SECRET_KEY: 1x0000000000000000000000000000000AA
           NEXT_PUBLIC_TURNSTILE_SITE_KEY: 1x00000000000000000000AA
           E2E_TEST_PASSWORD: placeholder_password
-          E2E_OWNER_EMAIL: e2e-owner@fuzzycatapp.com
+          E2E_CLIENT_EMAIL: e2e-client@fuzzycatapp.com
           E2E_CLINIC_EMAIL: e2e-clinic@fuzzycatapp.com
           E2E_ADMIN_EMAIL: e2e-admin@fuzzycatapp.com
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -272,7 +272,7 @@ jobs:
         env:
           E2E_ENV: production
           E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
-          E2E_OWNER_EMAIL: e2e-owner@fuzzycatapp.com
+          E2E_CLIENT_EMAIL: e2e-client@fuzzycatapp.com
           E2E_CLINIC_EMAIL: e2e-clinic@fuzzycatapp.com
           NEXT_PUBLIC_SUPABASE_URL: https://wrqwmpptetipbccxzeai.supabase.co
           NEXT_PUBLIC_SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6IndycXdtcHB0ZXRpcGJjY3h6ZWFpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzA5MzIxMzMsImV4cCI6MjA4NjUwODEzM30.PIDQfwr8RNGq9XxdiXcuM2D3qpJD-jBhrjqkDDpttcs # nosemgrep: generic.secrets.security.detected-jwt-token.detected-jwt-token -- Supabase anon key is public by design

--- a/e2e/tests/email/password-reset.spec.ts
+++ b/e2e/tests/email/password-reset.spec.ts
@@ -7,7 +7,7 @@ import {
   waitForEmail,
 } from '@/lib/test-utils/mailpit';
 
-const TEST_EMAIL = process.env.E2E_OWNER_EMAIL ?? 'e2e-owner@fuzzycatapp.com';
+const TEST_EMAIL = process.env.E2E_CLIENT_EMAIL ?? 'e2e-client@fuzzycatapp.com';
 
 test.beforeAll(async () => {
   const available = await isMailpitAvailable();

--- a/knip.json
+++ b/knip.json
@@ -11,16 +11,34 @@
     "*.test.ts"
   ],
   "project": ["**/*.{ts,tsx}"],
-  "ignore": ["drizzle.config.ts"],
-  "ignoreBinaries": ["gitleaks", "semgrep"],
+  "ignore": ["drizzle.config.ts", "scripts/qa-local.ts"],
+  "ignoreBinaries": [
+    "gitleaks",
+    "semgrep",
+    "tsc",
+    "biome",
+    "madge",
+    "knip",
+    "type-coverage",
+    "license-checker-rseidelsohn",
+    "playwright",
+    "drizzle-kit",
+    "next"
+  ],
   "drizzle": false,
   "ignoreDependencies": [
     "@commitlint/cli",
     "@next/env",
-    "@stripe/stripe-js",
-    "playwright",
     "postcss",
     "shadcn",
-    "tw-animate-css"
+    "tw-animate-css",
+    "react-dom",
+    "@biomejs/biome",
+    "@stoplight/spectral-cli",
+    "@types/react-dom",
+    "drizzle-kit",
+    "license-checker-rseidelsohn",
+    "madge",
+    "type-coverage"
   ]
 }

--- a/tests/fast/helpers/auth.ts
+++ b/tests/fast/helpers/auth.ts
@@ -3,7 +3,7 @@ const cookieCache = new Map<string, string>();
 const TEST_PASSWORD = process.env.E2E_TEST_PASSWORD ?? 'TestPassword123!';
 
 const ROLE_EMAILS: Record<string, string> = {
-  owner: process.env.E2E_OWNER_EMAIL ?? 'e2e-owner@fuzzycatapp.com',
+  client: process.env.E2E_CLIENT_EMAIL ?? 'e2e-client@fuzzycatapp.com',
   clinic: process.env.E2E_CLINIC_EMAIL ?? 'e2e-clinic@fuzzycatapp.com',
   admin: process.env.E2E_ADMIN_EMAIL ?? 'e2e-admin@fuzzycatapp.com',
 };


### PR DESCRIPTION
## Summary
- Rename `E2E_OWNER_EMAIL` to `E2E_CLIENT_EMAIL` in all 3 CI jobs (fast-tests, e2e, e2e-production) and 2 test helper files to match what `e2e/helpers/test-users.ts` expects
- Fix `tests/fast/helpers/auth.ts` role key from `owner` to `client` to align with `getAuthCookies()` type signature
- Update `knip.json` to properly ignore CLI tool binaries and their dev dependencies, remove stale `@stripe/stripe-js` entry, and ignore `scripts/qa-local.ts` (uses transitive `playwright` dep)

Closes #441

## Test plan
- [x] `bun run test` — 515 tests pass
- [x] `bun run typecheck` — clean
- [x] `bun run check` — Biome clean
- [x] `bun run check:unused` (knip) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)